### PR TITLE
fix(website): etu-55349 small uu-fixes

### DIFF
--- a/apps/documentation/src/components/Colors/ColorSwatch.tsx
+++ b/apps/documentation/src/components/Colors/ColorSwatch.tsx
@@ -3,7 +3,7 @@ import { colors, space } from '@entur/tokens';
 import hexrgb from 'hex-rgb';
 import { BaseCard } from '@entur/layout';
 import { GridItem } from '@entur/grid';
-import { Heading4, Label } from '@entur/typography';
+import { Heading4 } from '@entur/typography';
 import { formatVariable } from '../../utils/formatVariable';
 import { useSettings } from '@providers/SettingsContext';
 import { useColorContext } from '@providers/ColorProvider';
@@ -46,7 +46,7 @@ const ColorSwatch: React.FC<Props> = ({
   console.log(setChosenColor);
   return (
     <GridItem small={6} medium={4}>
-      {topLabel && <Label>{topLabel}</Label>}
+      {topLabel && <div className="eds-label">{topLabel}</div>}
       <BaseCard
         className="color-swatch"
         as="button"

--- a/apps/documentation/src/components/Footer/FrontPageFooter.tsx
+++ b/apps/documentation/src/components/Footer/FrontPageFooter.tsx
@@ -98,17 +98,18 @@ const FrontPageFooter = () => {
           />
         </div>
         <div style={{ float: 'right', position: 'relative', top: '0.9rem' }}>
-          <Label
+          <span
+            className="eds-label"
             style={{
               borderRight: `1px solid ${colors.greys.grey70}`,
               paddingRight: space.small,
             }}
           >
             Entur.no
-          </Label>
-          <Label style={{ paddingLeft: space.small }}>
+          </span>
+          <span className="eds-label" style={{ paddingLeft: space.small }}>
             © {year.getFullYear()} Entur AS
-          </Label>
+          </span>
         </div>
       </div>
     </div>

--- a/apps/documentation/src/components/Media/IllustrationList.tsx
+++ b/apps/documentation/src/components/Media/IllustrationList.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 
 import { SegmentedChoice, SegmentedControl, Switch } from '@entur/form';
 import { base } from '@entur/tokens';
-import { Label } from '@entur/typography';
 
 import {
   IllustrationListItem,
@@ -101,9 +100,9 @@ const IllustrationList = ({
             key={illustration.name + illustration.extension}
           >
             {showIllustrationName && (
-              <Label className="illustration-list__display-grid__image-box__label">
+              <div className="eds-label illustration-list__display-grid__image-box__label">
                 {illustration.sanitizedName}
-              </Label>
+              </div>
             )}
             <ImageDisplay
               imgSource={illustration.imgSource}

--- a/apps/documentation/src/components/Search/Search.tsx
+++ b/apps/documentation/src/components/Search/Search.tsx
@@ -84,7 +84,11 @@ export const Search = () => {
   );
   return (
     <>
-      <IconButton className="searchmodal__button" onClick={() => setOpen(true)}>
+      <IconButton
+        aria-label="Søk"
+        className="searchmodal__button"
+        onClick={() => setOpen(true)}
+      >
         <SearchIcon /> <span>Søk</span>
       </IconButton>
       <Modal

--- a/apps/documentation/src/pages/identitet/index.mdx
+++ b/apps/documentation/src/pages/identitet/index.mdx
@@ -45,9 +45,7 @@ export const Head = ( props ) => {
 
 <ImageDisplay
   imgSource={props.data.pageHeader.childImageSharp.gatsbyImageData}
-  alt="Et bilde som viser Entur sin profil gjennom et foto av en dame kledd i 
-      Enturs profilfarger på venstresiden og teksten «En resie, En billett, En app. 
-      Entur» på høyresiden"
+  alt="En reise, En billett, En app. Entur"
   style={{ marginBottom: space.extraLarge3 }}
   preset="full-width-image"
 />

--- a/apps/documentation/src/pages/identitet/verktoykassen/co-branding.mdx
+++ b/apps/documentation/src/pages/identitet/verktoykassen/co-branding.mdx
@@ -36,9 +36,11 @@ query coBrandingFiles {
 
 Der flaten er bred nok til å tillate en horisontal visning av de co-brandede logoene, skal de horisontale formatprinsippene brukes.
 
+Bildet viser en fremstilling av hvordan Entur-logoen og andre partnere sine logoer kan plasseres sammen horisontalt i en bunntekst.
+
 <ImageDisplay
   imgSource={props.data.files.images.find(image => image.name === "Co-brand 1").childImageSharp.gatsbyImageData}
-  alt="Viser en fremstilling av hvordan Entur-logoen og andre partnere sine logoer kan plasseres sammen horisontalt i en bunntekst. Teksten på bildet sier (engelsk): The 'X' widith as determined from the Entur logo (visually the witdh of 'TUR' in the ENTUR logo) sets the distance of the co-brands placement in relation to the Entur payoff. The 'Y'-height as determined from the Entur payoff (visually the Cap-height of the 'Vi kommer lenger sammen'-text to the right of the ENTUR logo) sets the guide for the height of co-branding logo placement. NB! When placing multiple co-branding logos together they sholuld appear wqual in prominance and should be adjusted accordingly withing the guide area."
+  alt="Teksten på bildet sier (engelsk): The 'X' widith as determined from the Entur logo (visually the witdh of 'TUR' in the ENTUR logo) sets the distance of the co-brands placement in relation to the Entur payoff. The 'Y'-height as determined from the Entur payoff (visually the Cap-height of the 'Vi kommer lenger sammen'-text to the right of the ENTUR logo) sets the guide for the height of co-branding logo placement. NB! When placing multiple co-branding logos together they sholuld appear wqual in prominance and should be adjusted accordingly withing the guide area."
   preset="full-width-image"
 />
 

--- a/apps/documentation/src/pages/identitet/verktoykassen/entur.mdx
+++ b/apps/documentation/src/pages/identitet/verktoykassen/entur.mdx
@@ -64,9 +64,11 @@ Oppsettet tilfører bevegelse og dynamikk til identiteten, og understøtter mang
 
 ## Bruk med Typografi
 
+Typografien kan brukes ved å legge inn et ord mellom EN og Tur som en sammenslått Entur-logo. For eksempel: En God Tur, En Rask Tur, En Forsinket Tur, En Eidsvoll Tur, En Laaaaang Tur, En Buss Tog Båt Tur.
+
 <ImageDisplay
   imgSource={props.data.files.images.find(image => image.name === "Typo_turer").childImageSharp.gatsbyImageData}
-  alt="Typografiske eksempler hvor et ord er lagt inn mellom EN og Tur som en sammenslått Entur-logo. Eksempel: En God Tur"
+  alt=""
   preset="full-width-image"
 />
 

--- a/apps/documentation/src/pages/identitet/verktoykassen/ikoner.mdx
+++ b/apps/documentation/src/pages/identitet/verktoykassen/ikoner.mdx
@@ -58,7 +58,7 @@ som benytter spesifikke transportfarger.
 
 <ImageDisplay
   imgSource={props.data.files.images.find(image => image.name === "to_farger")?.publicURL}
-  alt="En sammenligning av to ikoner der det venstre er en billett plassert på en lys bakgrunn med Entur Blå som strekfarge og det høyre er en bille pøassert på en Entur Blå bakgrunn med hvit strekfarge"
+  alt="En sammenligning av to ikoner der det venstre er en billett og det høyre er en bille."
   preset="full-width-image"
 />
 
@@ -79,7 +79,7 @@ balanse og lesbarhet for ikonene.
 
 <ImageDisplay 
   imgSource={props.data.files.images.find(image => image.name === "gridsystem")?.publicURL}
-  alt="En visuell fremstilling av gridsystemet som brukes for ikoner. Det består av ulike rettningslinjer og srikler som veileder hvor ikonet skal ligge innenfor."
+  alt="Retningslinjer og sirkler som vise hvor ikonet skal ligge innenfor."
   preset="full-width-image"
 />
 
@@ -91,14 +91,16 @@ ned til ulike størrelser. I dag bruker vi fire forskjellige størrelser for iko
     
 <ImageDisplay
   imgSource={props.data.files.images.find(image => image.name === "storrelser")?.publicURL}
-  alt="En visuell fremstilling av billettikonet i de fire ulike størrelsene plassert inne i gridsystemets rettningslinjer."
+  alt="Billettikonet i de fire ulike størrelsene plassert inne i gridsystemets retningslinjer."
   preset="full-width-image"
 />
 
 ### Ikonoppbygging
 
+Tabelloversikten viser ulike nøkkeltall for tykkelser på streker i ikonene under ulike størrelser.
+
 <ImageDisplay
   imgSource={props.data.files.images.find(image => image.name === "oppbygging")?.publicURL}
-  alt="En tabelloversikt som viser ulike nøkkeltall for tykkelser på streker i ikonene under ulike størrelser."
+  alt=""
   preset="full-width-image"
 />

--- a/apps/documentation/src/pages/identitet/verktoykassen/logo.mdx
+++ b/apps/documentation/src/pages/identitet/verktoykassen/logo.mdx
@@ -53,7 +53,8 @@ RGB er til digitalt bruk, og CMYK til trykk.
 ## Entur primærlogo
 
 Dette er vår hovedlogo og skal brukes i de aller fleste sammenhenger. Brukes på lyse bakgrunn og rolige bilder.
- 
+Entur sin primærlogo består av teksten Entur med skrifttype Nationale og den blå hovedfargen til Entur. «En» er understreket av en Entur-rød, også kalt koral, strek.
+
 <ImageDisplay
   imgSource={props.data.logosSvg.images.find(image => image.name === "PrimaryLogo").publicURL}
   downloadSources={[
@@ -62,7 +63,7 @@ Dette er vår hovedlogo og skal brukes i de aller fleste sammenhenger. Brukes p�
   ]} 
   name={props.data.logosSvg.images.find(image => image.name === "PrimaryLogo").name}
   preset="logo-display"
-  alt="Entur sin primærlogo består av teksten Entur med skrifttype Nationale og den blå hovedfargen til Entur. «En» er understreket av en Entur-rød, også kalt koral, strek"
+  alt=""
 />
 
 ## Entur sekundærlogo
@@ -78,7 +79,7 @@ Skal kun tas i bruk når primærlogo ikke er mulig å bruke. Brukes på mørke b
   ]}
   preset="logo-display"
   className="eds-contrast"
-  alt="Entur sin sekundærlogo består av teksten Entur med skrifttype Nationale og hvit farge. «En» er understreket av en Entur-rød, også kalt koral, strek"
+  alt=""
 />
 
 ## Svart-hvitt logo

--- a/apps/documentation/src/pages/komponenter/feedback/badge.mdx
+++ b/apps/documentation/src/pages/komponenter/feedback/badge.mdx
@@ -142,7 +142,7 @@ En bullet-badge uten tekst bryter WCAG 2.1, informasjon skal ikke kun kommuniser
 
 **Kilder:**
 - [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/wcag-standarden/111-ikke-tekstlig-innhold-niva/87)
-- [1.3.3 Sensoriske egenskaper](https://www.uutilsynet.no/wcag-standarden/111-ikke-tekstlig-innhold-niva/87)
+- [1.3.3 Sensoriske egenskaper](https://www.uutilsynet.no/wcag-standarden/133-sensoriske-egenskaper-niva/92)
 
 ## Props
 

--- a/apps/documentation/src/pages/komponenter/knapper/chip.mdx
+++ b/apps/documentation/src/pages/komponenter/knapper/chip.mdx
@@ -36,7 +36,7 @@ export const Head = ( props ) => {
         }}
       >
         <div>
-          <Label>ChoiceChips</Label>
+          <div className="eds-label">ChoiceChips</div>
           <ChoiceChipGroup
             name="city"
             label="Velg setekategori"
@@ -51,7 +51,7 @@ export const Head = ( props ) => {
           </ChoiceChipGroup>
         </div>
         <div>
-          <Label>ActionChip</Label>
+          <div className="eds-label">ActionChip</div>
           <div style={{ display: 'flex' }}>
             <ActionChip style={{ marginRight: '1rem' }}>Lagre</ActionChip>
             <ActionChip style={{ marginRight: '1rem' }}>
@@ -60,11 +60,11 @@ export const Head = ( props ) => {
           </div>
         </div>
         <div>
-          <Label>TagChip</Label>
+          <div className="eds-label">TagChip</div>
           <TagChip>Buss</TagChip>
         </div>
         <div>
-          <Label>FilterChip</Label>
+          <div className="eds-label">FilterChip</div>
           <FilterChip value="mandag">Mandag</FilterChip>
         </div>
       </div>

--- a/apps/documentation/src/pages/komponenter/knapper/icon-button.mdx
+++ b/apps/documentation/src/pages/komponenter/knapper/icon-button.mdx
@@ -104,7 +104,7 @@ Ikonknapper brukes ofte som inline-handlinger i tabellrader og verktøylinjer.
         <DataCell>12.00</DataCell>
         <DataCell>
           <Tooltip aria-hidden placement="bottom" content="Rediger reise">
-            <IconButton aira-label="Rediger reise">
+            <IconButton aria-label="Rediger reise">
               <EditIcon />
             </IconButton>
           </Tooltip>

--- a/apps/documentation/src/pages/komponenter/layout-og-flater/drawer.mdx
+++ b/apps/documentation/src/pages/komponenter/layout-og-flater/drawer.mdx
@@ -111,7 +111,7 @@ Den bør heller ikke inneholde navigasjon (tabs, expansion panels eller menyer).
               <HeaderCell>Publisert</HeaderCell>
               <HeaderCell>Kategori</HeaderCell>
               <HeaderCell>Mottaker</HeaderCell>
-              <HeaderCell padding="overflow-menu"></HeaderCell>
+              <HeaderCell padding="overflow-menu" aria-label="meny-knapper"></HeaderCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -121,7 +121,7 @@ Den bør heller ikke inneholde navigasjon (tabs, expansion panels eller menyer).
               <DataCell>Transaksjonssstatistikk</DataCell>
               <DataCell>Vy Alle</DataCell>
               <DataCell padding="overflow-menu">
-                <IconButton onClick={() => setMode(true)}>
+                <IconButton onClick={() => setMode(true)} aria-label="mer informasjon">
                   <ValidationInfoFilledIcon />
                 </IconButton>
               </DataCell>
@@ -132,7 +132,7 @@ Den bør heller ikke inneholde navigasjon (tabs, expansion panels eller menyer).
               <DataCell>Transaksjonssstatistikk</DataCell>
               <DataCell>Vy Alle</DataCell>
               <DataCell padding="overflow-menu">
-                <IconButton onClick={() => setMode(true)}>
+                <IconButton onClick={() => setMode(true)} aria-label="mer informasjon">
                   <ValidationInfoFilledIcon />
                 </IconButton>
               </DataCell>
@@ -143,7 +143,7 @@ Den bør heller ikke inneholde navigasjon (tabs, expansion panels eller menyer).
               <DataCell>Transaksjonssstatistikk</DataCell>
               <DataCell>Vy Alle</DataCell>
               <DataCell padding="overflow-menu">
-                <IconButton onClick={() => setMode(true)}>
+                <IconButton onClick={() => setMode(true)} aria-label="mer informasjon">
                   <ValidationInfoFilledIcon />
                 </IconButton>
               </DataCell>

--- a/apps/documentation/src/pages/komponenter/layout-og-flater/tab.mdx
+++ b/apps/documentation/src/pages/komponenter/layout-og-flater/tab.mdx
@@ -25,7 +25,7 @@ export const Head = ( props ) => {
     </TabList>
     <TabPanels>
       <TabPanel>
-        <Heading3>Informasjon</Heading3>
+        <Heading2>Informasjon</Heading2>
         <Paragraph>
           Et tab-panel kan inneholde masse informasjon, sortert og gruppert
           etter kategori.
@@ -36,7 +36,7 @@ export const Head = ( props ) => {
         </Paragraph>
       </TabPanel>
       <TabPanel>
-        <Heading3>Priser</Heading3>
+        <Heading2>Priser</Heading2>
         <TextField defaultValue="99,00" label="Pris" />
         <TextArea
           defaultValue="Prisen er inkludert MVA"
@@ -46,7 +46,7 @@ export const Head = ( props ) => {
       </TabPanel>
       <TabPanel />
       <TabPanel>
-        <Heading3>Denne er tom</Heading3>
+        <Heading2>Denne er tom</Heading2>
       </TabPanel>
     </TabPanels>
   </Tabs>

--- a/apps/documentation/src/pages/komponenter/layout-og-flater/table.mdx
+++ b/apps/documentation/src/pages/komponenter/layout-og-flater/table.mdx
@@ -333,14 +333,15 @@ Rader kan velges ved å gjøre første kolonne som en valgbar kolonne.
     return (
       <Table>
         <TableHead>
-          <TableRow>
-            <HeaderCell padding="checkbox">
+          <TableRow>                
+            <HeaderCell padding="checkbox" aria-label="avkrysningsbokser">
               <Checkbox
                 name="all"
                 checked={
                   isSomeSelected ? 'indeterminate' : isEverythingSelected
                 }
                 onChange={handleAllOrNothingChange}
+                aria-label="kryss av alle"
               />
             </HeaderCell>
             <HeaderCell>Fra</HeaderCell>
@@ -351,7 +352,7 @@ Rader kan velges ved å gjøre første kolonne som en valgbar kolonne.
         <TableBody>
           {selectedItems.map((item, index) => (
             <TableRow key={index}>
-              <DataCell padding="checkbox">
+              <DataCell padding="checkbox" aria-label="avkrysningsboks">
                 <Checkbox
                   name={item.fra}
                   checked={item.selected}
@@ -414,7 +415,7 @@ En utvidbar tabell lar brukeren vise og skjule innholdet på en rad. Utvidbare t
       return (
         <React.Fragment>
           <TableRow>
-            <DataCell>
+            <DataCell aria-label="ekspanderknapper">
               <ExpandRowButton onClick={() => setopen(!open)} open={open} />
             </DataCell>
             <DataCell>
@@ -471,7 +472,7 @@ En utvidbar tabell lar brukeren vise og skjule innholdet på en rad. Utvidbare t
         <TableHead>
           <TableRow>
             {/* Bruker padding="radio" her for å "enkelt" sette en god verdi for paddingen til venstre-kolonnen */}
-            <HeaderCell padding="radio">{''}</HeaderCell>
+            <HeaderCell padding="radio" aria-label="radioknapper">{''}</HeaderCell>
             <HeaderCell>Betalingsmåte</HeaderCell>
             <HeaderCell style={{ textAlign: 'right' }}>Salgssum</HeaderCell>
           </TableRow>
@@ -516,7 +517,7 @@ En utvidbar tabell lar brukeren vise og skjule innholdet på en rad. Utvidbare t
         <RadioGroup name="row" onChange={handleChange} value={value}>
           <TableHead>
             <TableRow>
-              <HeaderCell padding="radio"></HeaderCell>
+              <HeaderCell padding="radio" aria-label="radioknapper"></HeaderCell>
               <HeaderCell>Fra</HeaderCell>
               <HeaderCell>Til</HeaderCell>
               <HeaderCell>Avgang</HeaderCell>
@@ -663,7 +664,7 @@ den tabellraden. Har menyen en "slett" alternativ, bør det være på bunnen.
         <HeaderCell>Publisert</HeaderCell>
         <HeaderCell>Kategori</HeaderCell>
         <HeaderCell>Mottaker</HeaderCell>
-        <HeaderCell padding="overflow-menu"></HeaderCell>
+        <HeaderCell padding="overflow-menu" aria-label="menyknapper"></HeaderCell>
       </TableRow>
     </TableHead>
     <TableBody>
@@ -754,7 +755,7 @@ pen ikon for å konfigurere/redigere og søppelkasse ikon for å fjerne/slette e
         <HeaderCell>Publisert</HeaderCell>
         <HeaderCell>Kategori</HeaderCell>
         <HeaderCell>Mottaker</HeaderCell>
-        <HeaderCell></HeaderCell>
+        <HeaderCell aria-label="innstillinger"></HeaderCell>
       </TableRow>
     </TableHead>
     <TableBody>
@@ -764,14 +765,14 @@ pen ikon for å konfigurere/redigere og søppelkasse ikon for å fjerne/slette e
         <DataCell>Transaksjonssstatistikk</DataCell>
         <DataCell>Vy Alle</DataCell>
         <DataCell style={{ display: 'flex' }}>
-          <IconButton onClick={() => {}}>
-            <ValidationInfoFilledIcon aria-label="Info" />
+          <IconButton onClick={() => {}} aria-label="Info">
+            <ValidationInfoFilledIcon  />
           </IconButton>
-          <IconButton onClick={() => {}}>
-            <EditIcon aria-label="Rediger" />
+          <IconButton onClick={() => {}} aria-label="Rediger">
+            <EditIcon  />
           </IconButton>
-          <IconButton onClick={() => {}}>
-            <DeleteIcon aria-label="Slett" />
+          <IconButton onClick={() => {}} aria-label="Slett">
+            <DeleteIcon  />
           </IconButton>
         </DataCell>
       </TableRow>
@@ -781,14 +782,14 @@ pen ikon for å konfigurere/redigere og søppelkasse ikon for å fjerne/slette e
         <DataCell>Transaksjonssstatistikk</DataCell>
         <DataCell>Vy Alle</DataCell>
         <DataCell style={{ display: 'flex' }}>
-          <IconButton onClick={() => {}}>
-            <ValidationInfoFilledIcon aria-label="Info" />
+          <IconButton onClick={() => {}} aria-label="Info">
+            <ValidationInfoFilledIcon  />
           </IconButton>
-          <IconButton onClick={() => {}}>
-            <EditIcon aria-label="Rediger" />
+          <IconButton onClick={() => {}}  aria-label="Rediger" >
+            <EditIcon/>
           </IconButton>
-          <IconButton onClick={() => {}}>
-            <DeleteIcon aria-label="Slett" />
+          <IconButton onClick={() => {}} aria-label="Slett">
+            <DeleteIcon  />
           </IconButton>
         </DataCell>
       </TableRow>
@@ -798,14 +799,14 @@ pen ikon for å konfigurere/redigere og søppelkasse ikon for å fjerne/slette e
         <DataCell>Transaksjonssstatistikk</DataCell>
         <DataCell>Vy Alle</DataCell>
         <DataCell style={{ display: 'flex' }}>
-          <IconButton onClick={() => {}}>
-            <ValidationInfoFilledIcon aria-label="Info" />
+          <IconButton onClick={() => {}} aria-label="Info" >
+            <ValidationInfoFilledIcon />
           </IconButton>
-          <IconButton onClick={() => {}}>
-            <EditIcon aria-label="Rediger" />
+          <IconButton onClick={() => {}} aria-label="Rediger">
+            <EditIcon  />
           </IconButton>
-          <IconButton onClick={() => {}}>
-            <DeleteIcon aria-label="Slett" />
+          <IconButton onClick={() => {}} aria-label="Slett" >
+            <DeleteIcon />
           </IconButton>
         </DataCell>
       </TableRow>

--- a/apps/documentation/src/pages/komponenter/navigasjon/overflow-menu.mdx
+++ b/apps/documentation/src/pages/komponenter/navigasjon/overflow-menu.mdx
@@ -82,7 +82,7 @@ kan en `OverflowMenu` være nyttig å bruke på enden av raden.
         <HeaderCell>Publisert</HeaderCell>
         <HeaderCell>Kategori</HeaderCell>
         <HeaderCell>Mottaker</HeaderCell>
-        <HeaderCell padding="overflow-menu"></HeaderCell>
+        <HeaderCell padding="overflow-menu" aria-label="menyknapper"></HeaderCell>
       </TableRow>
     </TableHead>
     <TableBody>

--- a/apps/documentation/src/pages/komponenter/skjemaelementer/checkbox-panel.mdx
+++ b/apps/documentation/src/pages/komponenter/skjemaelementer/checkbox-panel.mdx
@@ -42,7 +42,7 @@ export const Head = ( props ) => {
   </Fieldset>
 ```
 
-### Test ut props
+## Test ut props
 
 <Playground props={inputpanel} code={`<CheckboxPanel title="249,-" value="non-flexi" size="large">
     Ikke fleksibel

--- a/apps/documentation/src/pages/tokens/fargetokens/generelt.mdx
+++ b/apps/documentation/src/pages/tokens/fargetokens/generelt.mdx
@@ -42,7 +42,7 @@ Med standardiserte fargetokens blir det enkelt og tydelig å endre tilknyttede r
 <BaseCardDesignEntur arrow>
 <ImageDisplay
   imgSource={props.data.imagefiles.images.find(image => image.name === "dont-tokens").childImageSharp.gatsbyImageData}
-  alt="illustrasjon av at utvikler A bruker navnet Lavender90 og utvikler B bruker navnet ColorBlue men begge er den samme fargen."
+  alt="utvikler A bruker navnet Lavender90 og utvikler B bruker navnet ColorBlue men begge er den samme fargen."
   preset="full-width-image"
   className="designentur-base-card__image--small"
 />
@@ -51,7 +51,8 @@ Med standardiserte fargetokens blir det enkelt og tydelig å endre tilknyttede r
 <BaseCardDesignEntur>
 <ImageDisplay
   imgSource={props.data.imagefiles.images.find(image => image.name === "do-tokens").childImageSharp.gatsbyImageData}
-  alt="illustrasjon av at Lavender 90-fargen ved navn Fill.Primary.Default er den man skal bruke i komponenter."    preset="full-width-image"
+  alt="Lavender 90-fargen ved navn Fill.Primary.Default er den man skal bruke i komponenter."
+  preset="full-width-image"
   className="designentur-base-card__image--small"
 />
 </BaseCardDesignEntur>
@@ -121,7 +122,7 @@ Som allerede nevnt er komponentene i designsystemet integrert med fargetokens, s
 <BaseCardDesignEntur  title="Eksempel i grensesnitt" >
   <ImageDisplay
   imgSource={props.data.imagefiles.images.find(image => image.name === "brukFlateBase").childImageSharp.gatsbyImageData}
-  alt="eksemplet viser at background skal brukes for bakgrunn, shape skal brukes på en sirkel, text skal brukes på tekst, og stroke kan brukes på en skillelinje" 
+  alt="background skal brukes for bakgrunn, shape skal brukes på en sirkel, text skal brukes på tekst, og stroke kan brukes på en skillelinje" 
   className="designentur-base-card__image--medium"
   />
 </BaseCardDesignEntur>
@@ -135,7 +136,7 @@ Som allerede nevnt er komponentene i designsystemet integrert med fargetokens, s
       props.data.imagefiles.images.find(image => image.name === 'brukBase')
         .childImageSharp.gatsbyImageData
     }
-    alt="eksemplet viser navnene på base-tokens. For eksempel for bakgrunn kan du bruke frame-default, for border kan du bruke stroke-subduedalt, for ikon kan du bruke shape-default, for titteltekst kan du bruke text-default og for subtekst kan du bruke text-subdued"
+    alt="For eksempel for bakgrunn kan du bruke frame-default, for border kan du bruke stroke-subduedalt, for ikon kan du bruke shape-default, for titteltekst kan du bruke text-default og for subtekst kan du bruke text-subdued"
     className="designentur-base-card__image--medium"
   />
 </BaseCardDesignEntur>


### PR DESCRIPTION
Denne PR'en retter opp i små UU-feil på nettsiden.
Oppsummering:
- label skal bare brukes i sammenheng med skjema-elementer, om utseende av en label er hensikten har jeg erstattet `<Label> `med css-klassen `eds-label`
- Alt-tekster skal ikke være lange. Om de blir for lange må man vurdere om man skal skrive mer beskrivende tekster i tillegg til bilder/illustrasjoner. Jeg har kortet ned noen, men andre steder bør vi ta en nærmere gjennomgang av bilder med tekst. (laget tasks)
- Lagt til aria-label på tomme tabell-celler og knapper