### PR TITLE
Etu 60876 add previous and next month dates to date picker

### DIFF
--- a/apps/documentation/src/pages/komponenter/skjemaelementer/datepicker.mdx
+++ b/apps/documentation/src/pages/komponenter/skjemaelementer/datepicker.mdx
@@ -332,7 +332,7 @@ Både `DatePicker` og `Calendar` har støtte for prop-en `classNameForDate`. `cl
 
 Hvis stylingen som legges til er meningsbærende bør du også bruke `ariaLabelForDate` til å beskrive stylingens mening for skjermlesere o.l.
 
-<Playground hideContrastOption  scope={now}
+<Playground hideContrastOption
 code={`() => {
     const [date, setDate] = React.useState(now('Europe/Oslo'));
     return (
@@ -347,6 +347,25 @@ code={`() => {
     );
   }`}
 scope={{now , isWeekend}} />
+
+#### Vise datoer utenfor måneden
+
+Hvis du ønsker å vise og gjøre det mulig å velge datoer fra forrige og neste måned i kalenderen, kan du bruke prop-en `showOutsideMonth`. Støttes i både `DatePicker` og `Calendar`.
+
+<Playground hideContrastOption
+code={`() => {
+    const [date, setDate] = React.useState(now('Europe/Oslo'));
+    return (
+      <Calendar
+        label="Dato"
+        selectedDate={date}
+        onChange={date => setDate(date)}
+        locale="nb-NO"
+        showOutsideMonth
+      />
+    );
+  }`}
+scope={{now}} />
 
 #### Vise ukenummer
 

--- a/packages/datepicker/src/DatePicker/Calendar.scss
+++ b/packages/datepicker/src/DatePicker/Calendar.scss
@@ -6,7 +6,7 @@
   padding: t.$space-large;
   padding-top: t.$space-small;
   background-color: var(--components-datepicker-calendar-background);
-  color: var(--components-datepicker-calendar-text-subdued);
+  color: var(--components-datepicker-calendar-text-accent);
   border-radius: 4px;
   box-shadow: t.$shadows-box-shadow;
 
@@ -73,6 +73,10 @@
         padding: 0;
         border: 1px solid var(--components-datepicker-calendar-dateborder);
 
+        &:has(.eds-datepicker__calendar__grid__cell--outside-month--visible) {
+          border-style: dashed;
+        }
+
         &:focus-within {
           z-index: 2;
         }
@@ -124,6 +128,31 @@
           background-color: transparent;
           color: transparent;
           cursor: default;
+        }
+
+        &--visible {
+          background-color: var(--components-datepicker-calendar-background-overflow);
+          color: var(--components-datepicker-calendar-text-subdued);
+          opacity: 1;
+
+          &:hover {
+            background-color: var(--components-datepicker-calendar-datefill-hover);
+            color: var(--components-datepicker-calendar-text-accent);
+            opacity: 0.8;
+            cursor: default;
+          }
+
+          &:active {
+            background-color: var(--components-datepicker-calendar-datefill-selected);
+            color: var(--components-datepicker-calendar-text-accent);
+            opacity: 1;
+          }
+
+          &:focus-visible {
+            outline: t.$outlines-focus;
+            outline-color: var(--basecolors-stroke-focus-standard);
+            outline-offset: t.$outline-offsets-focus;
+          }
         }
       }
 

--- a/packages/datepicker/src/DatePicker/Calendar.tsx
+++ b/packages/datepicker/src/DatePicker/Calendar.tsx
@@ -16,6 +16,7 @@ import {
   ariaLabelIfNorwegian,
   createCalendar,
   handleOnChange,
+  getAdjustedMaxDate,
 } from '../shared/utils';
 import { CalendarButton } from '../shared/CalendarButton';
 import { CalendarGrid } from './CalendarGrid';
