### PR TITLE
fix(textfield): fix double tab to exit input field

### DIFF
--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -150,13 +150,13 @@ export const Dropdown = React.forwardRef(
       useResolvedItems(initialItems);
     const isFilled = selectedItem !== null || placeholder !== undefined;
     const {
-      closeMenu,
       isOpen,
       getItemProps,
       getLabelProps,
       getMenuProps,
       getToggleButtonProps,
       highlightedIndex,
+      selectItem,
       reset,
     } = useSelect({
       items: normalizedItems,
@@ -257,10 +257,8 @@ export const Dropdown = React.forwardRef(
                 highlitedItem &&
                 highlitedItem !== selectedItem
               ) {
-                onChange?.(highlitedItem);
+                selectItem(highlitedItem);
               }
-              closeMenu();
-              e.preventDefault();
             }
           },
         })}

--- a/packages/dropdown/src/MultiSelect.tsx
+++ b/packages/dropdown/src/MultiSelect.tsx
@@ -222,12 +222,17 @@ export const MultiSelect = React.forwardRef(
       filterListItems({ inputValue });
     }, [normalizedItems]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const { hasSelectedItems, handleListItemClicked, selectAllCheckboxState } =
-      useMultiselectUtils<ValueType>({
-        listItems,
-        selectAll,
-        selectedItems,
-      });
+    const {
+      hasSelectedItems,
+      handleListItemClicked,
+      selectAllCheckboxState,
+      clickedItemIsInSelectedItems,
+      clickedItemIsSelectAll,
+    } = useMultiselectUtils<ValueType>({
+      listItems,
+      selectAll,
+      selectedItems,
+    });
 
     const {
       getSelectedItemProps,
@@ -505,12 +510,20 @@ export const MultiSelect = React.forwardRef(
               onKeyDown: (e: React.KeyboardEvent) => {
                 if (selectOnTab && isOpen && e.key === 'Tab') {
                   const highlitedItem = listItems[highlightedIndex];
-                  if (highlitedItem) {
-                    handleListItemClicked({
-                      clickedItem: highlitedItem,
-                      onChange: setSelectedItems,
-                    });
-                  }
+                  if (!highlitedItem) return;
+
+                  // Skip tab selection for select all or if item already is selected
+                  const shouldSkipTabSelection =
+                    clickedItemIsSelectAll(highlitedItem) ||
+                    (!clickedItemIsSelectAll(highlitedItem) &&
+                      clickedItemIsInSelectedItems(highlitedItem));
+
+                  if (shouldSkipTabSelection) return;
+
+                  handleListItemClicked({
+                    clickedItem: highlitedItem,
+                    onChange: setSelectedItems,
+                  });
                 }
               },
               ...getDropdownProps({

--- a/packages/dropdown/src/MultiSelect.tsx
+++ b/packages/dropdown/src/MultiSelect.tsx
@@ -229,13 +229,19 @@ export const MultiSelect = React.forwardRef(
         selectedItems,
       });
 
-    const { getSelectedItemProps, getDropdownProps } = useMultipleSelection({
+    const {
+      getSelectedItemProps,
+      getDropdownProps,
+      reset,
+      removeSelectedItem,
+      setSelectedItems,
+    } = useMultipleSelection({
       selectedItems,
       // @ts-expect-error prop missing from library types
       itemToString,
       itemToKey,
-      onStateChange({ selectedItems: newSelectedItems }) {
-        if (newSelectedItems !== undefined) onChange(newSelectedItems);
+      onSelectedItemsChange({ selectedItems: newSelectedItems }) {
+        onChange(newSelectedItems);
       },
     });
 
@@ -259,7 +265,6 @@ export const MultiSelect = React.forwardRef(
         switch (type) {
           // reset input value when leaving input field
           case useCombobox.stateChangeTypes.InputBlur:
-            if (state.isOpen) inputRef.current?.focus();
             return {
               ...changes,
               inputValue: EMPTY_INPUT,
@@ -341,13 +346,13 @@ export const MultiSelect = React.forwardRef(
         setHighlightedIndex(hideSelectAll ? 0 : 1);
         setLastHighlightedIndex(hideSelectAll ? 0 : 1);
       },
-      onStateChange({ selectedItem: clickedItem }) {
+      onSelectedItemChange({ selectedItem: clickedItem }) {
         // clickedItem means item chosen either via mouse or keyboard
         if (!clickedItem) return;
 
         handleListItemClicked({
           clickedItem,
-          onChange,
+          onChange: setSelectedItems,
         });
       },
       // Accessibility
@@ -396,10 +401,8 @@ export const MultiSelect = React.forwardRef(
     }, [isOpen, refs.reference, refs.floating, update]);
 
     const handleOnClear = () => {
-      onChange([]);
-      setInputValue(EMPTY_INPUT);
       inputRef.current?.focus();
-      updateListItems({ inputValue });
+      reset();
     };
 
     return (
@@ -481,10 +484,7 @@ export const MultiSelect = React.forwardRef(
                 }
                 readOnly={readOnly}
                 removeSelectedItem={() => {
-                  handleListItemClicked({
-                    clickedItem: selectedItem,
-                    onChange,
-                  });
+                  removeSelectedItem(selectedItem);
                   inputRef?.current?.focus();
                 }}
                 selectedItem={selectedItem}
@@ -505,11 +505,10 @@ export const MultiSelect = React.forwardRef(
               onKeyDown: (e: React.KeyboardEvent) => {
                 if (selectOnTab && isOpen && e.key === 'Tab') {
                   const highlitedItem = listItems[highlightedIndex];
-                  // we don't want to clear selection with tab
                   if (highlitedItem) {
                     handleListItemClicked({
                       clickedItem: highlitedItem,
-                      onChange,
+                      onChange: setSelectedItems,
                     });
                   }
                 }

--- a/packages/dropdown/src/SearchableDropdown.tsx
+++ b/packages/dropdown/src/SearchableDropdown.tsx
@@ -214,7 +214,6 @@ export const SearchableDropdown = React.forwardRef(
     );
 
     const {
-      closeMenu,
       isOpen,
       getToggleButtonProps,
       getLabelProps,
@@ -225,6 +224,8 @@ export const SearchableDropdown = React.forwardRef(
       selectedItem,
       inputValue,
       setInputValue,
+      selectItem,
+      reset,
     } = useCombobox({
       defaultHighlightedIndex: lastHighlightedIndex,
       items: listItems,
@@ -234,8 +235,7 @@ export const SearchableDropdown = React.forwardRef(
       onInputValueChange(changes) {
         updateListItems({ inputValue: changes.inputValue });
       },
-      onStateChange({ selectedItem: newSelectedItem }) {
-        if (newSelectedItem === undefined) return;
+      onSelectedItemChange({ selectedItem: newSelectedItem }) {
         onChange(newSelectedItem);
       },
       // Accessibility
@@ -279,11 +279,8 @@ export const SearchableDropdown = React.forwardRef(
     }, [isOpen, refs.reference, refs.floating, update]);
 
     const handleOnClear = () => {
-      onChange(null);
-      setInputValue(EMPTY_INPUT);
       inputRef.current?.focus();
-      updateListItems({ inputValue });
-      setShowSelectedItem(false);
+      reset();
     };
 
     return (
@@ -361,10 +358,8 @@ export const SearchableDropdown = React.forwardRef(
                   highlitedItem &&
                   highlitedItem !== selectedItem
                 ) {
-                  onChange?.(highlitedItem);
+                  selectItem(highlitedItem);
                 }
-                closeMenu();
-                e.preventDefault();
               }
             },
             onBlur() {

--- a/packages/dropdown/src/utils.ts
+++ b/packages/dropdown/src/utils.ts
@@ -99,7 +99,8 @@ export const useMultiselectUtils = <ValueType>({
 
   const clickedItemIsSelectAll = (
     clickedItem: NormalizedDropdownItemType<string | ValueType>,
-  ) => clickedItem.value === selectAll.value;
+  ): clickedItem is NormalizedDropdownItemType<string> =>
+    clickedItem.value === selectAll.value;
 
   const handleListItemClicked = ({
     clickedItem,

--- a/packages/form/src/BaseFormControl.tsx
+++ b/packages/form/src/BaseFormControl.tsx
@@ -134,7 +134,7 @@ export const BaseFormControl = React.forwardRef<
               },
             )}
             ref={ref}
-            tabIndex={readOnly ? -1 : 0}
+            tabIndex={readOnly ? -1 : undefined}
             {...rest}
           >
             {prepend && (


### PR DESCRIPTION
Fikser bug som ble innført da readOnly ble forbedret. Den nye verdien til tabIndex gjorde at man måtte innom to elementer på hvert tekstfelt – dette er nå utbedret. 

I samme slengen er det endret oppførsel i Dropdown-ene til at tab nå alltid går til neste element, selv når dropdown-listen er åpen. Dette skaper forhåpentligvis en litt mer forutsigbar oppførsel i grensesnittet når man bruker Tab