### PR TITLE
docs(docs): fix broken links in readme

### DIFF
--- a/apps/documentation/content/components/index.mdx
+++ b/apps/documentation/content/components/index.mdx
@@ -361,7 +361,7 @@ import TravelTag from './komponenterBilder/Travel tag.jpg';
   <ComponentPreview
     title="Travel header"
     description="Travel header presenterer destinasjonene som man reiser fra og til. "
-    to="/komponenter/reise/reiseskrift"
+    to="/komponenter/reise/travelheader"
   >
     <img alt="" src={TravelHeader} />
   </ComponentPreview>

--- a/apps/documentation/content/components/reise/travelheader.mdx
+++ b/apps/documentation/content/components/reise/travelheader.mdx
@@ -1,7 +1,7 @@
 ---
 name: Travel header
 description: Travel header viser destinasjonene som man reiser fra og til på en visuell måte. Vi benytter den røde streken fra logoen for å understreke identiteten til Entur.
-route: /komponenter/reise/reiseskrift
+route: /komponenter/reise/travelheader
 parent: Komponenter
 menu: reise
 npmPackage: travel

--- a/packages/a11y/README.md
+++ b/packages/a11y/README.md
@@ -2,8 +2,6 @@
 
 This package contains the different accessibility components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/resources/accessibility)?
-
 ## Installation
 
 ```sh
@@ -11,7 +9,3 @@ npm install @entur/a11y
 # or if you are using Yarn:
 yarn add @entur/a11y
 ```
-
-## Usage
-
-Please refer to the [documentation](https://design.entur.no/komponenter/resources/accessibility) for usage information.

--- a/packages/alert/README.md
+++ b/packages/alert/README.md
@@ -2,7 +2,7 @@
 
 This package contains the different AlertBox components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/feedback/alert-boxes)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/feedback/alert)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/alert
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/feedback/alert-boxes) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/feedback/alert) for usage information.

--- a/packages/dropdown/README.md
+++ b/packages/dropdown/README.md
@@ -2,7 +2,7 @@
 
 This package contains the different Dropdown components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/skjemaelementer/dropdowns)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/skjemaelementer/dropdown)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/dropdown
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/skjemaelementer/dropdowns) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/skjemaelementer/dropdown) for usage information.

--- a/packages/expand/README.md
+++ b/packages/expand/README.md
@@ -2,7 +2,7 @@
 
 This package contains the different Expand components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/expandable-sections)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-og-flater/expandable)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/expand
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/expandable-sections) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/layout-og-flater/expandable) for usage information.

--- a/packages/fileupload/README.md
+++ b/packages/fileupload/README.md
@@ -2,7 +2,7 @@
 
 This package contains the different Fileupload components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/skjemaelementer/fileupload)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/fileupload
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/skjemaelementer/fileupload) for usage information.

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -2,7 +2,7 @@
 
 This package contains all the common form-components
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/inputs/textfields)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/skjemaelementer/textfield)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/form
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/inputs/textfields) for further usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/skjemaelementer/textfield) for further usage information.

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -2,7 +2,7 @@
 
 This package contains the icon components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/resources/icons)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/ressurser/icons)?
 
 ## Installation
 
@@ -20,7 +20,7 @@ import { AddIcon } from '@entur/icons'; // Import specific icon
 <AddIcon />;
 ```
 
-Please refer to the [documentation](https://design.entur.no/komponenter/resources/icons) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/ressurser/icons) for usage information.
 
 ## Development
 

--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -2,7 +2,7 @@
 
 This package contains the different layout components, and the powerful Contrast wrapper
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/contrast-sections)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-og-flater/card)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/layout
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/alert-boxes) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/layout-og-flater/card) for usage information.

--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -2,7 +2,7 @@
 
 This package contains the different loader components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/feedback/loaders)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/feedback/loader)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/loader
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/feedback/loaders) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/feedback/loader) for usage information.

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -2,7 +2,7 @@
 
 This package contains the navigation components
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/navigation/top-navigation)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/navigasjon/top-navigation)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/menu
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/navigation/top-navigation) for further usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/navigasjon/top-navigation) for further usage information.

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -2,7 +2,7 @@
 
 This package contains the different Modal components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/modals)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-og-flater/modal)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/modal
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/modals) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/layout-og-flater/modal) for usage information.

--- a/packages/tab/README.md
+++ b/packages/tab/README.md
@@ -2,7 +2,7 @@
 
 This package contains the different Tab components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/tabs)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-og-flater/tabs)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/tab
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/tabs) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/layout-og-flater/tabs) for usage information.

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -2,7 +2,7 @@
 
 This package contains the different Table components.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/tables)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/layout-og-flater/table)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/table
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/layout-and-surfaces/tables) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/layout-og-flater/table) for usage information.

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -4,7 +4,7 @@ This package contains all design tokens and design variables used throughout the
 
 Since not all values are available as a variable yet and to avoid breaking changes, all previous design tokens will be kept around for a while. These are built from the `src/legacy-tokens.ts` file.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/resources/tokens)?
+> 💡 Looking for the [documentation](https://design.entur.no/tokens)?
 
 ## Installation
 
@@ -16,7 +16,7 @@ yarn add @entur/tokens
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/resources/tokens) for in-depth usage information.
+Please refer to the [documentation](https://design.entur.no/tokens) for in-depth usage information.
 
 This package has several main exports:
 

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -2,7 +2,7 @@
 
 This package contains the tooltip component.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/feedback/tooltips)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/feedback/tooltip)?
 
 ## Installation
 
@@ -14,4 +14,4 @@ yarn add @entur/tooltip
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/feedback/tooltips) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/feedback/tooltip) for usage information.

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -6,7 +6,7 @@ Entur's official font is Nationale and is created by Playtype Foundry, located i
 
 This package contains styles and React components for all of our typography.
 
-> 💡 Looking for the [documentation](https://design.entur.no/komponenter/resources/typography)?
+> 💡 Looking for the [documentation](https://design.entur.no/komponenter/ressurser/typography)?
 
 ## Installation
 
@@ -18,7 +18,7 @@ yarn add @entur/typography
 
 ## Usage
 
-Please refer to the [documentation](https://design.entur.no/komponenter/resources/typography) for usage information.
+Please refer to the [documentation](https://design.entur.no/komponenter/ressurser/typography) for usage information.
 
 ## Licenses
 


### PR DESCRIPTION
- fikset alle lenker til dokumentasjon i READMEs
- byttet lenkenavn fra "reiseskrift" til travelheader

affects: @entur/documentation, @entur/a11y, @entur/alert, @entur/dropdown, @entur/expand, @entur/fileupload, @entur/form, @entur/icons, @entur/layout, @entur/loader, @entur/menu, @entur/modal, @entur/tab, @entur/table, @entur/tokens, @entur/tooltip, @entur/typography