### PR TITLE
Etu 54382 endre deprekert syntaks i sass stilark

### DIFF
--- a/documentation/src/components/UU/ContrastChecker.scss
+++ b/documentation/src/components/UU/ContrastChecker.scss
@@ -5,23 +5,28 @@
   &__container {
     margin-top: $space-extra-large;
   }
+
   &__calculator {
     display: grid;
     grid-template-columns: 1fr;
+    grid-gap: $space-large;
+    margin-bottom: $space-extra-large4;
+
     @include for-large-desktop {
       grid-template-columns: 3fr 1fr;
     }
-    grid-gap: $space-large;
-    margin-bottom: $space-extra-large4;
   }
+
   &__ratio {
     border-width: $border-widths-medium;
     border-style: solid;
     padding: $space-extra-large2;
+
     &-header {
       font-size: $font-sizes-extra-large2;
       text-align: center;
     }
+
     &-ratio {
       font-weight: $font-weights-heading;
       font-size: $font-sizes-extra-large5;
@@ -53,14 +58,17 @@
     grid-template-columns: 3fr 1fr;
     margin-top: $space-large;
   }
+
   &__small-text {
     padding: $space-large;
   }
+
   &__large-text {
     font-size: $font-sizes-extra-large2;
     font-weight: $font-weights-heading;
     padding: $space-large;
   }
+
   &__graphics-object {
     display: flex;
     align-items: center;
@@ -74,6 +82,7 @@
   &__wrapper {
     display: flex;
   }
+
   &__names {
     display: grid;
     grid-template-rows: 1fr 1fr 1fr;
@@ -87,6 +96,7 @@
     color: $colors-blues-blue40;
     align-items: center;
   }
+
   &__values {
     display: grid;
     grid-template-rows: 1fr 1fr 1fr;

--- a/documentation/src/pages/index.scss
+++ b/documentation/src/pages/index.scss
@@ -4,6 +4,7 @@
 .content-margin {
   max-width: 1328px;
   padding: 0 1.5rem;
+
   @include breakpoint.for-desktop {
     padding: 0 1rem;
     margin: 0 auto;
@@ -13,12 +14,14 @@
 .front-page {
   &__desktop {
     display: none;
+
     @include breakpoint.for-desktop {
       display: block;
     }
   }
   &__mobile {
     display: block;
+
     @include breakpoint.for-desktop {
       display: none;
     }
@@ -36,6 +39,11 @@
 }
 
 .front-page__top-image {
+  position: absolute;
+  top: 4rem;
+  right: 0rem;
+  display: none;
+
   @include breakpoint.for-desktop {
     width: 51%;
     display: block;
@@ -43,15 +51,12 @@
   @include breakpoint.for-large-desktop {
     width: 60%;
   }
-  position: absolute;
-  top: 4rem;
-  right: 0rem;
-  display: none;
 }
 
 .front-page__blue-cards {
   background: var(--basecolors-frame-tint);
   padding-bottom: 3rem;
+
   @include breakpoint.for-desktop {
     padding-bottom: 7.5rem;
   }
@@ -61,6 +66,7 @@
   padding-top: 2rem;
   margin-bottom: 2rem;
   text-align: left;
+
   @include breakpoint.for-desktop {
     text-align: center;
     padding-top: 6.5rem;
@@ -73,6 +79,7 @@
   margin: 0 auto;
   margin-bottom: 4rem;
   margin-top: 4rem;
+
   @include breakpoint.for-desktop {
     margin-top: 8.5rem;
     margin-bottom: 12.5rem;

--- a/documentation/src/pages/kom-i-gang/for-designere/brukergrupper.scss
+++ b/documentation/src/pages/kom-i-gang/for-designere/brukergrupper.scss
@@ -3,26 +3,29 @@
 
 .brukergrupper {
   &__brukere {
-    &-wrapper {
-      margin-bottom: $space-extra-large;
-    }
-    min-height: 10rem;
-    background: var(--designentur-basecard-default-fill);
     display: flex;
     align-items: center;
     justify-content: center;
     flex-direction: column;
+    min-height: 10rem;
+    background: var(--designentur-basecard-default-fill);
+
+    &-wrapper {
+      margin-bottom: $space-extra-large;
+    }
+
     .eds-icon {
-      // color: $colors-brand-blue;
       font-size: $font-sizes-extra-large5;
       margin-top: $space-large;
     }
+
     .eds-paragraph {
       text-align: center;
       margin-top: $space-large;
       max-width: 10rem;
     }
   }
+
   &__situasjonsbehov {
     background-color: $fill-background-tint-neutral;
     padding: 1rem;


### PR DESCRIPTION
Obs: venter på at `Etu 52925 få posthog analytics til å fungere med gatsby browser` merges

Endrer slik at ingen `nested rules` kommer før vanlig css-deklarasjoner. Dette gjøres siden slik syntax er deprekert i Dart Sass. Les mer på https://sass-lang.com/d/mixed-decls 