### PR TITLE
Fix incorrect focus when clicking below datefield, datepicker or timepicker

### DIFF
--- a/packages/datepicker/src/DatePicker/DateField.scss
+++ b/packages/datepicker/src/DatePicker/DateField.scss
@@ -2,8 +2,10 @@
 
 .eds-datefield {
   width: fit-content;
+  display: block;
 
   .eds-form-control-wrapper {
+    display: inline-flex;
     padding-inline: 1rem;
     width: fit-content;
 

--- a/packages/datepicker/src/TimePicker/TimePicker.scss
+++ b/packages/datepicker/src/TimePicker/TimePicker.scss
@@ -3,6 +3,7 @@
 .eds-timepicker {
   width: fit-content;
   justify-content: center;
+  display: block;
 
   &--disabled {
     padding-inline: t.$space-medium;
@@ -18,6 +19,7 @@
     }
     &-wrapper {
       padding: 0rem;
+      display: inline-flex;
     }
   }
 


### PR DESCRIPTION
Implemented using this fix: https://github.com/adobe/react-spectrum/issues/3164#issuecomment-1521501331