### PR TITLE
fix(dropdown): fix rare crash when bluring or focusing searchable dropdown

### DIFF
--- a/packages/dropdown/src/SearchableDropdown.tsx
+++ b/packages/dropdown/src/SearchableDropdown.tsx
@@ -299,7 +299,6 @@ export const SearchableDropdown = React.forwardRef(
         labelId={getLabelProps().id}
         labelProps={getLabelProps()}
         labelTooltip={labelTooltip}
-        onBlur={() => setInputValue('')}
         onClick={(e: React.MouseEvent) => {
           if (e.target === e.currentTarget) {
             getInputProps()?.onClick?.(e);
@@ -339,7 +338,12 @@ export const SearchableDropdown = React.forwardRef(
             'eds-dropdown--searchable__selected-item--hidden':
               !showSelectedItem,
           })}
-          onClick={readOnly ? undefined : getInputProps()?.onClick}
+          onClick={event => {
+            if (!disabled && !readOnly) {
+              inputRef.current?.focus();
+              getInputProps()?.onClick?.(event);
+            }
+          }}
           tabIndex={readOnly ? 0 : -1}
         >
           {showSelectedItem ? selectedItem?.label : ''}


### PR DESCRIPTION
Virker som denne bug-en er skapt av en dobbel håndtering av hva som skjer når man kjører en blur på SearchableDropdown. Dette håndteres både av state-reducer-en og av en onBlur i BaseFormControl. Den i sistnevnte er nå fjernet. 

En tilsvarende bug kunne også skje når man trykket på selectedElement-label-en. Dette ble det lagt til en fokushåndtering for i tillegg til å kjøre onClick, men det er litt uklart hvordan dette fikset bug-en. Løsningen er kommet frem til ved hjelp av KI