### PR TITLE
fix(form): fix text copy on readonly in form and dropdown

### DIFF
--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -265,22 +265,24 @@ export const Dropdown = React.forwardRef(
           },
         })}
         after={
-          <DropdownList
-            ariaLabelChosenSingular={ariaLabelChosenSingular}
-            ariaLabelSelectedItem={ariaLabelSelectedItem}
-            floatingStyles={floatingStyles}
-            getItemProps={getItemProps}
-            getMenuProps={getMenuProps}
-            highlightedIndex={highlightedIndex}
-            isOpen={isOpen}
-            listItems={normalizedItems}
-            noMatchesText={noMatchesText}
-            style={listStyle}
-            setListRef={refs.setFloating}
-            loading={loading ?? resolvedItemsLoading}
-            loadingText={loadingText}
-            selectedItems={selectedItem !== null ? [selectedItem] : []}
-          />
+          !readOnly && (
+            <DropdownList
+              ariaLabelChosenSingular={ariaLabelChosenSingular}
+              ariaLabelSelectedItem={ariaLabelSelectedItem}
+              floatingStyles={floatingStyles}
+              getItemProps={getItemProps}
+              getMenuProps={getMenuProps}
+              highlightedIndex={highlightedIndex}
+              isOpen={isOpen}
+              listItems={normalizedItems}
+              noMatchesText={noMatchesText}
+              style={listStyle}
+              setListRef={refs.setFloating}
+              loading={loading ?? resolvedItemsLoading}
+              loadingText={loadingText}
+              selectedItems={selectedItem !== null ? [selectedItem] : []}
+            />
+          )
         }
         {...rest}
         // Append is not supported as of now

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -265,24 +265,23 @@ export const Dropdown = React.forwardRef(
           },
         })}
         after={
-          !readOnly && (
-            <DropdownList
-              ariaLabelChosenSingular={ariaLabelChosenSingular}
-              ariaLabelSelectedItem={ariaLabelSelectedItem}
-              floatingStyles={floatingStyles}
-              getItemProps={getItemProps}
-              getMenuProps={getMenuProps}
-              highlightedIndex={highlightedIndex}
-              isOpen={isOpen}
-              listItems={normalizedItems}
-              noMatchesText={noMatchesText}
-              style={listStyle}
-              setListRef={refs.setFloating}
-              loading={loading ?? resolvedItemsLoading}
-              loadingText={loadingText}
-              selectedItems={selectedItem !== null ? [selectedItem] : []}
-            />
-          )
+          <DropdownList
+            ariaLabelChosenSingular={ariaLabelChosenSingular}
+            ariaLabelSelectedItem={ariaLabelSelectedItem}
+            floatingStyles={floatingStyles}
+            getItemProps={getItemProps}
+            getMenuProps={getMenuProps}
+            highlightedIndex={highlightedIndex}
+            isOpen={isOpen}
+            listItems={normalizedItems}
+            noMatchesText={noMatchesText}
+            style={listStyle}
+            setListRef={refs.setFloating}
+            loading={loading ?? resolvedItemsLoading}
+            loadingText={loadingText}
+            selectedItems={selectedItem !== null ? [selectedItem] : []}
+            readOnly={readOnly}
+          />
         }
         {...rest}
         // Append is not supported as of now

--- a/packages/dropdown/src/MultiSelect.tsx
+++ b/packages/dropdown/src/MultiSelect.tsx
@@ -446,6 +446,7 @@ export const MultiSelect = React.forwardRef(
             selectAllCheckboxState={selectAllCheckboxState}
             selectAllItem={selectAll}
             selectedItems={selectedItems}
+            readOnly={readOnly}
           />
         }
         {...rest}

--- a/packages/dropdown/src/SearchableDropdown.tsx
+++ b/packages/dropdown/src/SearchableDropdown.tsx
@@ -330,6 +330,7 @@ export const SearchableDropdown = React.forwardRef(
             loadingText={loadingText}
             noMatchesText={noMatchesText}
             selectedItems={selectedItem !== null ? [selectedItem] : []}
+            readOnly={readOnly}
           />
         }
         {...rest}
@@ -341,8 +342,8 @@ export const SearchableDropdown = React.forwardRef(
             'eds-dropdown--searchable__selected-item--hidden':
               !showSelectedItem,
           })}
-          aria-hidden="true"
-          onClick={getInputProps()?.onClick}
+          onClick={readOnly ? undefined : getInputProps()?.onClick}
+          tabIndex={readOnly ? 0 : -1}
         >
           {showSelectedItem ? selectedItem?.label : ''}
         </span>
@@ -370,7 +371,9 @@ export const SearchableDropdown = React.forwardRef(
               if (selectedItem !== null) setShowSelectedItem(true);
             },
             onFocus() {
-              setShowSelectedItem(false);
+              if (!readOnly) {
+                setShowSelectedItem(false);
+              }
             },
             disabled: disabled,
             readOnly: readOnly,

