### PR TITLE
fix(icons): fix 'Received `true` for a non-boolean attribute `inline`…

### DIFF
--- a/packages/icons/bin/build.ts
+++ b/packages/icons/bin/build.ts
@@ -282,6 +282,7 @@ async function createSvgrConfig({
     height: '{(props.height || props.size || "1em")}',
     className,
     color,
+    inline: '{undefined}',
   };
 
   return config;


### PR DESCRIPTION
….' warning

`inline` is no longer incorrectly forwarded to svg-element.