### PR TITLE
feat(modal)!: use native <dialog>, drop react-focus-lock

### DIFF
--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -22,8 +22,8 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "dependencies": {
     "@entur/a11y": "workspace:^",
@@ -33,12 +33,11 @@
     "@entur/tokens": "workspace:^",
     "@entur/typography": "workspace:^",
     "@entur/utils": "workspace:^",
-    "classnames": "^2.5.1",
-    "react-focus-lock": "^2.13.6"
+    "classnames": "^2.5.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",
-    "@testing-library/react": "^10.4.9",
+    "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "14.6.1",
     "@vitejs/plugin-react": "^5.0.1",
     "jest": "^29.0.0",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -22,8 +22,8 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "dependencies": {
     "@entur/a11y": "workspace:^",
@@ -33,13 +33,12 @@
     "@entur/tokens": "workspace:^",
     "@entur/typography": "workspace:^",
     "@entur/utils": "workspace:^",
-    "@reach/dialog": "^0.16.2",
     "classnames": "^2.5.1",
     "react-focus-lock": "^2.13.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",
-    "@testing-library/react": "^16.3.0",
+    "@testing-library/react": "^10.4.9",
     "@testing-library/user-event": "14.6.1",
     "@vitejs/plugin-react": "^5.0.1",
     "jest": "^29.0.0",

--- a/packages/modal/src/Drawer.tsx
+++ b/packages/modal/src/Drawer.tsx
@@ -9,7 +9,6 @@ import { IconButton } from '@entur/button';
 
 import './Drawer.scss';
 import { ModalOverlay } from './ModalOverlay';
-import { DialogContent } from '@reach/dialog';
 
 export type DrawerProps = {
   /** Innholdet. Typisk tekst, lenker eller knapper */
@@ -63,7 +62,6 @@ export const Drawer: React.FC<DrawerProps> = ({
   };
 
   const Wrapper = contrast ? Contrast : React.Fragment;
-  const ContentContainer = overlay ? DialogContent : 'div';
   return (
     <ConditionalWrapper
       condition={overlay}
@@ -74,7 +72,7 @@ export const Drawer: React.FC<DrawerProps> = ({
       )}
     >
       <Wrapper>
-        <ContentContainer
+        <div
           aria-labelledby={titleId}
           className={classNames('eds-drawer', className)}
           onKeyDown={handleKeyDown}
@@ -96,7 +94,7 @@ export const Drawer: React.FC<DrawerProps> = ({
               {children}
             </div>
           </MoveFocusInside>
-        </ContentContainer>
+        </div>
       </Wrapper>
     </ConditionalWrapper>
   );

--- a/packages/modal/src/Drawer.tsx
+++ b/packages/modal/src/Drawer.tsx
@@ -66,7 +66,11 @@ export const Drawer: React.FC<DrawerProps> = ({
     <ConditionalWrapper
       condition={overlay}
       wrapper={(children: React.ReactNode) => (
-        <ModalOverlay open={open} onDismiss={onDismiss}>
+        <ModalOverlay
+          open={open}
+          onDismiss={onDismiss}
+          aria-labelledby={titleId}
+        >
           {children}
         </ModalOverlay>
       )}

--- a/packages/modal/src/Drawer.tsx
+++ b/packages/modal/src/Drawer.tsx
@@ -1,14 +1,13 @@
-import React from 'react';
+import React, { useEffect, useId, useRef } from 'react';
 import classNames from 'classnames';
-import { MoveFocusInside } from 'react-focus-lock';
 import { Contrast } from '@entur/layout';
 import { CloseIcon } from '@entur/icons';
 import { Heading3 } from '@entur/typography';
-import { useRandomId } from '@entur/utils';
 import { IconButton } from '@entur/button';
+import { ConditionalWrapper } from '@entur/utils';
+import { ModalOverlay } from './ModalOverlay';
 
 import './Drawer.scss';
-import { ModalOverlay } from './ModalOverlay';
 
 export type DrawerProps = {
   /** Innholdet. Typisk tekst, lenker eller knapper */
@@ -48,20 +47,44 @@ export const Drawer: React.FC<DrawerProps> = ({
   style,
   overlay = false,
 }) => {
-  const titleId = useRandomId('eds-drawer');
+  const titleId = useId();
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<Element | null>(null);
 
-  if (!open) {
-    return null;
-  }
+  useEffect(
+    function handleFocus() {
+      if (!open || overlay) return;
+      previouslyFocusedRef.current = document.activeElement;
+      drawerRef.current
+        ?.querySelector<HTMLElement>('[data-autofocus]')
+        ?.focus();
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+      return () => {
+        if (previouslyFocusedRef.current instanceof HTMLElement) {
+          previouslyFocusedRef.current.focus();
+        }
+      };
+    },
+    [open, overlay],
+  );
+
+  const shouldRemoveFromDOM = !open && !overlay;
+  if (shouldRemoveFromDOM) return null;
+
+  function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === 'Escape') {
       e.stopPropagation();
       onDismiss();
     }
+  }
+
+  const Wrapper = contrast ? Contrast : 'div';
+  const nonModalDialogProps = {
+    role: 'dialog' as const,
+    'aria-modal': false,
+    'aria-labelledby': titleId,
   };
 
-  const Wrapper = contrast ? Contrast : React.Fragment;
   return (
     <ConditionalWrapper
       condition={overlay}
@@ -75,38 +98,28 @@ export const Drawer: React.FC<DrawerProps> = ({
         </ModalOverlay>
       )}
     >
-      <Wrapper>
-        <div
-          aria-labelledby={titleId}
-          className={classNames('eds-drawer', className)}
-          onKeyDown={handleKeyDown}
-          style={style}
+      <Wrapper
+        ref={drawerRef}
+        {...(!overlay && nonModalDialogProps)}
+        className={classNames('eds-drawer', className)}
+        onKeyDown={handleKeyDown}
+        style={style}
+      >
+        <IconButton
+          className="eds-drawer__close-button"
+          onClick={onDismiss}
+          type="button"
+          aria-label={closeLabel}
         >
-          <MoveFocusInside>
-            <IconButton
-              className="eds-drawer__close-button"
-              onClick={onDismiss}
-              type="button"
-              aria-label={closeLabel}
-            >
-              <CloseIcon aria-hidden />
-            </IconButton>
-            <div className="eds-drawer__content">
-              <Heading3 as="h2" id={titleId}>
-                {title}
-              </Heading3>
-              {children}
-            </div>
-          </MoveFocusInside>
+          <CloseIcon aria-hidden />
+        </IconButton>
+        <div className="eds-drawer__content">
+          <Heading3 as="h2" id={titleId} tabIndex={-1} data-autofocus="">
+            {title}
+          </Heading3>
+          {children}
         </div>
       </Wrapper>
     </ConditionalWrapper>
   );
 };
-
-const ConditionalWrapper: React.FC<{
-  condition: boolean;
-  wrapper: (child: JSX.Element) => JSX.Element;
-  children: React.ReactElement;
-}> = ({ condition, wrapper, children }) =>
-  condition ? wrapper(children) : children;

--- a/packages/modal/src/Modal.scss
+++ b/packages/modal/src/Modal.scss
@@ -2,36 +2,59 @@
 
 $modal-animation-duration: t.$timings-medium;
 
+// Lock body scroll while a modal is open.
+html:has(dialog.eds-modal__overlay[open]),
+html:has(dialog.eds-modal__overlay[open]) body {
+  overflow: hidden;
+}
+
 .eds-modal {
+  // Native <dialog> centers itself via UA margin:auto. We strip UA chrome and
+  // set max-width per size; width:100% (capped) gives ModalContent a parent
+  // width to fill so its own width:100% resolves.
   &__overlay {
-    // Reset native <dialog> styles
     border: none;
     padding: 0;
-    margin: 0;
-    max-width: none;
-    max-height: none;
-    width: 100%;
-    height: 100%;
+    background: transparent;
     color: inherit;
+  }
 
-    background: rgba(black, 0.5);
-    bottom: 0;
-    display: flex;
-    left: 0;
+  &__overlay[open] {
+    z-index: t.$z-indexes-overlay;
+    width: 100%;
     overflow: hidden;
     overscroll-behavior: contain;
-    position: fixed;
-    right: 0;
-    top: 0;
-    z-index: t.$z-indexes-overlay;
-
-    animation: fadeInOverlay;
-    animation-duration: $modal-animation-duration;
-    animation-timing-function: ease-in-out;
+    animation: fadeInOverlay $modal-animation-duration ease-in-out;
 
     &::backdrop {
-      background: transparent;
+      background: rgba(black, 0.5);
+      animation: fadeInOverlay $modal-animation-duration ease-in-out;
     }
+  }
+
+  &__overlay--size-extraSmall {
+    max-width: 21rem;
+  }
+  &__overlay--size-small {
+    max-width: 28.125rem;
+  }
+  &__overlay--size-medium {
+    max-width: 45rem;
+  }
+  &__overlay--size-large {
+    max-width: 56.25rem;
+  }
+  &__overlay--size-extraLarge {
+    max-width: 78.75rem;
+  }
+
+  &__close {
+    position: absolute;
+    top: t.$space-medium;
+    right: t.$space-medium;
+    color: var(--components-modal-modal-standard-icon);
+    z-index: calc(#{t.$z-indexes-modal} + 1);
+    animation: slideInContent $modal-animation-duration ease-in-out;
   }
 
   &__content {
@@ -39,56 +62,48 @@ $modal-animation-duration: t.$timings-medium;
     border: 1px solid var(--components-modal-modal-standard-border);
     border-radius: 0.75rem;
     color: var(--components-modal-modal-standard-text);
-    margin: auto;
     padding: t.$space-large;
-    position: relative;
     width: 100%;
     max-height: 90vh;
     overflow: auto;
-    z-index: t.$z-indexes-modal;
+    animation: slideInContent $modal-animation-duration ease-in-out;
 
-    animation: slideInContent;
-    animation-duration: $modal-animation-duration;
-    animation-timing-function: ease-in-out;
+    &--align-center {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+    }
 
-    &--align {
-      &-center {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
-      }
-
-      &-end {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-end;
-      }
+    &--align-end {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
     }
 
     &--size-extraSmall {
       max-width: 21rem;
       padding: t.$space-large;
     }
-
     &--size-small {
       max-width: 28.125rem;
       padding: t.$space-extra-large2;
+      padding-top: t.$space-extra-large;
     }
-
     &--size-medium {
       max-width: 45rem;
       padding: t.$space-extra-large3;
+      padding-top: t.$space-extra-large;
     }
-
     &--size-large {
       max-width: 56.25rem;
       padding: t.$space-extra-large3;
+      padding-top: t.$space-extra-large;
     }
-
     &--size-extraLarge {
       max-width: 78.75rem;
       padding: t.$space-extra-large3;
+      padding-top: t.$space-extra-large;
     }
 
     &::-webkit-scrollbar {
@@ -107,20 +122,12 @@ $modal-animation-duration: t.$timings-medium;
       }
     }
   }
-
-  &__close {
-    position: absolute;
-    top: t.$space-medium;
-    right: t.$space-medium;
-    color: var(--components-modal-modal-standard-icon);
-  }
 }
 
 @keyframes fadeInOverlay {
   from {
     opacity: 0;
   }
-
   to {
     opacity: 1;
   }
@@ -128,12 +135,11 @@ $modal-animation-duration: t.$timings-medium;
 
 @keyframes slideInContent {
   from {
-    top: 5rem;
+    transform: translateY(0.5rem);
     opacity: 0;
   }
-
   to {
-    top: 0%;
+    transform: translateY(0);
     opacity: 1;
   }
 }

--- a/packages/modal/src/Modal.scss
+++ b/packages/modal/src/Modal.scss
@@ -143,3 +143,12 @@ html:has(dialog.eds-modal__overlay[open]) body {
     opacity: 1;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .eds-modal__overlay,
+  .eds-modal__overlay::backdrop,
+  .eds-modal__content,
+  .eds-modal__close {
+    animation: none;
+  }
+}

--- a/packages/modal/src/Modal.scss
+++ b/packages/modal/src/Modal.scss
@@ -4,11 +4,22 @@ $modal-animation-duration: t.$timings-medium;
 
 .eds-modal {
   &__overlay {
+    // Reset native <dialog> styles
+    border: none;
+    padding: 0;
+    margin: 0;
+    max-width: none;
+    max-height: none;
+    width: 100%;
+    height: 100%;
+    color: inherit;
+
     background: rgba(black, 0.5);
     bottom: 0;
     display: flex;
     left: 0;
     overflow: hidden;
+    overscroll-behavior: contain;
     position: fixed;
     right: 0;
     top: 0;
@@ -17,6 +28,10 @@ $modal-animation-duration: t.$timings-medium;
     animation: fadeInOverlay;
     animation-duration: $modal-animation-duration;
     animation-timing-function: ease-in-out;
+
+    &::backdrop {
+      background: transparent;
+    }
   }
 
   &__content {

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -61,6 +61,7 @@ export const Modal: React.FC<ModalProps> = ({
       open={open}
       onDismiss={handleOnDismiss}
       initialFocusRef={initialFocusRef}
+      aria-labelledby={title ? randomId : undefined}
     >
       <ModalContent size={size} align={align} {...rest}>
         {showCloseButton && (

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { useId } from 'react';
 
 import { CloseIcon } from '@entur/icons';
 import { IconButton } from '@entur/button';
 import { Heading2 } from '@entur/typography';
-import { useRandomId } from '@entur/utils';
 
 import { ModalOverlay } from './ModalOverlay';
 import { ModalContent, headingsMap } from './ModalContent';
@@ -15,12 +14,16 @@ export type ModalProps = {
   children: React.ReactNode;
   /** Skjermleser-label til lukk-knappen */
   closeLabel?: string;
-  /** En ref til elementet som skal være fokusert når modalen åpnes. Defaulter til lukkeknappen */
+  /** En ref til elementet som skal være fokusert når modalen åpnes. Defaulter til tittelen, ellers første interaktive element */
   initialFocusRef?: React.RefObject<HTMLElement>;
-  /** Flagg som sier om modalen er åpen */
+  /** Styrer om modalen er synlig */
   open?: boolean;
-  /** Callback som kalles når brukeren ber om å lukke modalen */
-  onDismiss?: () => void;
+  /** Callback som kalles når brukeren ber om å lukke modalen. Påkrevd: Esc og klikk utenfor lukker alltid (nettleserens innebygde atferd for native dialog) */
+  onDismiss: () => void;
+  /** Om lukkeknappen skal vises i øvre høyre hjørne
+   * @default true
+   */
+  showCloseButton?: boolean;
   /** Størrelsen på modalen */
   size: 'extraSmall' | 'small' | 'medium' | 'large' | 'extraLarge';
   /** Hvordan innholdet skal plasseres i modalen
@@ -29,12 +32,13 @@ export type ModalProps = {
   align?: 'start' | 'center' | 'end';
   /** Tittelen som vises i modalen */
   title?: React.ReactNode;
+  /** Tilgjengelig navn for modalen når title ikke er satt */
+  'aria-label'?: string;
   /** Om modalen skal lukkes når man klikker på utsiden av den
    * @default true
    */
   closeOnClickOutside?: boolean;
-  [key: string]: any;
-};
+} & Omit<React.HTMLAttributes<HTMLDivElement>, 'title' | 'aria-label'>;
 
 export const Modal: React.FC<ModalProps> = ({
   children,
@@ -46,36 +50,42 @@ export const Modal: React.FC<ModalProps> = ({
   align = 'start',
   title,
   closeOnClickOutside = true,
+  showCloseButton = true,
+  'aria-label': ariaLabel,
   ...rest
 }) => {
-  const randomId = useRandomId('eds-modal');
+  const randomId = useId();
   const Heading: React.ElementType = headingsMap[size] || Heading2;
-  const showCloseButton = ['medium', 'large', 'extraLarge'].includes(size);
 
-  let handleOnDismiss;
-  if (onDismiss && closeOnClickOutside) {
-    handleOnDismiss = onDismiss;
-  }
   return (
     <ModalOverlay
       open={open}
-      onDismiss={handleOnDismiss}
+      onDismiss={onDismiss}
+      closeOnClickOutside={closeOnClickOutside}
       initialFocusRef={initialFocusRef}
+      className={`eds-modal__overlay--size-${size}`}
       aria-labelledby={title ? randomId : undefined}
+      aria-label={!title ? ariaLabel : undefined}
     >
+      {showCloseButton && (
+        <IconButton
+          className="eds-modal__close"
+          aria-label={closeLabel}
+          onClick={onDismiss}
+          type="button"
+        >
+          <CloseIcon />
+        </IconButton>
+      )}
       <ModalContent size={size} align={align} {...rest}>
-        {showCloseButton && (
-          <IconButton
-            className="eds-modal__close"
-            aria-label={closeLabel}
-            onClick={onDismiss}
-            type="button"
-          >
-            <CloseIcon />
-          </IconButton>
-        )}
         {title && (
-          <Heading margin="bottom" as="h2" id={randomId}>
+          <Heading
+            margin="bottom"
+            as="h2"
+            id={randomId}
+            tabIndex={-1}
+            data-autofocus={initialFocusRef ? undefined : ''}
+          >
             {title}
           </Heading>
         )}

--- a/packages/modal/src/ModalContent.tsx
+++ b/packages/modal/src/ModalContent.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { useId } from 'react';
 import classNames from 'classnames';
 import { Heading4, Heading3, Heading2 } from '@entur/typography';
-import { useRandomId } from '@entur/utils';
 
 export type ModalContentProps = {
   /** Innholdet i modalen */
@@ -16,8 +15,7 @@ export type ModalContentProps = {
    * @default 'start'
    */
   align?: 'start' | 'center' | 'end';
-  [key: string]: any;
-};
+} & Omit<React.HTMLAttributes<HTMLDivElement>, 'title'>;
 
 export const headingsMap = {
   extraSmall: Heading4,
@@ -36,7 +34,7 @@ export const ModalContent: React.FC<ModalContentProps> = ({
   ...rest
 }) => {
   const Heading: React.ElementType = headingsMap[size] || Heading2;
-  const randomId = useRandomId('eds-modal');
+  const randomId = useId();
   return (
     <div
       className={classNames(

--- a/packages/modal/src/ModalContent.tsx
+++ b/packages/modal/src/ModalContent.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
-import { DialogContent } from '@reach/dialog';
-import { Heading2, Heading3, Heading4 } from '@entur/typography';
+import { Heading4, Heading3, Heading2 } from '@entur/typography';
 import { useRandomId } from '@entur/utils';
 
 export type ModalContentProps = {
@@ -39,14 +38,14 @@ export const ModalContent: React.FC<ModalContentProps> = ({
   const Heading: React.ElementType = headingsMap[size] || Heading2;
   const randomId = useRandomId('eds-modal');
   return (
-    <DialogContent
+    <div
       className={classNames(
         'eds-modal__content',
         `eds-modal__content--size-${size}`,
         `eds-modal__content--align-${align}`,
         className,
       )}
-      aria-labelledby={randomId}
+      aria-labelledby={title ? randomId : undefined}
       {...rest}
     >
       {title && (
@@ -55,6 +54,6 @@ export const ModalContent: React.FC<ModalContentProps> = ({
         </Heading>
       )}
       {children}
-    </DialogContent>
+    </div>
   );
 };

--- a/packages/modal/src/ModalOverlay.tsx
+++ b/packages/modal/src/ModalOverlay.tsx
@@ -16,6 +16,7 @@ export type ModalOverlayProps = {
 };
 
 let scrollLockCount = 0;
+let originalBodyOverflow = '';
 
 export const ModalOverlay: React.FC<ModalOverlayProps> = ({
   className,
@@ -71,12 +72,13 @@ export const ModalOverlay: React.FC<ModalOverlayProps> = ({
     if (!open) return;
     scrollLockCount++;
     if (scrollLockCount === 1) {
+      originalBodyOverflow = document.body.style.overflow;
       document.body.style.overflow = 'hidden';
     }
     return () => {
       scrollLockCount--;
       if (scrollLockCount === 0) {
-        document.body.style.overflow = '';
+        document.body.style.overflow = originalBodyOverflow;
       }
     };
   }, [open]);

--- a/packages/modal/src/ModalOverlay.tsx
+++ b/packages/modal/src/ModalOverlay.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import classNames from 'classnames';
-import { DialogOverlay } from '@reach/dialog';
 
 export type ModalOverlayProps = {
   /** Flagg som sier om modalen er åpen */
@@ -16,14 +15,105 @@ export type ModalOverlayProps = {
   [key: string]: any;
 };
 
+let scrollLockCount = 0;
+
 export const ModalOverlay: React.FC<ModalOverlayProps> = ({
   className,
   open,
+  onDismiss,
+  initialFocusRef,
+  children,
   ...rest
-}) => (
-  <DialogOverlay
-    className={classNames('eds-modal__overlay', className)}
-    isOpen={open}
-    {...rest}
-  />
-);
+}) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const previouslyFocusedRef = useRef<Element | null>(null);
+
+  // Open/close dialog and manage focus
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    previouslyFocusedRef.current = document.activeElement;
+
+    if (!dialog.open) {
+      dialog.showModal();
+    }
+    if (initialFocusRef?.current) {
+      initialFocusRef.current.focus();
+    }
+
+    return () => {
+      if (dialog.open) {
+        dialog.close();
+      }
+      if (previouslyFocusedRef.current instanceof HTMLElement) {
+        previouslyFocusedRef.current.focus();
+      }
+    };
+  }, [open, initialFocusRef]);
+
+  // Prevent native dialog close on Escape — native addEventListener
+  // is used instead of onCancel JSX prop for React 16/17 compatibility
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const handleCancel = (e: Event) => {
+      e.preventDefault();
+    };
+
+    dialog.addEventListener('cancel', handleCancel);
+    return () => dialog.removeEventListener('cancel', handleCancel);
+  }, [open]);
+
+  // Lock body scroll when open
+  useEffect(() => {
+    if (!open) return;
+    scrollLockCount++;
+    if (scrollLockCount === 1) {
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      scrollLockCount--;
+      if (scrollLockCount === 0) {
+        document.body.style.overflow = '';
+      }
+    };
+  }, [open]);
+
+  // Handle Escape key — stopPropagation prevents nested modals from
+  // both closing when Escape is pressed
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onDismiss?.();
+      }
+    },
+    [onDismiss],
+  );
+
+  // Dismiss when clicking the overlay backdrop (not children)
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) {
+        onDismiss?.();
+      }
+    },
+    [onDismiss],
+  );
+
+  if (!open) return null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={classNames('eds-modal__overlay', className)}
+      {...rest}
+      onKeyDown={handleKeyDown}
+      onClick={handleClick}
+    >
+      {children}
+    </dialog>
+  );
+};

--- a/packages/modal/src/ModalOverlay.tsx
+++ b/packages/modal/src/ModalOverlay.tsx
@@ -1,5 +1,7 @@
-import React, { useRef, useEffect, useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import classNames from 'classnames';
+import { ContrastContext } from '@entur/layout';
 
 export type ModalOverlayProps = {
   /** Flagg som sier om modalen er åpen */
@@ -12,110 +14,77 @@ export type ModalOverlayProps = {
   className?: string;
   /** En ref til elementet som skal være fokusert når modalen åpnes. Defaulter til lukkeknappen */
   initialFocusRef?: React.RefObject<HTMLElement>;
-  [key: string]: any;
-};
-
-let scrollLockCount = 0;
-let originalBodyOverflow = '';
+  /** Om modalen skal lukkes når man klikker utenfor den
+   * @default true
+   */
+  closeOnClickOutside?: boolean;
+} & Omit<React.DialogHTMLAttributes<HTMLDialogElement>, 'open' | 'onClick'>;
 
 export const ModalOverlay: React.FC<ModalOverlayProps> = ({
   className,
   open,
   onDismiss,
   initialFocusRef,
+  closeOnClickOutside = true,
   children,
   ...rest
 }) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const previouslyFocusedRef = useRef<Element | null>(null);
 
-  // Open/close dialog and manage focus
+  // Toggle native dialog open state. Always stays in DOM so the browser can
+  // manage initial focus storage + restore on close.
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
-
-    previouslyFocusedRef.current = document.activeElement;
-
-    if (!dialog.open) {
+    if (open && !dialog.open) {
       dialog.showModal();
+      const target =
+        initialFocusRef?.current ??
+        dialog.querySelector<HTMLElement>('[data-autofocus]') ??
+        dialog;
+      target.focus();
+    } else if (!open && dialog.open) {
+      dialog.close();
     }
-    if (initialFocusRef?.current) {
-      initialFocusRef.current.focus();
-    }
-
-    return () => {
-      if (dialog.open) {
-        dialog.close();
-      }
-      if (previouslyFocusedRef.current instanceof HTMLElement) {
-        previouslyFocusedRef.current.focus();
-      }
-    };
   }, [open, initialFocusRef]);
 
-  // Prevent native dialog close on Escape — native addEventListener
-  // is used instead of onCancel JSX prop for React 16/17 compatibility
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    const handleCancel = (e: Event) => {
-      e.preventDefault();
-    };
-
-    dialog.addEventListener('cancel', handleCancel);
-    return () => dialog.removeEventListener('cancel', handleCancel);
-  }, [open]);
-
-  // Lock body scroll when open
-  useEffect(() => {
-    if (!open) return;
-    scrollLockCount++;
-    if (scrollLockCount === 1) {
-      originalBodyOverflow = document.body.style.overflow;
-      document.body.style.overflow = 'hidden';
-    }
-    return () => {
-      scrollLockCount--;
-      if (scrollLockCount === 0) {
-        document.body.style.overflow = originalBodyOverflow;
-      }
-    };
-  }, [open]);
-
-  // Handle Escape key — stopPropagation prevents nested modals from
-  // both closing when Escape is pressed
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.stopPropagation();
-        onDismiss?.();
-      }
+  // Esc fires cancel — preventDefault so we route through onDismiss + state,
+  // which triggers the effect above to call close() (native restore runs).
+  useEffect(
+    function syncCancelEvent() {
+      const dialog = dialogRef.current;
+      if (!dialog || !onDismiss) return;
+      const handleCancel = (e: Event) => {
+        e.preventDefault();
+        onDismiss();
+      };
+      dialog.addEventListener('cancel', handleCancel);
+      return () => dialog.removeEventListener('cancel', handleCancel);
     },
     [onDismiss],
   );
 
-  // Dismiss when clicking the overlay backdrop (not children)
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLDialogElement>) => {
-      if (e.target === dialogRef.current) {
-        onDismiss?.();
-      }
+      if (!closeOnClickOutside) return;
+      if (e.target === dialogRef.current) onDismiss?.();
     },
-    [onDismiss],
+    [onDismiss, closeOnClickOutside],
   );
 
-  if (!open) return null;
+  if (typeof document === 'undefined') return null;
 
-  return (
-    <dialog
-      ref={dialogRef}
-      className={classNames('eds-modal__overlay', className)}
-      {...rest}
-      onKeyDown={handleKeyDown}
-      onClick={handleClick}
-    >
-      {children}
-    </dialog>
+  return createPortal(
+    <ContrastContext.Provider value={false}>
+      <dialog
+        ref={dialogRef}
+        className={classNames('eds-modal__overlay', className)}
+        {...rest}
+        onClick={handleClick}
+      >
+        {open && children}
+      </dialog>
+    </ContrastContext.Provider>,
+    document.body,
   );
 };

--- a/packages/modal/src/index.test.tsx
+++ b/packages/modal/src/index.test.tsx
@@ -9,12 +9,13 @@ beforeAll(() => {
   };
   HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
     this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
   };
 });
 
 test('renders a nice looking modal', () => {
   const spy = jest.fn();
-  const { getByTestId } = render(
+  const { getByTestId, baseElement } = render(
     <Modal onDismiss={spy} open={true} title="title" size="large">
       <div data-testid="content">Modal content</div>
     </Modal>,
@@ -22,7 +23,8 @@ test('renders a nice looking modal', () => {
   expect(getByTestId('content')).toHaveTextContent('Modal content');
 
   expect(spy).not.toHaveBeenCalled();
-  fireEvent.keyDown(getByTestId('content'), { key: 'Escape' });
+  const dialog = baseElement.querySelector('dialog');
+  dialog?.dispatchEvent(new Event('cancel', { cancelable: true }));
   expect(spy).toHaveBeenCalled();
 });
 

--- a/packages/modal/src/index.test.tsx
+++ b/packages/modal/src/index.test.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { Modal } from '.';
 
-// Needed to silence Reach's styling warning
-jest.mock('@reach/utils', () => ({
-  ...(jest.requireActual('@reach/utils') as object),
-  checkStyles: jest.fn(),
-}));
+// Polyfill <dialog> methods for jsdom
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  };
+  HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  };
+});
 
 test('renders a nice looking modal', () => {
   const spy = jest.fn();
@@ -17,7 +21,7 @@ test('renders a nice looking modal', () => {
   );
   expect(getByTestId('content')).toHaveTextContent('Modal content');
 
-  expect(spy);
+  expect(spy).not.toHaveBeenCalled();
   fireEvent.keyDown(getByTestId('content'), { key: 'Escape' });
   expect(spy).toHaveBeenCalled();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3842,15 +3842,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime-corejs3@npm:7.29.2":
-  version: 7.29.2
-  resolution: "@babel/runtime-corejs3@npm:7.29.2"
-  dependencies:
-    core-js-pure: "npm:^3.48.0"
-  checksum: 10c0/24a9de8b592cf67fbe62c36c002a0da8c0456079a0543646a40e2b1b0838e7712f5ff49e9551624395ccd67a409c63e7c638b23e3bebbfdf54e373b1c707ebff
-  languageName: node
-  linkType: hard
-
 "@babel/runtime@npm:7.29.2":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
@@ -6292,20 +6283,19 @@ __metadata:
     "@entur/typography": "workspace:^"
     "@entur/utils": "workspace:^"
     "@testing-library/jest-dom": "npm:^5.17.0"
-    "@testing-library/react": "npm:^10.4.9"
+    "@testing-library/react": "npm:^16.3.0"
     "@testing-library/user-event": "npm:14.6.1"
     "@vitejs/plugin-react": "npm:^5.0.1"
     classnames: "npm:^2.5.1"
     jest: "npm:^29.0.0"
     jest-environment-jsdom: "npm:^29.0.0"
-    react-focus-lock: "npm:^2.13.6"
     ts-jest: "npm:^29.0.0"
     typescript: "npm:^5.9.2"
     vite: "npm:^7.3.2"
     vite-plugin-dts: "npm:^4.5.4"
   peerDependencies:
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
+    react: ">=18.0.0"
+    react-dom: ">=18.0.0"
   languageName: unknown
   linkType: soft
 
@@ -8194,19 +8184,6 @@ __metadata:
     slash: "npm:^3.0.0"
     write-file-atomic: "npm:^4.0.2"
   checksum: 10c0/7f4a7f73dcf45dfdf280c7aa283cbac7b6e5a904813c3a93ead7e55873761fc20d5c4f0191d2019004fac6f55f061c82eb3249c2901164ad80e362e7a7ede5a6
-  languageName: node
-  linkType: hard
-
-"@jest/types@npm:^26.6.2":
-  version: 26.6.2
-  resolution: "@jest/types@npm:26.6.2"
-  dependencies:
-    "@types/istanbul-lib-coverage": "npm:^2.0.0"
-    "@types/istanbul-reports": "npm:^3.0.0"
-    "@types/node": "npm:*"
-    "@types/yargs": "npm:^15.0.0"
-    chalk: "npm:^4.0.0"
-  checksum: 10c0/5b9b957f38a002895eb04bbb8c3dda6fccce8e2551f3f44b02f1f43063a78e8bedce73cd4330b53ede00ae005de5cd805982fbb2ec6ab9feacf96344240d5db2
   languageName: node
   linkType: hard
 
@@ -13160,22 +13137,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^7.22.3":
-  version: 7.31.2
-  resolution: "@testing-library/dom@npm:7.31.2"
-  dependencies:
-    "@babel/code-frame": "npm:^7.10.4"
-    "@babel/runtime": "npm:^7.12.5"
-    "@types/aria-query": "npm:^4.2.0"
-    aria-query: "npm:^4.2.2"
-    chalk: "npm:^4.1.0"
-    dom-accessibility-api: "npm:^0.5.6"
-    lz-string: "npm:^1.4.4"
-    pretty-format: "npm:^26.6.2"
-  checksum: 10c0/51498f6552b669a547202f4f508a1e91b5a0c25a64be987e49601ec00f3d0cc514c591400f0ad49d91b7d522e40e29b29a209aecd43f8611e2240b1ba3d4f93d
-  languageName: node
-  linkType: hard
-
 "@testing-library/jest-dom@npm:^5.17.0":
   version: 5.17.0
   resolution: "@testing-library/jest-dom@npm:5.17.0"
@@ -13190,19 +13151,6 @@ __metadata:
     lodash: "npm:^4.17.15"
     redent: "npm:^3.0.0"
   checksum: 10c0/24e09c5779ea44644945ec26f2e4e5f48aecfe57d469decf2317a3253a5db28d865c55ad0ea4818d8d1df7572a6486c45daa06fa09644a833a7dd84563881939
-  languageName: node
-  linkType: hard
-
-"@testing-library/react@npm:^10.4.9":
-  version: 10.4.9
-  resolution: "@testing-library/react@npm:10.4.9"
-  dependencies:
-    "@babel/runtime": "npm:^7.10.3"
-    "@testing-library/dom": "npm:^7.22.3"
-  peerDependencies:
-    react: "*"
-    react-dom: "*"
-  checksum: 10c0/25880d8b43938966ace7c1b6210eb996b5d2889e98cdd58ede6b81d4b09c70229ea3e89721f36d005f1c09ea3acc172dacb30e5f3fae45bb2f727ecfd60c2576
   languageName: node
   linkType: hard
 
@@ -13295,13 +13243,6 @@ __metadata:
   version: 1.0.38
   resolution: "@types/argparse@npm:1.0.38"
   checksum: 10c0/4fc892da5df16923f48180da2d1f4562fa8b0507cf636b24780444fa0a1d7321d4dc0c0ecbee6152968823f5a2ae0d321b4f8c705a489bf1ae1245bdeb0868fd
-  languageName: node
-  linkType: hard
-
-"@types/aria-query@npm:^4.2.0":
-  version: 4.2.2
-  resolution: "@types/aria-query@npm:4.2.2"
-  checksum: 10c0/6dc0d94890c2c7c2e347148ea32215b73bf480e0f0888a9bbfb7b531285a3daf0b95e600db5be1c03d6e5f825d63cf8c2aabc5db93d8d1fd47ce3211f73e8d66
   languageName: node
   linkType: hard
 
@@ -14311,15 +14252,6 @@ __metadata:
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
   checksum: 10c0/e71c3bd9d0b73ca82e10bee2064c384ab70f61034bbfb78e74f5206283fc16a6d85267b606b5c22cb2a3338373586786fed595b2009825d6a9115afba36560a0
-  languageName: node
-  linkType: hard
-
-"@types/yargs@npm:^15.0.0":
-  version: 15.0.20
-  resolution: "@types/yargs@npm:15.0.20"
-  dependencies:
-    "@types/yargs-parser": "npm:*"
-  checksum: 10c0/7578e333b8e3e60e96950fc3d90f75afa5f6612cbaa309813848a5bf198fd39bd6bf8d25f8fde7106c614686e24fd409403cc22166f5571c9fc1148fe147c0f5
   languageName: node
   linkType: hard
 
@@ -15352,7 +15284,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:5.0.1, ansi-regex@npm:^5.0.0, ansi-regex@npm:^5.0.1":
+"ansi-regex@npm:5.0.1, ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
   checksum: 10c0/9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
@@ -15516,16 +15448,6 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.3"
   checksum: 10c0/2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
-  languageName: node
-  linkType: hard
-
-"aria-query@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "aria-query@npm:4.2.2"
-  dependencies:
-    "@babel/runtime": "npm:^7.10.2"
-    "@babel/runtime-corejs3": "npm:^7.10.2"
-  checksum: 10c0/7e224fbbb4de8210c5d8cbaf0e1a22caa78f2068bf231f4c75302bd77eeba1c3e3b97912080535140be60174720d2ac817e5d6fec18592951b4b6488d4da7cdc
   languageName: node
   linkType: hard
 
@@ -18453,13 +18375,6 @@ __metadata:
   version: 3.39.0
   resolution: "core-js-pure@npm:3.39.0"
   checksum: 10c0/5d954e467703ea1e860eb070bd72cf9dc5bfddd7037c09d750f0eba3ffc4066db741a595af86dc833a709929e161a909e48da3cbdd2d9bee7795cb516dc9f7d4
-  languageName: node
-  linkType: hard
-
-"core-js-pure@npm:^3.48.0":
-  version: 3.49.0
-  resolution: "core-js-pure@npm:3.49.0"
-  checksum: 10c0/b4580a57b917d0bf1029356b1a60abf0f9b99562b67bf39c01485d58891f23603459ed71bde1d7f75c0a9a346829d8c281b255c525fb119726341364c513e82e
   languageName: node
   linkType: hard
 
@@ -28550,7 +28465,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lz-string@npm:^1.4.4, lz-string@npm:^1.5.0":
+"lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
   bin:
@@ -34547,18 +34462,6 @@ __metadata:
     react-is-18: "npm:react-is@^18.3.1"
     react-is-19: "npm:react-is@^19.2.5"
   checksum: 10c0/c7e6633740cd2f6d382f188c00c8b4b3f2bee3cda16db6753471c6bb4b94f76531358d3a7793062a0fb00d72ebfb934e8ae1d4f5ced6bb34c8e7f60996f90076
-  languageName: node
-  linkType: hard
-
-"pretty-format@npm:^26.6.2":
-  version: 26.6.2
-  resolution: "pretty-format@npm:26.6.2"
-  dependencies:
-    "@jest/types": "npm:^26.6.2"
-    ansi-regex: "npm:^5.0.0"
-    ansi-styles: "npm:^4.0.0"
-    react-is: "npm:^17.0.1"
-  checksum: 10c0/b5ddf0e949b874b699d313fe9407f0eb65e67d00823b2dd95335905a73457260af7612f3bff6b48611fcca9ffcff003359e4c9faba4200d6209da433a859aef3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3842,6 +3842,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime-corejs3@npm:7.29.2":
+  version: 7.29.2
+  resolution: "@babel/runtime-corejs3@npm:7.29.2"
+  dependencies:
+    core-js-pure: "npm:^3.48.0"
+  checksum: 10c0/24a9de8b592cf67fbe62c36c002a0da8c0456079a0543646a40e2b1b0838e7712f5ff49e9551624395ccd67a409c63e7c638b23e3bebbfdf54e373b1c707ebff
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:7.29.2":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
@@ -6282,12 +6291,8 @@ __metadata:
     "@entur/tokens": "workspace:^"
     "@entur/typography": "workspace:^"
     "@entur/utils": "workspace:^"
-    "@react-aria/dialog": "npm:^3.5.33"
-    "@react-aria/focus": "npm:^3.21.4"
-    "@react-aria/overlays": "npm:^3.31.1"
-    "@react-stately/overlays": "npm:^3.6.22"
     "@testing-library/jest-dom": "npm:^5.17.0"
-    "@testing-library/react": "npm:^16.3.0"
+    "@testing-library/react": "npm:^10.4.9"
     "@testing-library/user-event": "npm:14.6.1"
     "@vitejs/plugin-react": "npm:^5.0.1"
     classnames: "npm:^2.5.1"
@@ -6299,8 +6304,8 @@ __metadata:
     vite: "npm:^7.3.2"
     vite-plugin-dts: "npm:^4.5.4"
   peerDependencies:
-    react: ">=18.0.0"
-    react-dom: ">=18.0.0"
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
   languageName: unknown
   linkType: soft
 
@@ -8189,6 +8194,19 @@ __metadata:
     slash: "npm:^3.0.0"
     write-file-atomic: "npm:^4.0.2"
   checksum: 10c0/7f4a7f73dcf45dfdf280c7aa283cbac7b6e5a904813c3a93ead7e55873761fc20d5c4f0191d2019004fac6f55f061c82eb3249c2901164ad80e362e7a7ede5a6
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^26.6.2":
+  version: 26.6.2
+  resolution: "@jest/types@npm:26.6.2"
+  dependencies:
+    "@types/istanbul-lib-coverage": "npm:^2.0.0"
+    "@types/istanbul-reports": "npm:^3.0.0"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^15.0.0"
+    chalk: "npm:^4.0.0"
+  checksum: 10c0/5b9b957f38a002895eb04bbb8c3dda6fccce8e2551f3f44b02f1f43063a78e8bedce73cd4330b53ede00ae005de5cd805982fbb2ec6ab9feacf96344240d5db2
   languageName: node
   linkType: hard
 
@@ -10900,23 +10918,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/dialog@npm:^3.5.33":
-  version: 3.5.33
-  resolution: "@react-aria/dialog@npm:3.5.33"
-  dependencies:
-    "@react-aria/interactions": "npm:^3.27.0"
-    "@react-aria/overlays": "npm:^3.31.1"
-    "@react-aria/utils": "npm:^3.33.0"
-    "@react-types/dialog": "npm:^3.5.23"
-    "@react-types/shared": "npm:^3.33.0"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10c0/8ccaee23239942d010c37c4e8e5a8a75163ea6ece8060e8f581148c2df99d46b4a59585c1d9f1a6a9f3ee29e91788bd43c900ad1d2f65c6da505e1b504e6ea46
-  languageName: node
-  linkType: hard
-
 "@react-aria/focus@npm:^3.21.4":
   version: 3.21.4
   resolution: "@react-aria/focus@npm:3.21.4"
@@ -11007,28 +11008,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/overlays@npm:^3.31.1":
-  version: 3.31.1
-  resolution: "@react-aria/overlays@npm:3.31.1"
-  dependencies:
-    "@react-aria/focus": "npm:^3.21.4"
-    "@react-aria/i18n": "npm:^3.12.15"
-    "@react-aria/interactions": "npm:^3.27.0"
-    "@react-aria/ssr": "npm:^3.9.10"
-    "@react-aria/utils": "npm:^3.33.0"
-    "@react-aria/visually-hidden": "npm:^3.8.30"
-    "@react-stately/overlays": "npm:^3.6.22"
-    "@react-types/button": "npm:^3.15.0"
-    "@react-types/overlays": "npm:^3.9.3"
-    "@react-types/shared": "npm:^3.33.0"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10c0/5de1c072d665547fa759446ef5c47a34d9c0fc8e404adf2d43b2ffc446940299dd28187ad04be9b5ceb1678d85c65c1634dfa5aae55d9739070c52adf4b5652c
-  languageName: node
-  linkType: hard
-
 "@react-aria/spinbutton@npm:^3.7.1":
   version: 3.7.1
   resolution: "@react-aria/spinbutton@npm:3.7.1"
@@ -11087,21 +11066,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10c0/15e9c79102632f96c611ca10ce5a3436617f1b3979ca7b4be192cf4c65c74871edb66c72bdbcedaeeaa6498d04947184d5bccf29a2a36a28eff89c3d55d9d1ca
-  languageName: node
-  linkType: hard
-
-"@react-aria/visually-hidden@npm:^3.8.30":
-  version: 3.8.30
-  resolution: "@react-aria/visually-hidden@npm:3.8.30"
-  dependencies:
-    "@react-aria/interactions": "npm:^3.27.0"
-    "@react-aria/utils": "npm:^3.33.0"
-    "@react-types/shared": "npm:^3.33.0"
-    "@swc/helpers": "npm:^0.5.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-  checksum: 10c0/ff0324a222ff05ad3743d1df56feb8d1e2d95791cd360dbfbc03fad4b8e9346eb7b65a29ffda85f80665a5edc1f7705fcd047eaecb4f38573ee7e9c5d562392e
   languageName: node
   linkType: hard
 
@@ -13196,6 +13160,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^7.22.3":
+  version: 7.31.2
+  resolution: "@testing-library/dom@npm:7.31.2"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^4.2.0"
+    aria-query: "npm:^4.2.2"
+    chalk: "npm:^4.1.0"
+    dom-accessibility-api: "npm:^0.5.6"
+    lz-string: "npm:^1.4.4"
+    pretty-format: "npm:^26.6.2"
+  checksum: 10c0/51498f6552b669a547202f4f508a1e91b5a0c25a64be987e49601ec00f3d0cc514c591400f0ad49d91b7d522e40e29b29a209aecd43f8611e2240b1ba3d4f93d
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-dom@npm:^5.17.0":
   version: 5.17.0
   resolution: "@testing-library/jest-dom@npm:5.17.0"
@@ -13210,6 +13190,19 @@ __metadata:
     lodash: "npm:^4.17.15"
     redent: "npm:^3.0.0"
   checksum: 10c0/24e09c5779ea44644945ec26f2e4e5f48aecfe57d469decf2317a3253a5db28d865c55ad0ea4818d8d1df7572a6486c45daa06fa09644a833a7dd84563881939
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^10.4.9":
+  version: 10.4.9
+  resolution: "@testing-library/react@npm:10.4.9"
+  dependencies:
+    "@babel/runtime": "npm:^7.10.3"
+    "@testing-library/dom": "npm:^7.22.3"
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 10c0/25880d8b43938966ace7c1b6210eb996b5d2889e98cdd58ede6b81d4b09c70229ea3e89721f36d005f1c09ea3acc172dacb30e5f3fae45bb2f727ecfd60c2576
   languageName: node
   linkType: hard
 
@@ -13302,6 +13295,13 @@ __metadata:
   version: 1.0.38
   resolution: "@types/argparse@npm:1.0.38"
   checksum: 10c0/4fc892da5df16923f48180da2d1f4562fa8b0507cf636b24780444fa0a1d7321d4dc0c0ecbee6152968823f5a2ae0d321b4f8c705a489bf1ae1245bdeb0868fd
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^4.2.0":
+  version: 4.2.2
+  resolution: "@types/aria-query@npm:4.2.2"
+  checksum: 10c0/6dc0d94890c2c7c2e347148ea32215b73bf480e0f0888a9bbfb7b531285a3daf0b95e600db5be1c03d6e5f825d63cf8c2aabc5db93d8d1fd47ce3211f73e8d66
   languageName: node
   linkType: hard
 
@@ -14311,6 +14311,15 @@ __metadata:
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
   checksum: 10c0/e71c3bd9d0b73ca82e10bee2064c384ab70f61034bbfb78e74f5206283fc16a6d85267b606b5c22cb2a3338373586786fed595b2009825d6a9115afba36560a0
+  languageName: node
+  linkType: hard
+
+"@types/yargs@npm:^15.0.0":
+  version: 15.0.20
+  resolution: "@types/yargs@npm:15.0.20"
+  dependencies:
+    "@types/yargs-parser": "npm:*"
+  checksum: 10c0/7578e333b8e3e60e96950fc3d90f75afa5f6612cbaa309813848a5bf198fd39bd6bf8d25f8fde7106c614686e24fd409403cc22166f5571c9fc1148fe147c0f5
   languageName: node
   linkType: hard
 
@@ -15343,7 +15352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:5.0.1, ansi-regex@npm:^5.0.1":
+"ansi-regex@npm:5.0.1, ansi-regex@npm:^5.0.0, ansi-regex@npm:^5.0.1":
   version: 5.0.1
   resolution: "ansi-regex@npm:5.0.1"
   checksum: 10c0/9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
@@ -15507,6 +15516,16 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.3"
   checksum: 10c0/2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^4.2.2":
+  version: 4.2.2
+  resolution: "aria-query@npm:4.2.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.10.2"
+    "@babel/runtime-corejs3": "npm:^7.10.2"
+  checksum: 10c0/7e224fbbb4de8210c5d8cbaf0e1a22caa78f2068bf231f4c75302bd77eeba1c3e3b97912080535140be60174720d2ac817e5d6fec18592951b4b6488d4da7cdc
   languageName: node
   linkType: hard
 
@@ -18434,6 +18453,13 @@ __metadata:
   version: 3.39.0
   resolution: "core-js-pure@npm:3.39.0"
   checksum: 10c0/5d954e467703ea1e860eb070bd72cf9dc5bfddd7037c09d750f0eba3ffc4066db741a595af86dc833a709929e161a909e48da3cbdd2d9bee7795cb516dc9f7d4
+  languageName: node
+  linkType: hard
+
+"core-js-pure@npm:^3.48.0":
+  version: 3.49.0
+  resolution: "core-js-pure@npm:3.49.0"
+  checksum: 10c0/b4580a57b917d0bf1029356b1a60abf0f9b99562b67bf39c01485d58891f23603459ed71bde1d7f75c0a9a346829d8c281b255c525fb119726341364c513e82e
   languageName: node
   linkType: hard
 
@@ -28524,7 +28550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lz-string@npm:^1.5.0":
+"lz-string@npm:^1.4.4, lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
   bin:
@@ -34521,6 +34547,18 @@ __metadata:
     react-is-18: "npm:react-is@^18.3.1"
     react-is-19: "npm:react-is@^19.2.5"
   checksum: 10c0/c7e6633740cd2f6d382f188c00c8b4b3f2bee3cda16db6753471c6bb4b94f76531358d3a7793062a0fb00d72ebfb934e8ae1d4f5ced6bb34c8e7f60996f90076
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^26.6.2":
+  version: 26.6.2
+  resolution: "pretty-format@npm:26.6.2"
+  dependencies:
+    "@jest/types": "npm:^26.6.2"
+    ansi-regex: "npm:^5.0.0"
+    ansi-styles: "npm:^4.0.0"
+    react-is: "npm:^17.0.1"
+  checksum: 10c0/b5ddf0e949b874b699d313fe9407f0eb65e67d00823b2dd95335905a73457260af7612f3bff6b48611fcca9ffcff003359e4c9faba4200d6209da433a859aef3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 💡 Hvorfor?

`@reach/dialog` støtter ikke React 18/19 og er ikke lenger vedlikeholdt. Modalen er flyttet over til det native HTML `<dialog>`-elementet (`showModal()`), som gir fokushåndtering, top-layer-rendering, sibling `inert` og backdrop direkte fra nettleseren. På samme tid er `react-focus-lock` fjernet — den native dialogen gjør jobben.

## 🔧 Hvordan?

Branchen består av fire commits:

1. **`feat(modal)!: replace @reach/dialog with native <dialog> element`** — bytter overlay og content til native `<dialog>` med `showModal()`. CSS-resetter på UA-stiler, transparent `::backdrop`, manuell scroll-lock + Escape-håndtering.
2. **`fix(modal): give Drawer dialog an accessible name`** — `aria-labelledby` propageres fra Drawer-tittelen til ModalOverlay slik at skjermlesere kunngjør drawer-en korrekt.
3. **`feat(modal)!: require onDismiss and add showCloseButton prop`** — krever nå `onDismiss`, ny `showCloseButton`-prop (default `true`), tittel får fokus ved åpning, modalen forventes å stå montert mellom åpninger, `react-focus-lock` fjernet helt.
4. **`feat(modal): respect prefers-reduced-motion`** — slide/fade-animasjoner deaktiveres for brukere som har satt reduced-motion-preferanse i operativsystemet.

## 🧩 Type endring

- [ ] 🐞 Feilretting
- [x] 🚀 Ny funksjonalitet
- [x] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

<!-- TODO: Legg ved skjermbilder av modal i ulike størrelser, og av Drawer overlay/inline. -->

## 💬 Tilleggsnotater

- Native `<dialog>` med `showModal()` krever Safari 15.4+, Firefox 98+, Chrome 37+ (Baseline siden mars 2022).
- `react-focus-lock` er fjernet fra `@entur/modal`. Pakkestørrelsen er redusert.
- Esc og klikk utenfor modalen lukker den alltid (nettleserens innebygde atferd for `<dialog>`) — `onDismiss` er derfor påkrevd så React-staten kan synkroniseres.
- Tittelen i modalen får fokus når den åpnes (WAI-ARIA APG dialog-mønster). Native fokusgjenoppretting flytter fokus tilbake til triggeren når modalen lukkes.

## 💣 Breaking changes

| Endring | Migrasjon |
|---------|-----------|
| **`onDismiss` er nå påkrevd** | Send med en callback som setter `open` til `false` i React-staten din. |
| **Modalen må stå montert** | Bruk `<Modal open={open} ...>` i stedet for `{open && <Modal ...>}`. Mønsteret med betinget rendering hindrer native fokusgjenoppretting. |
| **`react-focus-lock` er fjernet** | Ingen handling nødvendig hos forbrukere. Hvis du har patchet/overstyrt fokushåndtering, fjern det. |
| **DOM-struktur endret**: Overlay er nå `<dialog>`, backdrop er `::backdrop`-pseudoelementet | Oppdater CSS-selektorer som målrettet `[data-reach-dialog-*]` eller en backdrop-DOM-node. |
| **Lukkeknapp vises på alle størrelser** | Verifiser layout i små modaler. Sett `showCloseButton={false}` for å skjule X-knappen (f.eks. cmd-K-paletter). |
| **Non-overlay Drawer har `role="dialog"`** | Snapshot-tester for Drawer kan trenge refresh. |

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden
- [x] Unit-tester passerer (`yarn test:package modal`)
- [x] TypeScript kompilerer uten feil
- [x] Manuell verifisering av scenarier i TestBench: fokus ved åpning, Esc, backdrop-klikk, nestede modaler, command palette (`showCloseButton={false}`), Drawer overlay og inline, fokusgjenoppretting.
