### PR TITLE
fix(form): remove pointer events none on readonly

### DIFF
--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -193,7 +193,7 @@ export const Dropdown = <ValueType extends NonNullable<any>>({
         'eds-dropdown--has-tooltip': labelTooltip !== undefined,
       })}
       disabled={disabled}
-      disableLabelAnimation={disableLabelAnimation}
+      disableLabelAnimation={disableLabelAnimation || readOnly}
       feedback={feedback}
       isFilled={isFilled}
       label={label}

--- a/packages/form/src/BaseFormControl.scss
+++ b/packages/form/src/BaseFormControl.scss
@@ -73,7 +73,6 @@
 
     &--readonly {
       border-color: transparent;
-      pointer-events: none;
       cursor: default;
       background: var(--components-form-baseform-standard-fill-readonly);
       border: var(--components-form-baseform-standard-fill-readonly);
@@ -85,6 +84,9 @@
         .eds-input-group__label {
           color: var(--components-form-baseform-contrast-text-description);
         }
+      }
+      &:focus-within {
+        outline: none;
       }
 
       &::before,

--- a/packages/form/src/BaseFormControl.tsx
+++ b/packages/form/src/BaseFormControl.tsx
@@ -133,7 +133,7 @@ export const BaseFormControl = React.forwardRef<
               label={label}
               required={required}
               labelId={labelId}
-              staticAnimation={disableLabelAnimation}
+              staticAnimation={disableLabelAnimation || readOnly}
               {...labelProps}
             />
             {labelTooltip && (

--- a/packages/form/src/TextArea.tsx
+++ b/packages/form/src/TextArea.tsx
@@ -139,6 +139,7 @@ const TextAreaBase = React.forwardRef<HTMLTextAreaElement, TextAreaBaseProps>(
         onChange={handleChange}
         value={value}
         aria-invalid={currentVariant === 'error'}
+        tabIndex={readOnly ? -1 : undefined}
         {...rest}
       />
     );

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -186,6 +186,7 @@ const TextFieldBase = React.forwardRef<HTMLInputElement, TextFieldBaseProps>(
         placeholder={placeholder}
         onChange={handleChange}
         value={value}
+        tabIndex={readOnly ? -1 : undefined}
         {...rest}
       />
     );


### PR DESCRIPTION
WIP: Denne blir satt på vent

Videre jobb:
Endringene i BaseFormControl vil også da gjelde for dropdown. Så dropdown trenger også tilpasninger for å være readonly.


affects: @entur/form