--- a/packages/dropdown/src/components/DropdownList.tsx
+++ b/packages/dropdown/src/components/DropdownList.tsx
@@ -30,6 +30,7 @@ type DropdownListProps<ValueType> = {
   selectAllItem?: NormalizedDropdownItemType<string>;
   selectedItems: NormalizedDropdownItemType<ValueType>[];
   style?: React.CSSProperties;
+  readOnly?: boolean;
 };
 
 export const DropdownList = <ValueType extends NonNullable<any>>({
@@ -48,6 +49,7 @@ export const DropdownList = <ValueType extends NonNullable<any>>({
   selectAllCheckboxState,
   selectAllItem,
   selectedItems,
+  readOnly = false,
   ...rest
 }: DropdownListProps<ValueType>) => {
   const isMultiselect = selectAllItem !== undefined;
@@ -158,13 +160,13 @@ export const DropdownList = <ValueType extends NonNullable<any>>({
         className: 'eds-dropdown__list',
         style: {
           ...floatingStyles,
-          display: isOpen ? undefined : 'none',
+          display: isOpen && !readOnly ? undefined : 'none',
           ...rest.style,
         },
       })}
     >
       {(() => {
-        if (!isOpen) {
+        if (!isOpen || readOnly) {
           return null;
         }
 

--- a/packages/dropdown/src/components/FieldComponents.scss
+++ b/packages/dropdown/src/components/FieldComponents.scss
@@ -42,7 +42,7 @@
       .eds-contrast & {
         background-color: var(--components-form-baseform-standard-fill-readonly);
         border-color: var(--components-chip-contrast-border);
-        color: var(--components-form-baseform-standard-text-content);
+        color: var(--components-form-baseform-contrast-fill-default);
       }
     }
 

--- a/packages/form/src/BaseFormControl.scss
+++ b/packages/form/src/BaseFormControl.scss
@@ -37,7 +37,7 @@
       }
     }
 
-    &:focus-within {
+    &:focus-within:not(.eds-form-control-wrapper--readonly) {
       border-color: var(--components-form-baseform-standard-border-interactive);
       outline: 2px solid var(--components-form-baseform-standard-border-interactive);
       .eds-contrast & {
@@ -83,14 +83,15 @@
         }
       }
     }
-
     &--readonly {
       border-color: transparent;
-      pointer-events: none;
       cursor: default;
       background: var(--components-form-baseform-standard-fill-readonly);
       border: var(--components-form-baseform-standard-fill-readonly);
 
+      &:focus-visible {
+        outline: none;
+      }
       .eds-contrast & {
         background: var(--components-form-baseform-contrast-fill-readonly);
         border: var(--components-form-baseform-contrast-fill-readonly);

--- a/packages/form/src/BaseFormControl.tsx
+++ b/packages/form/src/BaseFormControl.tsx
@@ -65,6 +65,8 @@ export type BaseFormControlProps = React.HTMLAttributes<HTMLDivElement> & {
   after?: React.ReactNode;
   /** Legg til et element før feltet */
   before?: React.ReactNode;
+  /** Aria-label som brukes når inputfeltet er i read-only modus */
+  ariaLabelOnReadOnly?: string;
 };
 
 export const BaseFormControl = React.forwardRef<
@@ -95,6 +97,7 @@ export const BaseFormControl = React.forwardRef<
       style,
       disableLabelAnimation = false,
       ariaAlertOnFeedback = false,
+      ariaLabelOnReadOnly = 'Dette skjemafeltet kan bare leses',
       ...rest
     },
     ref,
@@ -131,6 +134,8 @@ export const BaseFormControl = React.forwardRef<
               },
             )}
             ref={ref}
+            tabIndex={readOnly ? -1 : 0}
+            aria-label={readOnly ? ariaLabelOnReadOnly : undefined}
             {...rest}
           >
             {prepend && (

--- a/packages/form/src/BaseFormControl.tsx
+++ b/packages/form/src/BaseFormControl.tsx
@@ -135,7 +135,6 @@ export const BaseFormControl = React.forwardRef<
             )}
             ref={ref}
             tabIndex={readOnly ? -1 : 0}
-            aria-label={readOnly ? ariaLabelOnReadOnly : undefined}
             {...rest}
           >
             {prepend && (
@@ -146,6 +145,9 @@ export const BaseFormControl = React.forwardRef<
               required={required}
               labelId={labelId}
               staticAnimation={disableLabelAnimation}
+              aria-label={
+                readOnly ? `${label}, ${ariaLabelOnReadOnly}` : undefined
+              }
               {...labelProps}
             />
             {labelTooltip && (


### PR DESCRIPTION
- bruk av `pointer-events: none `er ikke mulig å bruke sammen med `user-select: text;` i Firefox dessverre. Så derfor er `pointer-events: none;` fjernet fra BaseForm og man hopper heller over BaseForm i tabIndex ved readOnly. 
- fikset at dropdownList åpnet seg ved klikk på et readonly-felt

Update:
- nå skal kopiering fungere på searchable dropdown også. 
- Jeg har flyttet logikken "ikke åpne dropdownList" til DropdownList-komponenten
- det er fortsatt logikk som bør gjennomgås når det gjelder fokus på feltene ved readOnly, men siden dette fikser hovedproblemet med kopiering av readonly-felt, tenker jeg at dette bør holde for nå? Fokushåndtering bør gjøres når vi skal endre BaseForm designet ? Ellers ble dette litt scopecreep 😬 