### PR TITLE
fix: export types missing from previous release

### DIFF
--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -7,7 +7,6 @@ export const createBaseConfig = (): UserConfig =>
     plugins: [
       dts({
         insertTypesEntry: true,
-        rollupTypes: true,
       }),
     ],
     build: {


### PR DESCRIPTION
Denne PR-en er en midlertidig fiks for å unngå at typer som tidligere var eksponert ikke lenger er det. Alle filer eksporteres nå ut av index-filen og dermed burde alt som eksporteres minst ett sted være tilgjengelig for alle. 

Dette bør erstattes av et strengere eksporteringssystem der vi med mer kontroll velger hva som eksporteres slik at konsumenter ikke begynner å bruke interne typer og funksjonalitet / slik at vi vet hva som vi kan endre på uten å melde breaking change.