### PR TITLE
Etu 59710 forced return type i datepicker gjor ingenting

### DIFF
--- a/packages/datepicker/src/DatePicker/Calendar.tsx
+++ b/packages/datepicker/src/DatePicker/Calendar.tsx
@@ -80,6 +80,7 @@ type BaseCalendarProps<DateType extends DateValue> = {
    *  @example (date) => isWeekend(date, 'no-NO') ? 'helgedag' : ''
    */
   ariaLabelForDate?: (date: CalendarDate) => string;
+  disabled?: boolean;
   locale?: string;
   calendarRef?: React.MutableRefObject<HTMLDivElement | null>;
   forcedReturnType?: DateFieldProps<DateType>['forcedReturnType'];
@@ -92,10 +93,11 @@ export const Calendar = <DateType extends DateValue>({
   locale: localOverride,
   ...rest
 }: CalendarProps<DateType>) => {
+  const props = { isDisabled: rest.disabled, ...rest };
   const { locale } = useLocale();
   return (
     <I18nProvider locale={localOverride ?? locale}>
-      <CalendarBase {...rest} />
+      <CalendarBase {...props} />
     </I18nProvider>
   );
 };

--- a/packages/datepicker/src/DatePicker/DatePicker.tsx
+++ b/packages/datepicker/src/DatePicker/DatePicker.tsx
@@ -33,9 +33,9 @@ import {
   DateField,
   ExtendedDateFieldProps,
 } from './DateField';
-import { Calendar } from './Calendar';
+import { Calendar, CalendarProps } from './Calendar';
 import { CalendarButton } from '../shared/CalendarButton';
-import { lastMillisecondOfDay } from '../shared/utils';
+import { handleOnChange, lastMillisecondOfDay } from '../shared/utils';
 
 import './DatePicker.scss';
 
@@ -109,7 +109,6 @@ export const DatePicker = <DateType extends DateValue>({
   minDate,
   maxDate,
   modalTreshold = 1000,
-  forcedReturnType,
   ariaLabelForDate,
   append,
   prepend,
@@ -124,6 +123,13 @@ export const DatePicker = <DateType extends DateValue>({
 
   const _props: DatePickerStateOptions<DateType> = {
     ...rest,
+    onChange: value =>
+      handleOnChange<DateType>({
+        value,
+        selectedDate,
+        forcedReturnType: rest.forcedReturnType,
+        onChange: rest.onChange,
+      }),
     minValue: minDate,
     // this weird logic makes sure the entire day is included if no time is provided in maxDate
     maxValue:
@@ -167,10 +173,12 @@ export const DatePicker = <DateType extends DateValue>({
     state.setOpen(false);
   });
 
-  const calendarSharedProps = {
+  const calendarSharedProps: CalendarProps<DateType> = {
     ...dialogProps,
     ...calendarProps,
+    // We don't use handleOnChange here since it's handled internally by Calendar
     onChange: rest.onChange,
+    forcedReturnType: rest.forcedReturnType,
     disabled,
     navigationDescription,
     onSelectedCellClick: () => state.setOpen(false),
@@ -222,6 +230,7 @@ export const DatePicker = <DateType extends DateValue>({
       <DateField
         {...(groupProps as any)}
         {...fieldProps}
+        // We don't use handleOnChange here since it's handled internally by DateField
         {...rest}
         append={
           !disabled &&

--- a/packages/datepicker/src/tests/Datepicker.test.tsx
+++ b/packages/datepicker/src/tests/Datepicker.test.tsx
@@ -14,6 +14,7 @@ import {
 import { toHaveNoViolations, axe } from 'jest-axe';
 
 import { DateField, DatePicker } from '../DatePicker';
+import { ForcedReturnType } from '../shared/utils';
 
 jest.mock('@floating-ui/react-dom', () => ({
   useFloating: jest.fn(() => {
@@ -604,6 +605,56 @@ test.each([
     expect(emittedDefaultDateCalendarWithGranularity).toHaveProperty(
       'timeZone',
     );
+  },
+);
+
+test.each([
+  {
+    props: { forcedReturnType: 'CalendarDate' as ForcedReturnType },
+    result: { notHave: 'hour' },
+  },
+  {
+    props: { forcedReturnType: 'CalendarDateTime' as ForcedReturnType },
+    result: { notHave: 'timeZone' },
+  },
+])(
+  'emits correct DateType based on forcedReturnType from datefield and calendar in datepicker',
+  async ({ props, result }) => {
+    const user = userEvent.setup();
+    const spy = jest.fn();
+    const currentDate = null;
+
+    const { container } = render(
+      <DatePicker
+        label="test"
+        selectedDate={currentDate}
+        onChange={spy}
+        locale="en-GB"
+        forcedReturnType={props.forcedReturnType}
+      />,
+    );
+
+    const dateFields = screen.getAllByRole('spinbutton');
+    for (const field of dateFields) {
+      field.focus();
+      await user.keyboard('{ArrowUp}');
+    }
+
+    const emittedDateValueFromDateField = spy.mock.calls[0][0];
+    expect(emittedDateValueFromDateField).not.toHaveProperty(result.notHave);
+
+    const openCalendarButton = container.getElementsByClassName(
+      'eds-datepicker__open-calendar-button',
+    )[0];
+    await user.click(openCalendarButton);
+
+    const todaysDateButton = container.getElementsByClassName(
+      'eds-datepicker__calendar__grid__cell--today',
+    )[0];
+    await user.click(todaysDateButton);
+
+    const emittedDateValueFromCalendar = spy.mock.calls[1][0];
+    expect(emittedDateValueFromCalendar).not.toHaveProperty(result.notHave);
   },
 );
 


### PR DESCRIPTION
**Problem og løsning**
Det var glemt å inkludere handleOnChange og å videresende `forcedReturnType` på riktige steder i DatePicker, dermed ble hverken onChange håndtert med `forcedReturnType` i selve DatePicker eller i dens children, dvs. DateField og Calendar. Løsningen ble å legge inn HandleOnChange i onChange-eventet som selve DatePicker bruker, og å sende `forcedReturnType` og vanlig onChange uten handleOnChange til DateField sånn at den internt håndterer sin egen handleOnChange

**Todo**
- [x] Legg inn kommentar om hvorfor handleOnChange brukes et sted, men ikke alle i `DatePicker`