### PR TITLE
fix + refactor(layout/beta): Portal og Sidebar SCSS-forbedringer

### DIFF
--- a/packages/layout/src/beta/templates/Sidebar.scss
+++ b/packages/layout/src/beta/templates/Sidebar.scss
@@ -1,4 +1,5 @@
 @use '@entur/tokens/dist/styles.scss' as t;
+@use './variables' as v;
 
 .eds-layout-template-sidebar-wrapper {
   height: 100%;
@@ -6,15 +7,15 @@
 
   &--collapsible {
     position: relative;
-    max-height: var(--eds-viewport-height, 100dvh);
+    max-height: var(--eds-viewport-height, #{v.$default-viewport-height});
   }
 }
 
 .eds-layout-template-sidebar {
-  padding: var(--eds-sidebar-padding, 2rem);
+  padding: var(--eds-sidebar-padding, #{v.$default-sidebar-padding});
   height: 100%;
-  max-height: var(--eds-viewport-height, 100dvh);
-  width: var(--eds-sidebar-width, 20rem);
+  max-height: var(--eds-viewport-height, #{v.$default-viewport-height});
+  width: var(--eds-sidebar-width, #{v.$default-sidebar-width});
 
   &--collapsible {
     overflow-x: hidden;
@@ -23,7 +24,7 @@
   }
 
   &--collapsed {
-    padding: var(--eds-sidebar-padding, 2rem) 0;
+    padding: var(--eds-sidebar-padding, #{v.$default-sidebar-padding}) 0;
   }
 
   &--plain {
@@ -36,8 +37,8 @@
     overflow-y: auto;
     scrollbar-width: thin;
     scrollbar-color: rgba(255 255 255 / 0.3) transparent;
-    margin-left: calc(-1 * var(--eds-sidebar-padding, 2rem));
-    margin-right: calc(-1 * var(--eds-sidebar-padding, 2rem));
+    margin-left: calc(-1 * var(--eds-sidebar-padding, #{v.$default-sidebar-padding}));
+    margin-right: calc(-1 * var(--eds-sidebar-padding, #{v.$default-sidebar-padding}));
 
     .eds-layout-template-sidebar--plain & {
       scrollbar-color: rgba(0 0 0 / 0.2) transparent;
@@ -54,7 +55,7 @@
     gap: var(--m);
     flex: 1 1 0;
     min-height: 0;
-    min-width: calc(var(--eds-sidebar-width, 20rem) - 2 * var(--eds-sidebar-padding, 2rem));
+    min-width: calc(var(--eds-sidebar-width, #{v.$default-sidebar-width}) - 2 * var(--eds-sidebar-padding, #{v.$default-sidebar-padding}));
     opacity: 1;
     transition: opacity ease-in t.$timings-fast t.$timings-medium;
 

--- a/packages/layout/src/beta/templates/Sidebar.scss
+++ b/packages/layout/src/beta/templates/Sidebar.scss
@@ -6,6 +6,7 @@
 
   &--collapsible {
     position: relative;
+    max-height: var(--eds-viewport-height, 100dvh);
   }
 }
 
@@ -14,8 +15,6 @@
   height: 100%;
   max-height: var(--eds-viewport-height, 100dvh);
   width: var(--eds-sidebar-width, 20rem);
-  position: sticky;
-  top: 0;
 
   &--collapsible {
     overflow-x: hidden;
@@ -76,7 +75,7 @@
     border: none;
     cursor: pointer;
     background-color: var(--basecolors-frame-default);
-    color: var(--text-dark);
+    color: var(--basecolors-stroke-light);
     box-shadow: t.$shadows-box-shadow;
     display: flex;
     align-items: center;

--- a/packages/layout/src/beta/templates/_variables.scss
+++ b/packages/layout/src/beta/templates/_variables.scss
@@ -1,0 +1,6 @@
+$default-viewport-height: 100dvh;
+$default-sidebar-width: 20rem;
+$default-sidebar-padding: 2rem;
+$default-sidebar-column-width: min-content;
+$default-sidebar-collapsed-width: 2rem;
+$default-portal-main-padding: 1rem;

--- a/packages/layout/src/beta/templates/portal/Portal.scss
+++ b/packages/layout/src/beta/templates/portal/Portal.scss
@@ -1,11 +1,12 @@
 @use '@entur/tokens/dist/styles.scss' as t;
+@use '../variables' as v;
 
 .eds-layout-template-portal {
-  --grid-template-columns: var(--eds-sidebar-width, min-content) minmax(0, 1fr);
+  --grid-template-columns: var(--eds-sidebar-width, #{v.$default-sidebar-column-width}) minmax(0, 1fr);
 
   min-height: 0;
-  max-height: var(--eds-viewport-height, 100dvh);
-  height: var(--eds-viewport-height, 100dvh);
+  max-height: var(--eds-viewport-height, #{v.$default-viewport-height});
+  height: var(--eds-viewport-height, #{v.$default-viewport-height});
   width: 100%;
 
   // Animate the column width when a collapsible sidebar is present.
@@ -14,7 +15,7 @@
   }
 
   &:has(.eds-layout-template-sidebar--collapsed) {
-    --grid-template-columns: 2rem minmax(0, 1fr);
+    --grid-template-columns: #{v.$default-sidebar-collapsed-width} minmax(0, 1fr);
   }
 
   &:has(> .eds-layout-template-portal__status-bar) {
@@ -37,7 +38,7 @@
 }
 
 .eds-layout-template-portal__main {
-  padding: var(--eds-portal-main-padding, 1rem);
-  max-height: var(--eds-viewport-height, 100dvh);
+  padding: var(--eds-portal-main-padding, #{v.$default-portal-main-padding});
+  max-height: var(--eds-viewport-height, #{v.$default-viewport-height});
   overflow: auto;
 }

--- a/packages/layout/src/beta/templates/portal/Portal.scss
+++ b/packages/layout/src/beta/templates/portal/Portal.scss
@@ -38,4 +38,6 @@
 
 .eds-layout-template-portal__main {
   padding: var(--eds-portal-main-padding, 1rem);
+  max-height: var(--eds-viewport-height, 100dvh);
+  overflow: auto;
 }


### PR DESCRIPTION
## 💡 Hvorfor?

Fikser to feil i Portal/Sidebar-templates, og rydder opp i hardkodede standardverdier i CSS-variabelbruk.

## 🔧 Hvordan?

**Feilrettinger:**
- `Portal.main`: la til `overflow: auto` og `max-height` slik at innholdet scroller innenfor den faste høyden på portalen
- `Sidebar`: fjernet overflødig `position: sticky` (ingen effekt inne i et grid med fast høyde)
- `Sidebar`-wrapper: la til `max-height` på det kollapsible wrapper-elementet
- `Sidebar` collapse-toggle: rettet feil fargetoken (`--text-dark` → `--basecolors-stroke-light`)

**Refaktorering:**
- Alle hardkodede fallback-verdier i `var(--custom-prop, fallback)` er trukket ut til navngitte `$default-*` SCSS-variabler i en ny delt `_variables.scss`-fil

## 🧩 Type endring

- [x] 🐞 Feilretting
- [x] 🧹 Refaktorering (ingen funksjonelle endringer)

## 🖼️ Skjermbilder

<!-- Ikke aktuelt for SCSS-endringer -->

## 💬 Tilleggsnotater

`_variables.scss` ligger i `packages/layout/src/beta/templates/` og brukes av både `Sidebar.scss` og `portal/Portal.scss`.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden