### PR TITLE
fix(dropdown): etu-55943 Searchable dropdown lager whitespace ved åpning

### DIFF
--- a/apps/documentation/src/utils/gatsby/gatsby-types.d.ts
+++ b/apps/documentation/src/utils/gatsby/gatsby-types.d.ts
@@ -3383,7 +3383,7 @@ type PackageChangelogQuery = { readonly allFile: { readonly nodes: ReadonlyArray
 type pageQueryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-type pageQueryQuery = { readonly toneofvoice: { readonly images: ReadonlyArray<{ readonly name: string, readonly childImageSharp: { readonly gatsbyImageData: import('gatsby-plugin-image').IGatsbyImageData } | null }> } };
+type pageQueryQuery = { readonly verdier: { readonly images: ReadonlyArray<{ readonly name: string, readonly childImageSharp: { readonly gatsbyImageData: import('gatsby-plugin-image').IGatsbyImageData } | null }> } };
 
 type PowerpointFileQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:documentation": "lerna run --scope @entur/documentation build",
     "build:documentation:skip-packages-dependency": "cd apps/documentation && yarn build",
     "build:packages": "lerna run build --no-private",
-    "cleanStart": "lerna run --scope @entur/documentation cleanStart",
+    "cleanStart": "lerna run --scope @entur/documentation clean-start",
     "deploy-docs": "lerna exec --scope @entur/documentation -- yarn deploy-docs",
     "deploy-docs:preview": "lerna exec --scope @entur/documentation -- yarn deploy-docs:preview",
     "gc:format": "cz",

--- a/packages/dropdown/src/components/DropdownList.scss
+++ b/packages/dropdown/src/components/DropdownList.scss
@@ -1,6 +1,8 @@
 @use '@entur/tokens/dist/styles.scss' as t;
 
 .eds-dropdown__list {
+  position: absolute;
+  width: 100%;
   box-sizing: content-box;
   max-height: 50vh;
   overflow-y: auto;
@@ -14,7 +16,7 @@
 
   &__floating-container {
     z-index: t.$z-indexes-popover;
-    width: calc(100% + t.$border-widths-medium * 2);
+    width: 100%;
   }
 
   &:focus {


### PR DESCRIPTION
The dropdown now opens without affecting the page height

La ved test-side. /test
Gjøre før merging:

- [x] Fjerne testside og testdata