### PR TITLE
Add component size for icon buttons

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,10 @@
   "rules": {
     "selector-max-specificity": "0,1,0",
     "selector-max-id": 0,
-    "selector-max-compound-selectors": 1,
-    "selector-no-qualifying-type": [true, { "ignore": ["attribute"] }]
+    "selector-no-qualifying-type": [true, { "ignore": ["attribute"] }],
+    "selector-class-pattern": [
+      "^[a-z0-9]+(?:-[a-z0-9]+)*(?:__(?:[a-z0-9]+(?:-[a-z0-9]+)*))?(?:--(?:[a-z0-9]+(?:-[a-z0-9]+)*))?$",
+      { "resolveNestedSelectors": true }
+    ]
   }
 }

--- a/apps/code-playground/package.json
+++ b/apps/code-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/code-playground",
-  "version": "2.3.10",
+  "version": "2.3.10-beta-automat.0",
   "private": true,
   "license": "EUPL-1.2",
   "scripts": {

--- a/apps/documentation/package.json
+++ b/apps/documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/documentation",
-  "version": "6.13.1",
+  "version": "6.13.1-beta-automat.0",
   "private": true,
   "description": "Documentation for Entur's design system",
   "keywords": [

--- a/apps/studio-linje/package.json
+++ b/apps/studio-linje/package.json
@@ -1,7 +1,7 @@
 {
   "name": "studio-linje",
   "private": true,
-  "version": "1.8.1",
+  "version": "1.8.1-beta-automat.0",
   "main": "package.json",
   "license": "UNLICENSED",
   "scripts": {

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/a11y",
-  "version": "0.2.104",
+  "version": "0.2.104-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/a11y.cjs.js",
   "module": "dist/a11y.esm.js",

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/alert",
-  "version": "0.18.1",
+  "version": "0.18.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/alert.cjs.js",
   "module": "dist/alert.esm.js",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/button",
-  "version": "3.4.1",
+  "version": "3.4.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/button.cjs.js",
   "module": "dist/button.esm.js",

--- a/packages/button/src/Button.scss
+++ b/packages/button/src/Button.scss
@@ -1,16 +1,6 @@
 @use '@entur/tokens/dist/styles.scss' as t;
 @use '@entur/utils/dist/color-utils.scss' as util;
 
-a.eds-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  .eds-icon {
-    position: unset;
-  }
-}
-
 .eds-button {
   min-width: var(--components-button-height-horizontalcontent-medium);
   width: max-content;
@@ -23,7 +13,6 @@ a.eds-button {
   overflow-x: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-
   padding-inline: var(--components-button-inlinepadding-medium);
   font-size: var(--font-size-body-m, var(--size-8));
   line-height: var(--font-line-height-body-m, var(--size-10));
@@ -32,34 +21,38 @@ a.eds-button {
   font-family: inherit;
   position: relative;
   vertical-align: middle;
-
   background-color: var(--eds-button-background);
   border: var(--components-button-border-medium) solid var(--eds-button-border);
   color: var(--eds-button-text);
 
-  &:hover {
+  &:where(:hover) {
     background-color: var(--eds-button-background-hover);
   }
-  &:active {
+
+  &:where(:active) {
     background-color: var(--eds-button-background-active);
     border-color: var(--eds-button-border-active);
     color: var(--eds-button-text-active);
   }
-  &:focus-visible {
+
+  &:where(:focus-visible) {
     outline: t.$outlines-focus;
     outline-color: var(--basecolors-stroke-focus-standard);
     outline-offset: t.$outline-offsets-focus;
-    .eds-contrast & {
+
+    :where(.eds-contrast) & {
       outline-color: var(--basecolors-stroke-focus-contrast);
     }
   }
 
-  > .eds-button__loading-dots {
+  > :where(.eds-button__loading-dots) {
     width: 100%;
-    .eds-loading-dots__dot {
+
+    :where(.eds-loading-dots__dot) {
       background: var(--eds-button-text);
     }
   }
+
   :where(.eds-icon) {
     vertical-align: middle;
     margin-bottom: 0.1em;
@@ -70,11 +63,11 @@ a.eds-button {
       margin-left: var(--components-button-gap-medium);
     }
 
-    &:where(.eds-button--size-small .eds-icon:last-child) {
+    &:where(.eds-button--size-small) :where(.eds-icon:last-child) {
       margin-left: var(--components-button-gap-small);
     }
 
-    &:where(.eds-button--size-large .eds-icon:last-child) {
+    &:where(.eds-button--size-large) :where(.eds-icon:last-child) {
       margin-left: var(--components-button-gap-large);
     }
   }
@@ -84,11 +77,11 @@ a.eds-button {
       margin-right: var(--components-button-gap-medium);
     }
 
-    &:where(.eds-button--size-small .eds-icon:first-child) {
+    &:where(.eds-button--size-small) :where(.eds-icon:first-child) {
       margin-right: var(--components-button-gap-small);
     }
 
-    &:where(.eds-button--size-large .eds-icon:first-child) {
+    &:where(.eds-button--size-large) :where(.eds-icon:first-child) {
       margin-right: var(--components-button-gap-large);
     }
   }
@@ -101,6 +94,7 @@ a.eds-button {
     line-height: var(--font-line-height-body-s, var(--size-9));
     border: var(--components-button-border-small) solid var(--eds-button-border);
   }
+
   &--size-large {
     height: var(--components-button-height-horizontalcontent-large);
     border-radius: var(--components-button-radius-large);
@@ -123,7 +117,7 @@ a.eds-button {
     --eds-button-border: transparent;
     --eds-button-border-active: transparent;
 
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       --eds-button-background: var(--components-button-primary-contrast-default);
       --eds-button-text: var(--components-button-primary-contrast-text);
       --eds-button-text-active: var(--components-button-primary-contrast-text);
@@ -143,7 +137,7 @@ a.eds-button {
     --eds-button-border: var(--components-button-secondary-standard-border);
     --eds-button-border-active: var(--components-button-secondary-standard-border-active);
 
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       --eds-button-background: var(--components-button-secondary-contrast-default);
       --eds-button-text: var(--components-button-secondary-contrast-text);
       --eds-button-text-active: var(--components-button-secondary-contrast-text-active);
@@ -163,7 +157,7 @@ a.eds-button {
     --eds-button-border: var(--components-button-success-standard-border);
     --eds-button-border-active: var(--components-button-success-standard-border);
 
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       --eds-button-background: var(--components-button-success-contrast-default);
       --eds-button-text: var(--components-button-success-contrast-text);
       --eds-button-text-active: var(--components-button-success-contrast-text);
@@ -183,7 +177,7 @@ a.eds-button {
     --eds-button-border: var(--components-button-negative-standard-border);
     --eds-button-border-active: var(--components-button-negative-standard-border);
 
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       --eds-button-background: var(--components-button-negative-contrast-default);
       --eds-button-text: var(--components-button-negative-contrast-text);
       --eds-button-text-active: var(--components-button-negative-contrast-text-active);
@@ -204,50 +198,65 @@ a.eds-button {
     height: 2rem;
     padding: 0 t.$space-small;
     min-width: 6rem;
-    &:hover {
+
+    &:where(:hover) {
       background-color: util.tint(t.$colors-brand-lavender, 40%);
     }
-    &:active {
+
+    &:where(:active) {
       background-color: t.$colors-brand-lavender;
     }
 
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       background-color: transparent;
       color: t.$colors-brand-white;
       border-color: t.$colors-brand-lavender;
 
-      > .eds-button__loading-dots .eds-loading-dots__dot {
+      > :where(.eds-button__loading-dots) :where(.eds-loading-dots__dot) {
         background: t.$colors-brand-white;
       }
-      &:hover {
+
+      &:where(:hover) {
         background-color: rgba(t.$colors-brand-lavender, 0.2);
       }
-      &:active {
+
+      &:where(:active) {
         background: t.$colors-brand-lavender;
         color: t.$colors-brand-blue;
-        > .eds-button__loading-dots .eds-loading-dots__dot {
+
+        > :where(.eds-button__loading-dots) :where(.eds-loading-dots__dot) {
           background: t.$colors-brand-blue;
         }
       }
     }
   }
 
-  &[disabled] {
-    &.eds-button--loading {
+  &:where([disabled]) {
+    &:where(.eds-button--loading) {
       pointer-events: none;
     }
   }
 
-  &[disabled]:not(.eds-button--loading) {
+  &:where([disabled]):where(:not(.eds-button--loading)) {
     background: var(--components-button-disabled-standard-fill);
     color: var(--components-button-disabled-standard-text-disabled);
     border-color: transparent;
     cursor: not-allowed;
 
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       background-color: var(--components-button-disabled-contrast-fill);
       color: var(--components-button-disabled-contrast-text-disabled);
       border-color: transparent;
+    }
+  }
+
+  &:where(a) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    :where(.eds-icon) {
+      position: unset;
     }
   }
 }

--- a/packages/button/src/Button.scss
+++ b/packages/button/src/Button.scss
@@ -12,7 +12,7 @@ a.eds-button {
 }
 
 .eds-button {
-  min-width: var(--size-30);
+  min-width: var(--components-button-height-horizontalcontent-medium);
   width: max-content;
   height: var(--components-button-height-horizontalcontent-medium);
   border-radius: var(--components-button-radius-medium);
@@ -93,7 +93,6 @@ a.eds-button {
     }
   }
 
-  // Size
   &--size-small {
     height: var(--components-button-height-horizontalcontent-small);
     border-radius: var(--components-button-radius-small);
@@ -115,7 +114,6 @@ a.eds-button {
     width: 100%;
   }
 
-  //Variant
   &--variant-primary {
     --eds-button-background: var(--components-button-primary-standard-default);
     --eds-button-text: var(--components-button-primary-standard-text);

--- a/packages/button/src/Button.scss
+++ b/packages/button/src/Button.scss
@@ -12,27 +12,26 @@ a.eds-button {
 }
 
 .eds-button {
-  min-width: 9.5rem;
+  min-width: var(--size-30);
   width: max-content;
-  min-height: t.$space-extra-large3;
-  height: fit-content;
-  border-radius: t.$border-radiuses-medium;
-  font-size: inherit;
+  height: var(--components-button-height-horizontalcontent-medium);
+  border-radius: var(--components-button-radius-medium);
   cursor: pointer;
   display: inline-block;
   appearance: none;
   text-decoration: none;
-  padding: 0 t.$space-default;
-  font-size: t.$font-sizes-large;
-  line-height: t.$line-heights-extra-large;
-  font-weight: t.$font-weights-body;
+
+  padding-inline: var(--components-button-inlinepadding-medium);
+  font-size: var(--font-size-body-m);
+  line-height: var(--font-line-height-body-m);
+  font-weight: var(--font-weight-body);
   text-align: center;
   font-family: inherit;
   position: relative;
-  vertical-align: top;
+  vertical-align: middle;
 
   background-color: var(--eds-button-background);
-  border: t.$border-widths-default solid var(--eds-button-border);
+  border: var(--components-button-border-medium) solid var(--eds-button-border);
   color: var(--eds-button-text);
 
   &:hover {
@@ -58,28 +57,55 @@ a.eds-button {
       background: var(--eds-button-text);
     }
   }
-  .eds-icon {
-    position: relative;
-    top: 0.2em;
+  :where(.eds-icon) {
+    vertical-align: middle;
+    margin-bottom: 0.1em;
   }
 
-  &--leading-icon .eds-icon {
-    margin-right: t.$space-small;
+  &--trailing-icon {
+    :where(.eds-icon:last-child) {
+      margin-left: var(--components-button-gap-medium);
+    }
+
+    &:where(.eds-button--size-small .eds-icon:last-child) {
+      margin-left: var(--components-button-gap-small);
+    }
+
+    &:where(.eds-button--size-large .eds-icon:last-child) {
+      margin-left: var(--components-button-gap-large);
+    }
   }
-  &--trailing-icon .eds-icon {
-    margin-left: t.$space-small;
+
+  &--leading-icon {
+    :where(.eds-icon:first-child) {
+      margin-right: var(--components-button-gap-medium);
+    }
+
+    &:where(.eds-button--size-small .eds-icon:first-child) {
+      margin-right: var(--components-button-gap-small);
+    }
+
+    &:where(.eds-button--size-large .eds-icon:first-child) {
+      margin-right: var(--components-button-gap-large);
+    }
   }
 
   // Size
   &--size-small {
-    min-width: 5.75rem;
-    min-height: 2rem;
-    font-size: t.$font-sizes-medium;
-    line-height: t.$line-heights-large;
+    height: var(--components-button-height-horizontalcontent-small);
+    border-radius: var(--components-button-radius-small);
+    padding-inline: var(--components-button-inlinepadding-small);
+    font-size: var(--font-size-body-s);
+    line-height: var(--font-line-height-body-s);
+    border: var(--components-button-border-small) solid var(--eds-button-border);
   }
   &--size-large {
-    min-width: 11.75rem;
-    min-height: 3.75rem;
+    height: var(--components-button-height-horizontalcontent-large);
+    border-radius: var(--components-button-radius-large);
+    padding-inline: var(--components-button-inlinepadding-large);
+    font-size: var(--font-size-body-xl);
+    line-height: var(--font-line-height-body-xl);
+    border: var(--components-button-border-large) solid var(--eds-button-border);
   }
 
   &--width-fluid {
@@ -184,12 +210,6 @@ a.eds-button {
       background-color: t.$colors-brand-lavender;
     }
 
-    &.eds-button--leading-icon .eds-icon {
-      margin-right: t.$space-extra-small;
-    }
-    &.eds-button--trailing-icon .eds-icon {
-      margin-left: t.$space-extra-small;
-    }
     .eds-contrast & {
       background-color: transparent;
       color: t.$colors-brand-white;

--- a/packages/button/src/Button.scss
+++ b/packages/button/src/Button.scss
@@ -25,9 +25,9 @@ a.eds-button {
   white-space: nowrap;
 
   padding-inline: var(--components-button-inlinepadding-medium);
-  font-size: var(--font-size-body-m);
-  line-height: var(--font-line-height-body-m);
-  font-weight: var(--font-weight-body);
+  font-size: var(--font-size-body-m, var(--size-8));
+  line-height: var(--font-line-height-body-m, var(--size-10));
+  font-weight: var(--font-weight-body, 500);
   text-align: center;
   font-family: inherit;
   position: relative;
@@ -97,16 +97,16 @@ a.eds-button {
     height: var(--components-button-height-horizontalcontent-small);
     border-radius: var(--components-button-radius-small);
     padding-inline: var(--components-button-inlinepadding-small);
-    font-size: var(--font-size-body-s);
-    line-height: var(--font-line-height-body-s);
+    font-size: var(--font-size-body-s, var(--size-7));
+    line-height: var(--font-line-height-body-s, var(--size-9));
     border: var(--components-button-border-small) solid var(--eds-button-border);
   }
   &--size-large {
     height: var(--components-button-height-horizontalcontent-large);
     border-radius: var(--components-button-radius-large);
     padding-inline: var(--components-button-inlinepadding-large);
-    font-size: var(--font-size-body-xl);
-    line-height: var(--font-line-height-body-xl);
+    font-size: var(--font-size-body-xl, var(--size-10));
+    line-height: var(--font-line-height-body-xl, var(--size-12));
     border: var(--components-button-border-large) solid var(--eds-button-border);
   }
 

--- a/packages/button/src/Button.scss
+++ b/packages/button/src/Button.scss
@@ -20,6 +20,9 @@ a.eds-button {
   display: inline-block;
   appearance: none;
   text-decoration: none;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   padding-inline: var(--components-button-inlinepadding-medium);
   font-size: var(--font-size-body-m);

--- a/packages/button/src/IconButton.scss
+++ b/packages/button/src/IconButton.scss
@@ -1,27 +1,27 @@
 @use '@entur/tokens/dist/styles.scss' as t;
 
 .eds-icon-button {
-  border: t.$border-widths-default solid transparent;
-  border-radius: t.$border-radiuses-medium;
+  align-items: center;
   background: none;
+  border-radius: var(--components-button-radius-medium);
+  border: var(--components-button-border-medium) solid transparent;
   color: var(--components-button-iconbutton-standard-text);
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
+  font-size: var(--font-size-body-m);
+  font-weight: var(--font-weight-body);
+  gap: var(--components-button-gap-medium);
+  height: var(--components-button-height-horizontalcontent-medium);
   justify-content: center;
-  align-items: center;
-  font-size: t.$font-sizes-large;
-  padding: t.$space-extra-small;
+  line-height: var(--font-line-height-body-m);
+  padding-inline: var(--components-button-inlinepadding-medium);
+
   .eds-contrast & {
     color: var(--components-button-iconbutton-contrast-text);
 
     > .eds-loading-dots .eds-loading-dots__dot {
       background-color: var(--components-button-iconbutton-contrast-icon);
     }
-  }
-  &--size-small {
-    height: 1.5rem;
-    width: 1.5rem;
-    padding: 0;
   }
   &:hover {
     background-color: var(--components-button-iconbutton-standard-hover);
@@ -53,5 +53,23 @@
       cursor: not-allowed;
       width: fit-content;
     }
+  }
+
+  // Size
+  &--size-small {
+    border-radius: var(--components-button-radius-small);
+    border: var(--components-button-border-small) solid var(--eds-button-border);
+    font-size: var(--font-size-body-s);
+    height: var(--components-button-height-horizontalcontent-small);
+    line-height: var(--font-line-height-body-s);
+    padding-inline: var(--components-button-inlinepadding-small);
+  }
+  &--size-large {
+    border-radius: var(--components-button-radius-large);
+    border: var(--components-button-border-large) solid var(--eds-button-border);
+    font-size: var(--font-size-body-xl);
+    height: var(--components-button-height-horizontalcontent-large);
+    line-height: var(--font-line-height-body-xl);
+    padding-inline: var(--components-button-inlinepadding-large);
   }
 }

--- a/packages/button/src/IconButton.scss
+++ b/packages/button/src/IconButton.scss
@@ -16,32 +16,32 @@
   line-height: var(--font-line-height-body-m);
   padding-inline: var(--components-button-inlinepadding-medium);
 
-  .eds-contrast & {
+  :where(.eds-contrast) & {
     color: var(--components-button-iconbutton-contrast-text);
 
-    > .eds-loading-dots .eds-loading-dots__dot {
+    > :where(.eds-loading-dots) :where(.eds-loading-dots__dot) {
       background-color: var(--components-button-iconbutton-contrast-icon);
     }
   }
-  &:hover {
+  &:where(:hover) {
     background-color: var(--components-button-iconbutton-standard-hover);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       background-color: var(--components-button-iconbutton-contrast-hover);
     }
   }
-  &:active {
+  &:where(:active) {
     background: var(--components-button-iconbutton-standard-active);
     color: var(--components-button-iconbutton-standard-text-active);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       background: var(--components-button-iconbutton-contrast-active);
       color: var(--components-button-iconbutton-contrast-text-active);
     }
   }
-  &:focus-visible {
+  &:where(:focus-visible) {
     outline: t.$outlines-focus;
     outline-color: var(--basecolors-stroke-focus-standard);
     outline-offset: t.$outline-offsets-focus;
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       outline-color: var(--basecolors-stroke-focus-contrast);
     }
   }

--- a/packages/button/src/IconButton.tsx
+++ b/packages/button/src/IconButton.tsx
@@ -22,7 +22,7 @@ export type IconButtonBaseProps = {
   /**Størrelsen på knappen
    * @default 'medium'
    */
-  size?: 'small' | 'medium';
+  size?: 'small' | 'medium' | 'large';
   /** Om knappen er opptatt, f.eks. med å lagre eller å kjøpe
    * @default false
    */

--- a/packages/button/src/index.scss
+++ b/packages/button/src/index.scss
@@ -1,5 +1,7 @@
 @use './componentVariables.scss';
 @use '@entur/tokens/dist/base.scss' as *;
+// Manually import typography tokens (to support dynamic text sizes) until these are out of beta
+@use '@entur/typography/src/beta/typographyTokens.scss' as *;
 
 // Used to register the styles as loaded!
 :root {

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/chip",
-  "version": "0.10.1",
+  "version": "0.10.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/chip.cjs.js",
   "module": "dist/chip.esm.js",

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/datepicker",
-  "version": "11.5.1",
+  "version": "11.5.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/datepicker.cjs.js",
   "module": "dist/datepicker.esm.js",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/dropdown",
-  "version": "8.0.3",
+  "version": "8.0.3-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/dropdown.cjs.js",
   "module": "dist/dropdown.esm.js",

--- a/packages/expand/package.json
+++ b/packages/expand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/expand",
-  "version": "3.7.1",
+  "version": "3.7.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/expand.cjs.js",
   "module": "dist/expand.esm.js",

--- a/packages/fileupload/package.json
+++ b/packages/fileupload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/fileupload",
-  "version": "0.5.1",
+  "version": "0.5.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/fileupload.cjs.js",
   "module": "dist/fileupload.esm.js",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/form",
-  "version": "9.2.1",
+  "version": "9.2.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/form.cjs.js",
   "module": "dist/form.esm.js",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/grid",
-  "version": "0.3.70",
+  "version": "0.3.70-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/grid.cjs.js",
   "module": "dist/grid.esm.js",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/icons",
-  "version": "8.4.0",
+  "version": "8.3.2-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/layout",
-  "version": "3.3.1",
+  "version": "3.3.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/layout.cjs.js",
   "module": "dist/layout.esm.js",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/loader",
-  "version": "0.6.1",
+  "version": "0.6.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/loader.cjs.js",
   "module": "dist/loader.esm.js",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/menu",
-  "version": "5.3.1",
+  "version": "5.3.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/menu.cjs.js",
   "module": "dist/menu.esm.js",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/modal",
-  "version": "1.8.1",
+  "version": "1.8.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/modal.cjs.js",
   "module": "dist/modal.esm.js",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/tab",
-  "version": "0.6.1",
+  "version": "0.6.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/tab.cjs.js",
   "module": "dist/tab.esm.js",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/table",
-  "version": "4.10.1",
+  "version": "4.10.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/table.cjs.js",
   "module": "dist/table.esm.js",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/tokens",
-  "version": "3.21.1",
+  "version": "3.21.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/tokens.cjs.js",
   "module": "dist/tokens.esm.js",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/tooltip",
-  "version": "5.3.1",
+  "version": "5.3.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/tooltip.cjs.js",
   "module": "dist/tooltip.esm.js",

--- a/packages/travel/package.json
+++ b/packages/travel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/travel",
-  "version": "6.5.1",
+  "version": "6.5.1-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/travel.cjs.js",
   "module": "dist/travel.esm.js",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/typography",
-  "version": "2.1.1",
+  "version": "2.1.1-beta-automat.0",
   "license": "SEE LICENSE IN README.md",
   "main": "./dist/typography.cjs.js",
   "module": "./dist/typography.esm.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/utils",
-  "version": "0.13.1",
+  "version": "0.12.6-beta-automat.0",
   "license": "EUPL-1.2",
   "main": "dist/utils.cjs.js",
   "module": "dist/utils.esm.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5657,7 +5657,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@entur/tokens@npm:^3.19.1, @entur/tokens@workspace:^, @entur/tokens@workspace:packages/tokens":
+"@entur/tokens@npm:^3.19.1":
+  version: 3.21.1
+  resolution: "@entur/tokens@npm:3.21.1"
+  dependencies:
+    flat: "npm:^5.0.2"
+    hex-rgb: "npm:^4.3.0"
+  checksum: 10c0/9c29e971fb72de320a4962f45a389f852248c860f379b354a66d2e2fd7e71209678c47f67856f7b1752180723620f43113c9c02d4e7fcb857b3254601a79accf
+  languageName: node
+  linkType: hard
+
+"@entur/tokens@workspace:^, @entur/tokens@workspace:packages/tokens":
   version: 0.0.0-use.local
   resolution: "@entur/tokens@workspace:packages/tokens"
   dependencies:


### PR DESCRIPTION
## 💡 Hvorfor?

Større ikonknapper som kan brukes på automat. 

## 🔧 Hvordan?

<!-- Forklar hvordan endringene er implementert -->

## 🧩 Type endring

<!-- Kryss av det som passer -->

- [ ] 🐞 Feilretting
- [x] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

<img width="1191" height="693" alt="Skjermbilde 2025-12-10 kl  15 22 00" src="https://github.com/user-attachments/assets/078a0146-affa-4880-8eaa-c96135b09bb7" />

## 💬 Tilleggsnotater

<!-- Andre tanker, bekymringer eller relevante lenker -->

## 💣 Breaking changes (om aktuelt)

<!-- Beskriv hva som brytes og hvordan man migrerer -->

<!-- Fjern seksjonen om ikke relevant -->

## ✅ Sjekkliste

<!-- Kryss av når punktene er oppfylt -->

- [ ] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [ ] Ingen ubrukte imports / varsler / console.logs
- [ ] Funker og ser ut som forventet i pakker som avhenger av denne

## 🧪 Testing

<!-- Hvordan er endringen testet og verifisert? -->

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden
