### PR TITLE
Etu 60363 legge til mulighet for a vite valideringsstatusen til datovelgeren

### DIFF
--- a/apps/documentation/src/pages/komponenter/skjemaelementer/datepicker.mdx
+++ b/apps/documentation/src/pages/komponenter/skjemaelementer/datepicker.mdx
@@ -164,6 +164,36 @@ Følgende eksempel godtar datoer som ikke er en helg.
   scope={{now, isWeekend}}
 />
 
+#### Lese ut nåværende datovalidering
+
+Gjennom callback prop-en `onValidate` kan vi hente ut verdien på valideringen av datoen vår: 
+
+<Playground
+  defaultShowEditor
+  hideContrastOption
+  style={{ overflow: 'visible' }}
+  code={`() => {
+    const [date, setDate] = React.useState(now('Europe/Oslo'));
+    const [dateIsValid, setDateIsValid] = React.useState(true);
+    return (
+      <>
+        <DatePicker
+          label="Velg dato"
+          selectedDate={date}
+          onChange={setDate}
+          locale="nb-NO"
+          isDateUnavailable={date => isWeekend(date, 'nb-NO')}
+          onValidate={isValid => setDateIsValid(isValid)}
+        />
+        <SmallAlertBox variant={dateIsValid ? "information" : "negative"} style={{ marginTop: "0.5rem" }}>
+          Valgt dato er {dateIsValid ? "gyldig" : "ikke gyldig"}
+        </SmallAlertBox>
+      </>
+    );
+  }`}
+  scope={{now, isWeekend}}
+/>
+
 ### Bruke JS Date i stedet for @internationalized/date
 
 Hvis du ikke har mulighet til å bruke `@internationalized/date`, kan du bruke konverteringsfunksjonene: `nativeDateToDateValue` og `timeOrDateValueToNativeDate`. Disse konverterer

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ActionChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ActionChip.json
@@ -1,82 +1,80 @@
-[
-  {
-    "tags": {},
-    "description": "",
-    "displayName": "ActionChip",
-    "methods": [],
-    "props": {
-      "children": {
-        "defaultValue": null,
-        "description": "Teksten som vises i ActionChip",
-        "name": "children",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/ActionChip.tsx",
-            "name": "TypeLiteral"
-          },
-          {
-            "fileName": "design-system/node_modules/@types/react/index.d.ts",
-            "name": "DOMAttributes"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "ReactNode"
-        }
-      },
-      "className": {
-        "defaultValue": null,
-        "description": "Ekstra klassenavn",
-        "name": "className",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/ActionChip.tsx",
-            "name": "TypeLiteral"
-          },
-          {
-            "fileName": "design-system/node_modules/@types/react/index.d.ts",
-            "name": "HTMLAttributes"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
-        }
-      },
-      "loading": {
-        "defaultValue": {
-          "value": false
+{
+  "tags": {},
+  "description": "",
+  "displayName": "ActionChip",
+  "methods": [],
+  "props": {
+    "children": {
+      "defaultValue": null,
+      "description": "Teksten som vises i ActionChip",
+      "name": "children",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/ActionChip.tsx",
+          "name": "TypeLiteral"
         },
-        "description": "Om chip-en er opptatt, f.eks med å oppdatere informasjon",
-        "name": "loading",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/ActionChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "boolean | undefined"
+        {
+          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "name": "DOMAttributes"
         }
-      },
-      "size": {
-        "defaultValue": {
-          "value": "medium"
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "className": {
+      "defaultValue": null,
+      "description": "Ekstra klassenavn",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/ActionChip.tsx",
+          "name": "TypeLiteral"
         },
-        "description": "Størrelsen på chip",
-        "name": "size",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/ActionChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "\"small\" | \"medium\" | undefined"
+        {
+          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "name": "HTMLAttributes"
         }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "loading": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Om chip-en er opptatt, f.eks med å oppdatere informasjon",
+      "name": "loading",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/ActionChip.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "size": {
+      "defaultValue": {
+        "value": "medium"
+      },
+      "description": "Størrelsen på chip",
+      "name": "size",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/ActionChip.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "\"small\" | \"medium\" | undefined"
       }
     }
   }
-]
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Calendar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Calendar.json
@@ -211,6 +211,21 @@
         "name": "((date: CalendarDate) => string) | undefined"
       }
     },
+    "onValidate": {
+      "defaultValue": null,
+      "description": "Callback-funksjon for når valideringen til datovelgeren endrer seg",
+      "name": "onValidate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((isValid?: boolean | undefined) => void) | undefined"
+      }
+    },
     "disabled": {
       "defaultValue": null,
       "description": "",

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChip.json
@@ -1,101 +1,99 @@
-[
-  {
-    "tags": {},
-    "description": "",
-    "displayName": "ChoiceChip",
-    "methods": [],
-    "props": {
-      "value": {
-        "defaultValue": null,
-        "description": "Verdien til ChoiceChip",
-        "name": "value",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": true,
-        "type": {
-          "name": "string"
+{
+  "tags": {},
+  "description": "",
+  "displayName": "ChoiceChip",
+  "methods": [],
+  "props": {
+    "value": {
+      "defaultValue": null,
+      "description": "Verdien til ChoiceChip",
+      "name": "value",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "name": "TypeLiteral"
         }
+      ],
+      "required": true,
+      "type": {
+        "name": "string"
+      }
+    },
+    "size": {
+      "defaultValue": {
+        "value": "medium"
       },
-      "size": {
-        "defaultValue": {
-          "value": "medium"
+      "description": "Størrelsen på chip",
+      "name": "size",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "\"small\" | \"medium\" | undefined"
+      }
+    },
+    "disabled": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Om Choicechip er deaktivert eller ikke",
+      "name": "disabled",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "name": "TypeLiteral"
         },
-        "description": "Størrelsen på chip",
-        "name": "size",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "\"small\" | \"medium\" | undefined"
+        {
+          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "name": "InputHTMLAttributes"
         }
-      },
-      "disabled": {
-        "defaultValue": {
-          "value": false
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "className": {
+      "defaultValue": null,
+      "description": "Ekstra klassenavn",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "name": "TypeLiteral"
         },
-        "description": "Om Choicechip er deaktivert eller ikke",
-        "name": "disabled",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
-            "name": "TypeLiteral"
-          },
-          {
-            "fileName": "design-system/node_modules/@types/react/index.d.ts",
-            "name": "InputHTMLAttributes"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "boolean | undefined"
+        {
+          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "name": "HTMLAttributes"
         }
-      },
-      "className": {
-        "defaultValue": null,
-        "description": "Ekstra klassenavn",
-        "name": "className",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
-            "name": "TypeLiteral"
-          },
-          {
-            "fileName": "design-system/node_modules/@types/react/index.d.ts",
-            "name": "HTMLAttributes"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "children": {
+      "defaultValue": null,
+      "description": "Label til ChoiceChip",
+      "name": "children",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "name": "TypeLiteral"
+        },
+        {
+          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "name": "DOMAttributes"
         }
-      },
-      "children": {
-        "defaultValue": null,
-        "description": "Label til ChoiceChip",
-        "name": "children",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
-            "name": "TypeLiteral"
-          },
-          {
-            "fileName": "design-system/node_modules/@types/react/index.d.ts",
-            "name": "DOMAttributes"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "ReactNode"
-        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
       }
     }
   }
-]
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
@@ -1,517 +1,545 @@
-[
-  {
-    "tags": {},
-    "description": "",
-    "displayName": "DateField",
-    "methods": [],
-    "props": {
-      "selectedDate": {
-        "defaultValue": null,
-        "description": "Den valgte tiden. Tid i '@internationalized/date'-pakkens format",
-        "name": "selectedDate",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": true,
-        "type": {
-          "name": "DateValue | null"
+{
+  "tags": {},
+  "description": "",
+  "displayName": "DateField",
+  "methods": [],
+  "props": {
+    "selectedDate": {
+      "defaultValue": null,
+      "description": "Den valgte tiden. Tid i '@internationalized/date'-pakkens format",
+      "name": "selectedDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
+      ],
+      "required": true,
+      "type": {
+        "name": "DateValue | null"
+      }
+    },
+    "onChange": {
+      "defaultValue": null,
+      "description": "Kalles når dato endres. Tid i '@internationalized/date'-pakkens format",
+      "name": "onChange",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((value: MappedDateValue<DateType> | null) => void) | undefined"
+      }
+    },
+    "label": {
+      "defaultValue": null,
+      "description": "Ledetekst til DateField",
+      "name": "label",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "string"
+      }
+    },
+    "locale": {
+      "defaultValue": {
+        "value": "Brukerenhetens selvvalgte locale"
       },
-      "onChange": {
-        "defaultValue": null,
-        "description": "Kalles når dato endres. Tid i '@internationalized/date'-pakkens format",
-        "name": "onChange",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "((value: MappedDateValue<DateType> | null) => void) | undefined"
+      "description": "BCP47-språkkoden til locale-en du ønsker å bruke.",
+      "name": "locale",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "showTimeZone": {
+      "defaultValue": {
+        "value": "false"
       },
-      "label": {
-        "defaultValue": null,
-        "description": "Ledetekst til DateField",
-        "name": "label",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": true,
-        "type": {
-          "name": "string"
+      "description": "Viser den gjeldende tidssonen hvis en er valgt",
+      "name": "showTimeZone",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "granularity": {
+      "defaultValue": {
+        "value": "showTime ? 'minute' : 'day'"
       },
-      "locale": {
-        "defaultValue": {
-          "value": "Brukerenhetens selvvalgte locale"
-        },
-        "description": "BCP47-språkkoden til locale-en du ønsker å bruke.",
-        "name": "locale",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
+      "description": "Brukes for å vise tid i datovelgeren. Velg minste enhet som skal vises.\nHvis du vil vise tid vil \"minute\" vise minutt og ikke sekund, mens \"second\" viser\nsekunder også.",
+      "name": "granularity",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
+      ],
+      "required": false,
+      "type": {
+        "name": "Granularity | undefined"
+      }
+    },
+    "showTime": {
+      "defaultValue": null,
+      "description": "Viser tidspunkt i tillegg til dato.\nOBS: selectedDate må være av typen CalendarDateTime eller ZonedDateTime",
+      "name": "showTime",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "minDate": {
+      "defaultValue": null,
+      "description": "Tidligste gyldige datovalg.\nEks: today(getLocalTimeZone()) == i dag i lokal tidssone.\n\nOBS: Hvis du bruker dato med tid vil tidspunktet også tas hensyn til.\nGyldig fra og med den tiden som legges inn som minDate.\nDato uten tid vil være gyldig hele minDate-dagen",
+      "name": "minDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "DateValue | undefined"
+      }
+    },
+    "maxDate": {
+      "defaultValue": null,
+      "description": "Seneste gyldige datovalg.\nEks: today(getLocalTimeZone()).add({days: 1}) == i morgen i lokal tidssone\n\nOBS: Hvis du bruker dato med tid vil tidspunktet også tas hensyn til.\nGyldig til og med den tiden som legges inn som maxDate.\nDato uten tid vil være gyldig hele maxDate-dagen",
+      "name": "maxDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "DateValue | undefined"
+      }
+    },
+    "isDateUnavailable": {
+      "defaultValue": null,
+      "description": "Funksjon som tar inn en dato og sier om den er utilgjengelig.\nEks. (date) => isWeekend(date, 'no-NO') == helgedager er ikke tilgjengelig",
+      "name": "isDateUnavailable",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((date: DateValue) => boolean) | undefined"
+      }
+    },
+    "forcedReturnType": {
+      "defaultValue": {
+        "value": "undefined"
       },
-      "showTimeZone": {
-        "defaultValue": {
-          "value": "false"
-        },
-        "description": "Viser den gjeldende tidssonen hvis en er valgt",
-        "name": "showTimeZone",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "boolean | undefined"
+      "description": "Tvinger typen på onChange til den gitte typen.\nDette er nyttig når utgangsverdien din er 'null', men du ønsker at\nDatePicker alltid skal returnere f.eks ZonedDateTime.\n\nSom standard returnerer onChange DateValue basert på selectedDate,\neller CalendarDate hvis selectedDate er 'null'.",
+      "name": "forcedReturnType",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
+      ],
+      "required": false,
+      "type": {
+        "name": "ForcedReturnType"
+      }
+    },
+    "feedback": {
+      "defaultValue": null,
+      "description": "Varselmelding, som vil komme under TimePicker",
+      "name": "feedback",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "variant": {
+      "defaultValue": null,
+      "description": "Valideringsvariant",
+      "name": "variant",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "VariantType | \"error\" | \"info\" | undefined"
+      }
+    },
+    "validationFeedback": {
+      "defaultValue": {
+        "value": "Ugyldig dato"
       },
-      "granularity": {
-        "defaultValue": {
-          "value": "showTime ? 'minute' : 'day'"
-        },
-        "description": "Brukes for å vise tid i datovelgeren. Velg minste enhet som skal vises.\nHvis du vil vise tid vil \"minute\" vise minutt og ikke sekund, mens \"second\" viser\nsekunder også.",
-        "name": "granularity",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "Granularity | undefined"
+      "description": "Varselmelding som forteller om ugyldig dato",
+      "name": "validationFeedback",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "validationVariant": {
+      "defaultValue": {
+        "value": "negative"
       },
-      "showTime": {
-        "defaultValue": null,
-        "description": "Viser tidspunkt i tillegg til dato.\nOBS: selectedDate må være av typen CalendarDateTime eller ZonedDateTime",
-        "name": "showTime",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "boolean | undefined"
+      "description": "Valideringsvariant for melding om ugyldig dato",
+      "name": "validationVariant",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "minDate": {
-        "defaultValue": null,
-        "description": "Tidligste gyldige datovalg.\nEks: today(getLocalTimeZone()) == i dag i lokal tidssone.\n\nOBS: Hvis du bruker dato med tid vil tidspunktet også tas hensyn til.\nGyldig fra og med den tiden som legges inn som minDate.\nDato uten tid vil være gyldig hele minDate-dagen",
-        "name": "minDate",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "DateValue | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "VariantType | \"error\" | \"info\" | undefined"
+      }
+    },
+    "onValidate": {
+      "defaultValue": null,
+      "description": "Callback-funksjon for når valideringen til datovelgeren endrer seg",
+      "name": "onValidate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "maxDate": {
-        "defaultValue": null,
-        "description": "Seneste gyldige datovalg.\nEks: today(getLocalTimeZone()).add({days: 1}) == i morgen i lokal tidssone\n\nOBS: Hvis du bruker dato med tid vil tidspunktet også tas hensyn til.\nGyldig til og med den tiden som legges inn som maxDate.\nDato uten tid vil være gyldig hele maxDate-dagen",
-        "name": "maxDate",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "DateValue | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "((isValid?: boolean | undefined) => void) | undefined"
+      }
+    },
+    "labelTooltip": {
+      "defaultValue": null,
+      "description": "",
+      "name": "labelTooltip",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "isDateUnavailable": {
-        "defaultValue": null,
-        "description": "Funksjon som tar inn en dato og sier om den er utilgjengelig.\nEks. (date) => isWeekend(date, 'no-NO') == helgedager er ikke tilgjengelig",
-        "name": "isDateUnavailable",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "((date: DateValue) => boolean) | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "labelProps": {
+      "defaultValue": null,
+      "description": "",
+      "name": "labelProps",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "forcedReturnType": {
-        "defaultValue": {
-          "value": "undefined"
-        },
-        "description": "Tvinger typen på onChange til den gitte typen.\nDette er nyttig når utgangsverdien din er 'null', men du ønsker at\nDatePicker alltid skal returnere f.eks ZonedDateTime.\n\nSom standard returnerer onChange DateValue basert på selectedDate,\neller CalendarDate hvis selectedDate er 'null'.",
-        "name": "forcedReturnType",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "ForcedReturnType"
+      ],
+      "required": false,
+      "type": {
+        "name": "DOMAttributes<Element> | undefined"
+      }
+    },
+    "fieldProps": {
+      "defaultValue": null,
+      "description": "",
+      "name": "fieldProps",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "feedback": {
-        "defaultValue": null,
-        "description": "Varselmelding, som vil komme under TimePicker",
-        "name": "feedback",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "DateFieldProps<DateType> | undefined"
+      }
+    },
+    "dateFieldRef": {
+      "defaultValue": null,
+      "description": "",
+      "name": "dateFieldRef",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "variant": {
-        "defaultValue": null,
-        "description": "Valideringsvariant",
-        "name": "variant",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "VariantType | \"error\" | \"info\" | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "Ref<HTMLDivElement> | undefined"
+      }
+    },
+    "disabled": {
+      "defaultValue": null,
+      "description": "",
+      "name": "disabled",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "validationFeedback": {
-        "defaultValue": {
-          "value": "Ugyldig dato"
-        },
-        "description": "Varselmelding som forteller om ugyldig dato",
-        "name": "validationFeedback",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "readOnly": {
+      "defaultValue": null,
+      "description": "",
+      "name": "readOnly",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "validationVariant": {
-        "defaultValue": {
-          "value": "negative"
-        },
-        "description": "Valideringsvariant for melding om ugyldig dato",
-        "name": "validationVariant",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "VariantType | \"error\" | \"info\" | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "className": {
+      "defaultValue": null,
+      "description": "Ekstra klassenavn",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "labelTooltip": {
-        "defaultValue": null,
-        "description": "",
-        "name": "labelTooltip",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "ReactNode"
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "style": {
+      "defaultValue": null,
+      "description": "",
+      "name": "style",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "labelProps": {
-        "defaultValue": null,
-        "description": "",
-        "name": "labelProps",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "DOMAttributes<Element> | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "CSSProperties | undefined"
+      }
+    },
+    "prepend": {
+      "defaultValue": null,
+      "description": "Tekst eller ikon som vises foran skjema-elementet",
+      "name": "prepend",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "fieldProps": {
-        "defaultValue": null,
-        "description": "",
-        "name": "fieldProps",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "DateFieldProps<DateType> | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "append": {
+      "defaultValue": null,
+      "description": "Tekst eller ikon som vises etter skjema-elementet",
+      "name": "append",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "dateFieldRef": {
-        "defaultValue": null,
-        "description": "",
-        "name": "dateFieldRef",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "Ref<HTMLDivElement> | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "labelTooltipButtonAriaLabel": {
+      "defaultValue": null,
+      "description": "Forklarende tekst for knappen som åpner labelTooltip",
+      "name": "labelTooltipButtonAriaLabel",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "disabled": {
-        "defaultValue": null,
-        "description": "",
-        "name": "disabled",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "boolean | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "labelTooltipPlacement": {
+      "defaultValue": null,
+      "description": "",
+      "name": "labelTooltipPlacement",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "readOnly": {
-        "defaultValue": null,
-        "description": "",
-        "name": "readOnly",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "boolean | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "Placement | undefined"
+      }
+    },
+    "required": {
+      "defaultValue": null,
+      "description": "Illustrerer om inputfeltet er påkrevd eller ikke",
+      "name": "required",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "className": {
-        "defaultValue": null,
-        "description": "Ekstra klassenavn",
-        "name": "className",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "labelId": {
+      "defaultValue": null,
+      "description": "ID som settes på labelen til inputfeltet",
+      "name": "labelId",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "style": {
-        "defaultValue": null,
-        "description": "",
-        "name": "style",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "CSSProperties | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "disableLabelAnimation": {
+      "defaultValue": null,
+      "description": "Plasserer labelen statisk på toppen av inputfeltet",
+      "name": "disableLabelAnimation",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "prepend": {
-        "defaultValue": null,
-        "description": "Tekst eller ikon som vises foran skjema-elementet",
-        "name": "prepend",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "ReactNode"
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "ariaAlertOnFeedback": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "append": {
-        "defaultValue": null,
-        "description": "Tekst eller ikon som vises etter skjema-elementet",
-        "name": "append",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "ReactNode"
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "after": {
+      "defaultValue": null,
+      "description": "Legg til et element etter feltet",
+      "name": "after",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "labelTooltipButtonAriaLabel": {
-        "defaultValue": null,
-        "description": "Forklarende tekst for knappen som åpner labelTooltip",
-        "name": "labelTooltipButtonAriaLabel",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "before": {
+      "defaultValue": null,
+      "description": "Legg til et element før feltet",
+      "name": "before",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "labelTooltipPlacement": {
-        "defaultValue": null,
-        "description": "",
-        "name": "labelTooltipPlacement",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "Placement | undefined"
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "ariaLabelOnReadOnly": {
+      "defaultValue": null,
+      "description": "Aria-label som brukes når inputfeltet er i read-only modus",
+      "name": "ariaLabelOnReadOnly",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
         }
-      },
-      "required": {
-        "defaultValue": null,
-        "description": "Illustrerer om inputfeltet er påkrevd eller ikke",
-        "name": "required",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "boolean | undefined"
-        }
-      },
-      "labelId": {
-        "defaultValue": null,
-        "description": "ID som settes på labelen til inputfeltet",
-        "name": "labelId",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
-        }
-      },
-      "disableLabelAnimation": {
-        "defaultValue": null,
-        "description": "Plasserer labelen statisk på toppen av inputfeltet",
-        "name": "disableLabelAnimation",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "boolean | undefined"
-        }
-      },
-      "ariaAlertOnFeedback": {
-        "defaultValue": null,
-        "description": "",
-        "name": "ariaAlertOnFeedback",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "boolean | undefined"
-        }
-      },
-      "after": {
-        "defaultValue": null,
-        "description": "Legg til et element etter feltet",
-        "name": "after",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "ReactNode"
-        }
-      },
-      "before": {
-        "defaultValue": null,
-        "description": "Legg til et element før feltet",
-        "name": "before",
-        "declarations": [
-          {
-            "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "ReactNode"
-        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
       }
     }
   }
-]
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FilterChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FilterChip.json
@@ -1,80 +1,78 @@
-[
-  {
-    "tags": {},
-    "description": "",
-    "displayName": "FilterChip",
-    "methods": [],
-    "props": {
-      "className": {
-        "defaultValue": null,
-        "description": "Ekstra klassenavn",
-        "name": "className",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/FilterChip.tsx",
-            "name": "TypeLiteral"
-          },
-          {
-            "fileName": "design-system/node_modules/@types/react/index.d.ts",
-            "name": "HTMLAttributes"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
-        }
-      },
-      "children": {
-        "defaultValue": null,
-        "description": "Label til FilterChip",
-        "name": "children",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/FilterChip.tsx",
-            "name": "TypeLiteral"
-          },
-          {
-            "fileName": "design-system/node_modules/@types/react/index.d.ts",
-            "name": "DOMAttributes"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "ReactNode"
-        }
-      },
-      "value": {
-        "defaultValue": null,
-        "description": "Verdien til FilterChip",
-        "name": "value",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/FilterChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": true,
-        "type": {
-          "name": "string"
-        }
-      },
-      "size": {
-        "defaultValue": {
-          "value": "medium"
+{
+  "tags": {},
+  "description": "",
+  "displayName": "FilterChip",
+  "methods": [],
+  "props": {
+    "className": {
+      "defaultValue": null,
+      "description": "Ekstra klassenavn",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/FilterChip.tsx",
+          "name": "TypeLiteral"
         },
-        "description": "Størrelsen på chip",
-        "name": "size",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/FilterChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "\"small\" | \"medium\" | undefined"
+        {
+          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "name": "HTMLAttributes"
         }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "children": {
+      "defaultValue": null,
+      "description": "Label til FilterChip",
+      "name": "children",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/FilterChip.tsx",
+          "name": "TypeLiteral"
+        },
+        {
+          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "name": "DOMAttributes"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "value": {
+      "defaultValue": null,
+      "description": "Verdien til FilterChip",
+      "name": "value",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/FilterChip.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "string"
+      }
+    },
+    "size": {
+      "defaultValue": {
+        "value": "medium"
+      },
+      "description": "Størrelsen på chip",
+      "name": "size",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/FilterChip.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "\"small\" | \"medium\" | undefined"
       }
     }
   }
-]
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TagChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TagChip.json
@@ -1,87 +1,85 @@
-[
-  {
-    "tags": {},
-    "description": "",
-    "displayName": "TagChip",
-    "methods": [],
-    "props": {
-      "children": {
-        "defaultValue": null,
-        "description": "Teksten som vises i TagChip",
-        "name": "children",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/TagChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": true,
-        "type": {
-          "name": "ReactNode"
+{
+  "tags": {},
+  "description": "",
+  "displayName": "TagChip",
+  "methods": [],
+  "props": {
+    "children": {
+      "defaultValue": null,
+      "description": "Teksten som vises i TagChip",
+      "name": "children",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "name": "TypeLiteral"
         }
+      ],
+      "required": true,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "className": {
+      "defaultValue": null,
+      "description": "Ekstra klassenavn",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "onClose": {
+      "defaultValue": null,
+      "description": "Callback for når man klikker på krysset",
+      "name": "onClose",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "() => void"
+      }
+    },
+    "closeButtonAriaLabel": {
+      "defaultValue": null,
+      "description": "Skjermlesertekst for X-knappen",
+      "name": "closeButtonAriaLabel",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "size": {
+      "defaultValue": {
+        "value": "medium"
       },
-      "className": {
-        "defaultValue": null,
-        "description": "Ekstra klassenavn",
-        "name": "className",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/TagChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
+      "description": "Størrelsen på chip",
+      "name": "size",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "name": "TypeLiteral"
         }
-      },
-      "onClose": {
-        "defaultValue": null,
-        "description": "Callback for når man klikker på krysset",
-        "name": "onClose",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/TagChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": true,
-        "type": {
-          "name": "() => void"
-        }
-      },
-      "closeButtonAriaLabel": {
-        "defaultValue": null,
-        "description": "Skjermlesertekst for X-knappen",
-        "name": "closeButtonAriaLabel",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/TagChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "string | undefined"
-        }
-      },
-      "size": {
-        "defaultValue": {
-          "value": "medium"
-        },
-        "description": "Størrelsen på chip",
-        "name": "size",
-        "declarations": [
-          {
-            "fileName": "design-system/packages/chip/src/TagChip.tsx",
-            "name": "TypeLiteral"
-          }
-        ],
-        "required": false,
-        "type": {
-          "name": "\"small\" | \"medium\" | undefined"
-        }
+      ],
+      "required": false,
+      "type": {
+        "name": "\"small\" | \"medium\" | undefined"
       }
     }
   }
-]
+}

--- a/packages/datepicker/src/DatePicker/Calendar.tsx
+++ b/packages/datepicker/src/DatePicker/Calendar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import classNames from 'classnames';
 import { I18nProvider, useLocale } from '@react-aria/i18n';
@@ -81,6 +81,8 @@ type BaseCalendarProps<DateType extends DateValue> = {
    *  @example (date) => isWeekend(date, 'no-NO') ? 'helgedag' : ''
    */
   ariaLabelForDate?: (date: CalendarDate) => string;
+  /** Callback-funksjon for når valideringen til datovelgeren endrer seg */
+  onValidate?: (isValid?: boolean) => void;
   disabled?: boolean;
   locale?: string;
   calendarRef?: React.MutableRefObject<HTMLDivElement | null>;
@@ -146,6 +148,11 @@ const CalendarBase = <DateType extends DateValue>({
   const state = useCalendarState(_props);
   const { calendarProps, prevButtonProps, nextButtonProps, title } =
     useCalendar(_props, state);
+
+  useEffect(
+    () => rest.onValidate?.(!state.isValueInvalid),
+    [state.isValueInvalid],
+  );
 
   return (
     <div

--- a/packages/datepicker/src/DatePicker/DateField.tsx
+++ b/packages/datepicker/src/DatePicker/DateField.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from 'react';
+import React, { ReactNode, useEffect, useRef } from 'react';
 
 import {
   DateFieldStateOptions,
@@ -125,6 +125,8 @@ export type BaseDateFieldProps<DateType extends DateValue> = {
    * @default "negative"
    */
   validationVariant?: VariantType | typeof error | typeof info;
+  /** Callback-funksjon for når valideringen til datovelgeren endrer seg */
+  onValidate?: (isValid?: boolean) => void;
   labelTooltip?: React.ReactNode;
   labelProps?: React.DOMAttributes<Element>;
   fieldProps?: DateFieldProps<DateType>;
@@ -163,6 +165,7 @@ export const DateField = <DateType extends DateValue>({
   labelProps: parentLabelProps,
   append,
   prepend,
+  onValidate,
   dateFieldRef: ref,
   ...rest
 }: DateFieldProps<DateType>) => {
@@ -199,6 +202,8 @@ export const DateField = <DateType extends DateValue>({
 
   const dateFieldRef = useRef(null);
   const { labelProps, fieldProps } = useDateField(_props, state, dateFieldRef);
+
+  useEffect(() => onValidate?.(!state.isInvalid), [state.isInvalid]);
 
   const id = useRandomId('datefield');
 

--- a/packages/datepicker/src/tests/Datepicker.test.tsx
+++ b/packages/datepicker/src/tests/Datepicker.test.tsx
@@ -658,6 +658,26 @@ test.each([
   },
 );
 
+test('onValidate fires on invalid date', async () => {
+  const spy = jest.fn();
+  const currentDate = new CalendarDate(1997, 7, 10);
+  const minValidDate = new CalendarDate(1997, 7, 11);
+
+  render(
+    <DatePicker
+      label="test"
+      selectedDate={currentDate}
+      onChange={() => undefined}
+      minDate={minValidDate}
+      onValidate={spy}
+      locale="en-GB"
+    />,
+  );
+
+  const emittedValidationState = spy.mock.calls[0][0];
+  expect(emittedValidationState).toBeFalsy();
+}, 10000);
+
 test('Timezones should always be UTC', () => {
   expect(new Date().getTimezoneOffset()).toBe(0);
 });


### PR DESCRIPTION
Legger til en callback prop for å gjøre det mulig å lese av valideringsstatusen til datovelgeren. Dette er nyttig i situasjoner der andre deler av grensesnittet trenger å vite om datoen du har gitt inn er gyldig; uten en slik prop må det da valideres både i datovelgeren _og_ i den komponenten det skal sjekkes, noe som er litt unødvendig. 