@@ -147,7 +148,7 @@ const CalendarBase = <DateType extends DateValue>({
     locale,
     createCalendar,
     minValue: minDate,
-    maxValue: maxDate,
+    maxValue: getAdjustedMaxDate(maxDate),
   };
 
   const state = useCalendarState(_props);

--- a/packages/datepicker/src/DatePicker/Calendar.tsx
+++ b/packages/datepicker/src/DatePicker/Calendar.tsx
@@ -66,6 +66,10 @@ type BaseCalendarProps<DateType extends DateValue> = {
   /** Overskrift som vises for ukenummer-kolonnen. Vises kun hvis 'showWeekNumbers' er true.
    * @default 'uke' */
   weekNumberHeader?: string;
+  /** Vis datoer som ligger utenfor den viste måneden.
+   * @example Hvis uken starter på onsdag vises de to siste datoene i forrige måned i ruten til mandagen og tirsdagen før.
+   * @default false */
+  showOutsideMonth?: boolean;
   /** Brukes for å legge til klassenavn på spesifikke datoer i kalenderen.
    *  Tar inn en dato og skal returnere klassenavnet som skal legges til den datoen.
    *  @default undefined
@@ -112,6 +116,7 @@ const CalendarBase = <DateType extends DateValue>({
   maxDate,
   showWeekNumbers = false,
   weekNumberHeader = 'uke',
+  showOutsideMonth = false,
   forcedReturnType,
   style,
   className,
@@ -194,6 +199,7 @@ const CalendarBase = <DateType extends DateValue>({
         ariaLabelForDate={ariaLabelForDate}
         showWeekNumbers={showWeekNumbers}
         weekNumberHeader={weekNumberHeader}
+        showOutsideMonth={showOutsideMonth}
       />
     </div>
   );

--- a/packages/datepicker/src/DatePicker/CalendarCell.tsx
+++ b/packages/datepicker/src/DatePicker/CalendarCell.tsx
@@ -14,6 +14,7 @@ type CalendarCellProps = {
   state: CalendarState;
   date: CalendarDate;
   weekNumberString: string;
+  showOutsideMonth?: boolean;
   onSelectedCellClick?: () => void;
   onCellClick?: () => void;
   classNameForDate?: (date: CalendarDate) => string;
@@ -23,6 +24,7 @@ type CalendarCellProps = {
 export const CalendarCell = ({
   state,
   date,
+  showOutsideMonth = false,
   onSelectedCellClick = () => {
     return;
   },
@@ -50,27 +52,47 @@ export const CalendarCell = ({
     ariaLabelForDate?.(date) ?? ''
   }`;
 
-  const cellCanBeSelected = !(
-    isOutsideVisibleRange ||
-    isDisabled ||
-    isUnavailable
-  );
+  const cellCanBeSelected = showOutsideMonth
+    ? !(isDisabled || isUnavailable)
+    : !(isOutsideVisibleRange || isDisabled || isUnavailable);
+
+  const shouldHideDate = !showOutsideMonth && isOutsideVisibleRange;
+
+  // Override button props when showOutsideMonth is true and date is outside visible range
+  const extendedButtonProps = {
+    ...buttonProps,
+    ...(showOutsideMonth &&
+      isOutsideVisibleRange && {
+        onClick: () => {
+          state.selectDate(date);
+          onCellClick();
+        },
+        onKeyUp: (e: React.KeyboardEvent) => {
+          if (e.key === 'Enter') {
+            state.selectDate(date);
+            onCellClick();
+          }
+        },
+      }),
+  };
 
   return (
     <td {...cellProps} className="eds-datepicker__calendar__grid__cell__td">
       <div
-        {...buttonProps}
+        {...extendedButtonProps}
         aria-label={ariaLabel}
-        aria-hidden={isOutsideVisibleRange}
+        aria-hidden={shouldHideDate}
         ref={cellRef}
-        hidden={isOutsideVisibleRange}
+        hidden={shouldHideDate}
         className={classNames('eds-datepicker__calendar__grid__cell', {
-          [classNameForDate?.(date) ?? '']: !isOutsideVisibleRange,
+          [classNameForDate?.(date) ?? '']: !shouldHideDate,
           'eds-datepicker__calendar__grid__cell--selected': isSelected,
           'eds-datepicker__calendar__grid__cell--disabled':
             isDisabled || isUnavailable,
           'eds-datepicker__calendar__grid__cell--outside-month':
-            isOutsideVisibleRange,
+            isOutsideVisibleRange && !showOutsideMonth,
+          'eds-datepicker__calendar__grid__cell--outside-month--visible':
+            isOutsideVisibleRange && showOutsideMonth,
           'eds-datepicker__calendar__grid__cell--today': isEqualDay(
             date,
             now(state.timeZone ?? getLocalTimeZone()),
@@ -78,13 +100,13 @@ export const CalendarCell = ({
         })}
         {...rest}
         onClick={e => {
-          buttonProps.onClick && buttonProps.onClick(e);
+          extendedButtonProps?.onClick?.(e);
           // Used to force close calendar on select
           isSelected && onSelectedCellClick();
           cellCanBeSelected && onCellClick();
         }}
         onKeyUp={e => {
-          buttonProps.onKeyUp && buttonProps.onKeyUp(e);
+          extendedButtonProps?.onKeyUp?.(e);
           if (e.key === 'Enter') {
             // Used to force close calendar on select
             isSelected && onSelectedCellClick();

--- a/packages/datepicker/src/DatePicker/CalendarGrid.tsx
+++ b/packages/datepicker/src/DatePicker/CalendarGrid.tsx
@@ -16,6 +16,7 @@ type CalendarGridProps = {
   navigationDescription?: string;
   showWeekNumbers: boolean;
   weekNumberHeader: string;
+  showOutsideMonth?: boolean;
   onSelectedCellClick?: () => void;
   onCellClick?: () => void;
   classNameForDate?: (date: CalendarDate) => string;
@@ -33,6 +34,7 @@ export const CalendarGrid = ({
   },
   showWeekNumbers,
   weekNumberHeader,
+  showOutsideMonth = false,
   classNameForDate,
   ariaLabelForDate,
   ...rest
@@ -92,7 +94,7 @@ export const CalendarGrid = ({
               <tr key={weekIndex}>
                 {showWeekNumbers && (
                   <th
-                    aria-hidden
+                    aria-label={`${weekNumberHeader} ${weekNumber}`}
                     className="eds-datepicker__calendar__grid__weeknumber"
                   >
                     {weekNumber}
@@ -116,6 +118,7 @@ export const CalendarGrid = ({
                         onCellClick={onCellClick}
                         classNameForDate={classNameForDate}
                         ariaLabelForDate={ariaLabelForDate}
+                        showOutsideMonth={showOutsideMonth}
                       />
                     ) : (
                       <td key={i} />

--- a/packages/datepicker/src/DatePicker/DateField.tsx
+++ b/packages/datepicker/src/DatePicker/DateField.tsx
@@ -28,7 +28,7 @@ import {
   createCalendar,
   ForcedReturnType,
   handleOnChange,
-  lastMillisecondOfDay,
+  getAdjustedMaxDate,
 } from '../shared/utils';
 
 import './DateField.scss';
@@ -187,13 +187,7 @@ export const DateField = <DateType extends DateValue>({
     hideTimeZone: !showTimeZone,
     granularity,
     minValue: minDate,
-    // this weird logic makes sure the entire day is included if no time is provided in maxDate
-    maxValue:
-      'hour' in (maxDate ?? {})
-        ? maxDate
-        : maxDate !== undefined
-        ? lastMillisecondOfDay(maxDate)
-        : undefined,
+    maxValue: getAdjustedMaxDate(maxDate),
     isDisabled: isDisabled || disabled || readOnly,
     shouldForceLeadingZeros: true,
   };

--- a/packages/datepicker/src/DatePicker/DatePicker.tsx
+++ b/packages/datepicker/src/DatePicker/DatePicker.tsx
@@ -47,6 +47,10 @@ type BaseDatePickerProps = {
   /** Overskrift som vises for ukenummer-kolonnen. Vises kun hvis 'showWeekNumbers' er true.
    * @default '#' */
   weekNumberHeader?: string;
+  /** Vis datoer som ligger utenfor den viste måneden.
+   * @example Hvis uken starter på onsdag vises de to siste datoene i forrige måned i ruten til mandagen og tirsdagen før.
+   * @default false */
+  showOutsideMonth?: boolean;
   /** Hvis true vil kalenderen alltid vises i en popover når den åpnes
    *  @default false
    */
@@ -103,6 +107,7 @@ export const DatePicker = <DateType extends DateValue>({
   validationFeedback,
   showWeekNumbers,
   weekNumberHeader,
+  showOutsideMonth = false,
   disableModal = false,
   labelTooltip,
   navigationDescription,
@@ -189,6 +194,7 @@ export const DatePicker = <DateType extends DateValue>({
     ariaLabelForDate,
     showWeekNumbers,
     weekNumberHeader,
+    showOutsideMonth,
   };
 
   const isModal =

--- a/packages/datepicker/src/DatePicker/DatePicker.tsx
+++ b/packages/datepicker/src/DatePicker/DatePicker.tsx
@@ -35,7 +35,7 @@ import {
 } from './DateField';
 import { Calendar, CalendarProps } from './Calendar';
 import { CalendarButton } from '../shared/CalendarButton';
-import { handleOnChange, lastMillisecondOfDay } from '../shared/utils';
+import { getAdjustedMaxDate, handleOnChange } from '../shared/utils';
 
 import './DatePicker.scss';
 
@@ -137,12 +137,7 @@ export const DatePicker = <DateType extends DateValue>({
       }),
     minValue: minDate,
     // this weird logic makes sure the entire day is included if no time is provided in maxDate
-    maxValue:
-      'hour' in (maxDate ?? {})
-        ? maxDate
-        : maxDate !== undefined
-        ? lastMillisecondOfDay(maxDate)
-        : undefined,
+    maxValue: getAdjustedMaxDate(maxDate),
     value: selectedDate,
     granularity,
     isDisabled: disabled || readOnly,

--- a/packages/datepicker/src/shared/utils.ts
+++ b/packages/datepicker/src/shared/utils.ts
@@ -271,3 +271,10 @@ export function handleOnChange<DateType extends DateValue>({
 
   onChange?.(value);
 }
+
+// this weird logic makes sure the entire day is included if no time is provided in maxDate
+export function getAdjustedMaxDate(maxDate?: DateValue) {
+  if ('hour' in (maxDate ?? {})) return maxDate;
+  if (maxDate !== undefined) return lastMillisecondOfDay(maxDate);
+  return undefined;
+}

--- a/packages/datepicker/src/tests/Calendar.test.tsx
+++ b/packages/datepicker/src/tests/Calendar.test.tsx
@@ -299,6 +299,50 @@ describe('Calendar', () => {
     expect(results).toHaveNoViolations();
   });
 
+  test('shows outside month dates when showOutsideMonth is true', () => {
+    const { container } = render(
+      <Calendar {...defaultProps} showOutsideMonth />,
+    );
+
+    const outsideMonthCells = container.querySelectorAll(
+      '.eds-datepicker__calendar__grid__cell--outside-month--visible',
+    );
+    expect(outsideMonthCells.length).toBeGreaterThan(0);
+  });
+
+  test('hides outside month dates when showOutsideMonth is false', () => {
+    const { container } = render(
+      <Calendar {...defaultProps} showOutsideMonth={false} />,
+    );
+
+    const outsideMonthVisibleCells = container.querySelectorAll(
+      '.eds-datepicker__calendar__grid__cell--outside-month--visible',
+    );
+    expect(outsideMonthVisibleCells.length).toBe(0);
+
+    const outsideMonthHiddenCells = container.querySelectorAll(
+      '.eds-datepicker__calendar__grid__cell--outside-month',
+    );
+    expect(outsideMonthHiddenCells.length).toBeGreaterThan(0);
+  });
+
+  test('allows selecting outside month dates when showOutsideMonth is true', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    const { container } = render(
+      <Calendar {...defaultProps} showOutsideMonth onChange={onChange} />,
+    );
+
+    const outsideMonthCell = container.querySelector(
+      '.eds-datepicker__calendar__grid__cell--outside-month--visible',
+    );
+    expect(outsideMonthCell).toBeInTheDocument();
+
+    await user.click(outsideMonthCell!);
+    expect(onChange).toHaveBeenCalled();
+  });
+
   test('Timezones should always be UTC', () => {
     expect(new Date().getTimezoneOffset()).toBe(0);
   });


### PR DESCRIPTION
Legger til en prop som lar brukeren både se og velge datoer utenfor nåværende måned, men innenfor uker med datoer fra nåværende måned. 
Originalt ønske utløst av kundesenter som vil spare tid ved å slippe å bytte måned i kalenderoversikten mer enn nødvendig.

**Todo**
- [x] Finne et design for hvordan datoer utenfor nåværende måned som _er_ valgbare skal se ut (se bildet for nåværende design)

<img width="375" height="340" alt="image" src="https://github.com/user-attachments/assets/20c79fcd-58a3-4cfc-9f64-f11459a51660" />
