### PR TITLE
feat(root): add PostHog export to design system usage scanner

### DIFF
--- a/.github/workflows/design-system-usage-scan.yml
+++ b/.github/workflows/design-system-usage-scan.yml
@@ -190,6 +190,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+      POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}
     steps:
       - name: Checkout design-system repository
         uses: actions/checkout@v5
@@ -227,9 +230,6 @@ jobs:
       - name: Export to PostHog
         if: ${{ env.POSTHOG_API_KEY != '' }}
         working-directory: tools/design-system-scanner
-        env:
-          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}
         run: node dist/index.js --posthog-export scan-report.json
 
       - name: Generate catalog

--- a/.github/workflows/design-system-usage-scan.yml
+++ b/.github/workflows/design-system-usage-scan.yml
@@ -179,9 +179,9 @@ jobs:
           path: tools/design-system-scanner/scan-result.json
           retention-days: 1
 
-  # Step 3: Aggregate all results and load into BigQuery
+  # Step 3: Aggregate all results and export data (PostHog + BigQuery)
   aggregate:
-    name: Aggregate results and load into BigQuery
+    name: Aggregate results and export data
     needs: [discover, scan-repo]
     if: always() && needs.discover.result == 'success'
     runs-on: ubuntu-latest

--- a/.github/workflows/design-system-usage-scan.yml
+++ b/.github/workflows/design-system-usage-scan.yml
@@ -224,6 +224,14 @@ jobs:
           path: tools/design-system-scanner/scan-report.json
           retention-days: 90
 
+      - name: Export to PostHog
+        if: ${{ env.POSTHOG_API_KEY != '' }}
+        working-directory: tools/design-system-scanner
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST || 'https://eu.i.posthog.com' }}
+        run: node dist/index.js --posthog-export scan-report.json
+
       - name: Generate catalog
         working-directory: tools/design-system-scanner
         run: yarn workspace @entur/design-system-scanner generate-catalog

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -14,7 +14,6 @@
     "no-unused-vars": ["warn", { "ignoreRestSiblings": true }],
     "no-unused-expressions": "off",
 
-    "react/prop-types": "off",
     "react/display-name": "off",
     "react/no-unknown-property": "off",
     "react/react-in-jsx-scope": "off",
@@ -29,7 +28,6 @@
     "import/namespace": "off",
     "import/no-named-as-default": "off",
     "import/no-named-as-default-member": "off",
-    "import/order": "off",
     "sort-imports": [
       "warn",
       { "ignoreDeclarationSort": true, "ignoreMemberSort": false }

--- a/tools/design-system-scanner/README.md
+++ b/tools/design-system-scanner/README.md
@@ -41,6 +41,12 @@ yarn start --bigquery-export scan-report.json --output ./bq-export/
 
 # Export with catalog for unused symbol detection
 yarn start --bigquery-export scan-report.json --catalog catalog.json --output ./bq-export/
+
+# Send scan results to PostHog (dry-run)
+yarn start --posthog-export scan-report.json --posthog-dry-run
+
+# Send scan results to PostHog
+POSTHOG_API_KEY=phc_xxx yarn start --posthog-export scan-report.json
 ```
 
 ## CLI reference
@@ -52,6 +58,7 @@ yarn start --bigquery-export scan-report.json --catalog catalog.json --output ./
 | `--local <path>`           | Scan a single local repository               |
 | `--aggregate <path>`       | Merge per-repo JSON results from a directory |
 | `--bigquery-export <path>` | Export a scan report as NDJSON for BigQuery  |
+| `--posthog-export <path>`  | Send a scan report as events to PostHog      |
 
 ### Options
 
@@ -69,7 +76,47 @@ yarn start --bigquery-export scan-report.json --catalog catalog.json --output ./
 | `--primary-language <lang>` | Primary language from GitHub                          |
 | `--created-at <iso-date>`   | Repo creation date                                    |
 | `--include-file-findings`   | Collect per-file findings for drilldown               |
+| `--posthog-export <path>`   | Path to scan-report.json to send to PostHog           |
+| `--posthog-dry-run`         | Print PostHog events as JSON, don't send              |
+| `--posthog-host <url>`      | PostHog host (default: `https://eu.i.posthog.com`)    |
+| `--posthog-key <key>`       | PostHog API key (default: `POSTHOG_API_KEY` env var)  |
 | `--help, -h`                | Show help                                             |
+
+## PostHog export
+
+The scanner can send usage data to [PostHog](https://posthog.com) for product analytics dashboards.
+
+### Setup
+
+Add `POSTHOG_API_KEY` as a GitHub Actions secret in the repository settings. Optionally set `POSTHOG_HOST` as a variable (defaults to `https://eu.i.posthog.com`).
+
+### Local usage
+
+```bash
+# Dry-run: print all events as JSON without sending (no API key needed)
+yarn start --posthog-export scan-report.json --posthog-dry-run
+
+# Send to PostHog
+POSTHOG_API_KEY=phc_xxx yarn start --posthog-export scan-report.json
+
+# Custom host
+POSTHOG_API_KEY=phc_xxx yarn start --posthog-export scan-report.json --posthog-host https://app.posthog.com
+```
+
+### Events
+
+| Event               | One per                       | Key properties                                                                           |
+| ------------------- | ----------------------------- | ---------------------------------------------------------------------------------------- |
+| `ds_scan_run`       | scan execution                | `total_repos_scanned`, `repos_with_usage`, `scan_status`, `scanner_version`              |
+| `ds_repo_scanned`   | repository                    | `visibility`, `framework`, `is_monorepo`, `ds_package_count`, `component_instance_count` |
+| `ds_package_used`   | (repo, `@entur/*` package)    | `package_name`, `version`, `resolved_version`, `is_imported`, `symbol_count_used`        |
+| `ds_component_used` | (repo, JSX component)         | `component_name`, `package_name`, `instance_count`, `file_count`, `props_spread_count`   |
+| `ds_symbol_used`    | (repo, non-JSX symbol)        | `symbol_name`, `symbol_type`, `reference_count`, `files_used_in`                         |
+| `ds_css_override`   | (repo, `.eds-*` CSS override) | `selector`, `file_path`, `line_number`, `file_extension`                                 |
+
+Events use PostHog Group Analytics with `repo`, `ds_package`, `ds_component`, and `ds_symbol` groups, enabling dashboard breakdowns by e.g. "which packages are used in the most repos" or "repos using PrimaryButton".
+
+Timestamps are set to the scan's `timestamp` (not the send time), so weekly scans attribute data to the correct date.
 
 ## BigQuery output format
 

--- a/tools/design-system-scanner/package.json
+++ b/tools/design-system-scanner/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
     "js-yaml": "^4.1.0",
+    "posthog-node": "^4.18.0",
     "react-scanner": "1.1.0",
     "typescript": "^5.9.0-beta"
   },

--- a/tools/design-system-scanner/src/export/posthogClient.test.ts
+++ b/tools/design-system-scanner/src/export/posthogClient.test.ts
@@ -380,6 +380,39 @@ describe('sendScanReport', () => {
 
     expect(count).toBe(events.length);
   });
+
+  it('flushes in batches when client supports flush', async () => {
+    let flushCount = 0;
+    const mockClient = {
+      capture: jest.fn(),
+      groupIdentify: jest.fn(),
+      flush: jest.fn().mockImplementation(async () => {
+        flushCount++;
+      }),
+    };
+
+    await sendScanReport(FIXTURE_REPORT, {
+      client: mockClient,
+      scannerVersion: '0.2.0',
+      flushBatchSize: 3,
+    });
+
+    // With small batch size, should flush multiple times
+    expect(flushCount).toBeGreaterThan(0);
+    expect(mockClient.flush).toHaveBeenCalled();
+  });
+
+  it('works without flush when client does not support it', async () => {
+    const mockClient = { capture: jest.fn(), groupIdentify: jest.fn() };
+
+    // Should not throw even without flush method
+    const count = await sendScanReport(FIXTURE_REPORT, {
+      client: mockClient,
+      scannerVersion: '0.2.0',
+    });
+
+    expect(count).toBeGreaterThan(0);
+  });
 });
 
 describe('createDryRunClient', () => {

--- a/tools/design-system-scanner/src/export/posthogClient.test.ts
+++ b/tools/design-system-scanner/src/export/posthogClient.test.ts
@@ -1,0 +1,418 @@
+import {
+  buildScanEvents,
+  buildGroupIdentifies,
+  sendScanReport,
+  createDryRunClient,
+} from './posthogClient';
+import type { ScanReport } from '../types';
+
+const FIXED_TS = '2025-01-06T06:00:00.000Z';
+
+const FIXTURE_REPORT: ScanReport = {
+  timestamp: FIXED_TS,
+  source: 'github-actions',
+  scanRun: {
+    scanId: 'test-scan-id',
+    scanTimestamp: FIXED_TS,
+    scannerVersion: '0.2.0',
+    totalReposDiscovered: 2,
+    totalReposScanned: 2,
+    totalReposFailed: 0,
+    scanStatus: 'success',
+  },
+  totalReposScanned: 2,
+  reposWithUsage: 1,
+  limitations: [],
+  repositories: [
+    {
+      name: 'entur/my-app',
+      url: 'https://github.com/entur/my-app',
+      defaultBranch: 'main',
+      lastCommitDate: '2025-01-05T12:00:00.000Z',
+      repoMetadata: {
+        visibility: 'internal',
+        archived: false,
+        primaryLanguage: 'TypeScript',
+        createdAt: '2020-01-01T00:00:00.000Z',
+        pushedAt: '2025-01-05T12:00:00.000Z',
+        isMonorepo: false,
+        framework: 'next',
+      },
+      workspaces: [],
+      designSystemPackages: [
+        {
+          name: '@entur/button',
+          version: '^4.0.0',
+          resolvedVersion: '4.0.5',
+          isDev: false,
+          isImported: true,
+          filesImportingCount: 3,
+          symbolCountUsed: 2,
+        },
+        {
+          name: '@entur/tokens',
+          version: '^3.0.0',
+          resolvedVersion: undefined,
+          isDev: false,
+          isImported: true,
+          filesImportingCount: 5,
+          symbolCountUsed: 1,
+        },
+      ],
+      otherUILibraries: [],
+      componentUsage: [
+        {
+          packageName: '@entur/button',
+          componentName: 'PrimaryButton',
+          instanceCount: 7,
+          props: { onClick: 3, disabled: 1 },
+          propsSpreadCount: 0,
+          files: ['src/App.tsx', 'src/Header.tsx'],
+          importStyle: 'named',
+          isAliased: false,
+        },
+      ],
+      importUsage: [
+        {
+          packageName: '@entur/tokens',
+          symbolName: 'colors',
+          symbolType: 'token',
+          importStyle: 'named',
+          isAliased: false,
+          referenceCount: 4,
+          filesUsedIn: 2,
+        },
+      ],
+      cssOverrides: [
+        {
+          selector: '.eds-primary-button',
+          filePath: 'src/styles/overrides.scss',
+          lineNumber: 12,
+          fileExtension: '.scss',
+        },
+      ],
+      fileFindings: undefined,
+    },
+    {
+      name: 'entur/no-ds-app',
+      url: 'https://github.com/entur/no-ds-app',
+      defaultBranch: 'main',
+      lastCommitDate: '2025-01-04T10:00:00.000Z',
+      workspaces: [],
+      designSystemPackages: [],
+      otherUILibraries: [],
+      componentUsage: [],
+      importUsage: [],
+      cssOverrides: [],
+    },
+  ],
+};
+
+describe('buildScanEvents', () => {
+  it('emits exactly one ds_scan_run event', () => {
+    const events = buildScanEvents(FIXTURE_REPORT, { scannerVersion: '0.2.0' });
+    const scanRunEvents = events.filter(e => e.event === 'ds_scan_run');
+    expect(scanRunEvents).toHaveLength(1);
+  });
+
+  it('ds_scan_run has correct properties', () => {
+    const events = buildScanEvents(FIXTURE_REPORT, { scannerVersion: '0.2.0' });
+    const scanRun = events.find(e => e.event === 'ds_scan_run')!;
+
+    expect(scanRun.distinctId).toBe('scan-run:test-scan-id');
+    expect(scanRun.properties.total_repos_scanned).toBe(2);
+    expect(scanRun.properties.repos_with_usage).toBe(1);
+    expect(scanRun.properties.scanner_version).toBe('0.2.0');
+    expect(scanRun.properties.source).toBe('github-actions');
+    expect(scanRun.properties.scan_status).toBe('success');
+    expect(scanRun.properties.$timestamp).toBe(FIXED_TS);
+  });
+
+  it('emits one ds_repo_scanned per repository', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const repoEvents = events.filter(e => e.event === 'ds_repo_scanned');
+    expect(repoEvents).toHaveLength(2);
+  });
+
+  it('ds_repo_scanned distinctId is stable repo:<name> for weekly timelines', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const repoEvent = events.find(
+      e =>
+        e.event === 'ds_repo_scanned' &&
+        e.properties.repo_name === 'entur/my-app',
+    )!;
+    expect(repoEvent.distinctId).toBe('repo:entur/my-app');
+  });
+
+  it('ds_repo_scanned includes repoMetadata fields', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const repoEvent = events.find(
+      e =>
+        e.event === 'ds_repo_scanned' &&
+        e.properties.repo_name === 'entur/my-app',
+    )!;
+
+    expect(repoEvent.properties.visibility).toBe('internal');
+    expect(repoEvent.properties.archived).toBe(false);
+    expect(repoEvent.properties.framework).toBe('next');
+    expect(repoEvent.properties.primary_language).toBe('TypeScript');
+    expect(repoEvent.properties.is_monorepo).toBe(false);
+  });
+
+  it('ds_repo_scanned includes usage counts', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const repoEvent = events.find(
+      e =>
+        e.event === 'ds_repo_scanned' &&
+        e.properties.repo_name === 'entur/my-app',
+    )!;
+
+    expect(repoEvent.properties.ds_package_count).toBe(2);
+    expect(repoEvent.properties.component_instance_count).toBe(7);
+    expect(repoEvent.properties.import_usage_count).toBe(1);
+    expect(repoEvent.properties.css_override_count).toBe(1);
+    expect(repoEvent.properties.workspace_count).toBe(0);
+  });
+
+  it('emits one ds_package_used per design system package', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const pkgEvents = events.filter(e => e.event === 'ds_package_used');
+    expect(pkgEvents).toHaveLength(2);
+  });
+
+  it('ds_package_used has correct distinctId and properties', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const pkgEvent = events.find(
+      e =>
+        e.event === 'ds_package_used' &&
+        e.properties.package_name === '@entur/button',
+    )!;
+
+    expect(pkgEvent.distinctId).toBe('repo:entur/my-app:package:@entur/button');
+    expect(pkgEvent.properties.version).toBe('^4.0.0');
+    expect(pkgEvent.properties.resolved_version).toBe('4.0.5');
+    expect(pkgEvent.properties.is_dev).toBe(false);
+    expect(pkgEvent.properties.is_imported).toBe(true);
+    expect(pkgEvent.properties.files_importing_count).toBe(3);
+    expect(pkgEvent.properties.symbol_count_used).toBe(2);
+  });
+
+  it('ds_package_used resolved_version is null when undefined', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const pkgEvent = events.find(
+      e =>
+        e.event === 'ds_package_used' &&
+        e.properties.package_name === '@entur/tokens',
+    )!;
+    expect(pkgEvent.properties.resolved_version).toBeNull();
+  });
+
+  it('emits one ds_component_used per component', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const compEvents = events.filter(e => e.event === 'ds_component_used');
+    expect(compEvents).toHaveLength(1);
+  });
+
+  it('ds_component_used has correct properties', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const compEvent = events.find(e => e.event === 'ds_component_used')!;
+
+    expect(compEvent.distinctId).toBe(
+      'repo:entur/my-app:component:@entur/button::PrimaryButton',
+    );
+    expect(compEvent.properties.package_name).toBe('@entur/button');
+    expect(compEvent.properties.component_name).toBe('PrimaryButton');
+    expect(compEvent.properties.instance_count).toBe(7);
+    expect(compEvent.properties.file_count).toBe(2);
+    expect(compEvent.properties.import_style).toBe('named');
+    expect(compEvent.properties.is_aliased).toBe(false);
+    expect(compEvent.properties.props_spread_count).toBe(0);
+  });
+
+  it('emits one ds_symbol_used per import usage', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const symbolEvents = events.filter(e => e.event === 'ds_symbol_used');
+    expect(symbolEvents).toHaveLength(1);
+  });
+
+  it('ds_symbol_used has correct properties', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const symbolEvent = events.find(e => e.event === 'ds_symbol_used')!;
+
+    expect(symbolEvent.distinctId).toBe(
+      'repo:entur/my-app:symbol:@entur/tokens::colors',
+    );
+    expect(symbolEvent.properties.package_name).toBe('@entur/tokens');
+    expect(symbolEvent.properties.symbol_name).toBe('colors');
+    expect(symbolEvent.properties.symbol_type).toBe('token');
+    expect(symbolEvent.properties.reference_count).toBe(4);
+    expect(symbolEvent.properties.files_used_in).toBe(2);
+    expect(symbolEvent.properties.import_style).toBe('named');
+  });
+
+  it('emits one ds_css_override per override finding', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const overrideEvents = events.filter(e => e.event === 'ds_css_override');
+    expect(overrideEvents).toHaveLength(1);
+  });
+
+  it('ds_css_override has correct properties', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const overrideEvent = events.find(e => e.event === 'ds_css_override')!;
+
+    expect(overrideEvent.distinctId).toBe(
+      'repo:entur/my-app:css:src/styles/overrides.scss:12',
+    );
+    expect(overrideEvent.properties.selector).toBe('.eds-primary-button');
+    expect(overrideEvent.properties.file_path).toBe(
+      'src/styles/overrides.scss',
+    );
+    expect(overrideEvent.properties.line_number).toBe(12);
+    expect(overrideEvent.properties.file_extension).toBe('.scss');
+  });
+
+  it('all events have $timestamp set to report.timestamp', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    for (const event of events) {
+      expect(event.properties.$timestamp).toBe(FIXED_TS);
+    }
+  });
+
+  it('repo with no usage emits only ds_repo_scanned (no package/component/override events)', () => {
+    const events = buildScanEvents(FIXTURE_REPORT);
+    const noAppEvents = events.filter(
+      e =>
+        e.properties.repo_name === 'entur/no-ds-app' &&
+        e.event !== 'ds_repo_scanned',
+    );
+    expect(noAppEvents).toHaveLength(0);
+  });
+});
+
+describe('buildGroupIdentifies', () => {
+  it('creates one repo group per repository', () => {
+    const identifies = buildGroupIdentifies(FIXTURE_REPORT);
+    const repoGroups = identifies.filter(i => i.groupType === 'repo');
+    expect(repoGroups).toHaveLength(2);
+  });
+
+  it('repo group includes metadata properties', () => {
+    const identifies = buildGroupIdentifies(FIXTURE_REPORT);
+    const repoGroup = identifies.find(
+      i => i.groupType === 'repo' && i.groupKey === 'entur/my-app',
+    )!;
+
+    expect(repoGroup.properties.name).toBe('entur/my-app');
+    expect(repoGroup.properties.visibility).toBe('internal');
+    expect(repoGroup.properties.framework).toBe('next');
+  });
+
+  it('creates ds_package groups deduplicated across repos', () => {
+    // both repos share no packages, so should have 2 (button + tokens)
+    const identifies = buildGroupIdentifies(FIXTURE_REPORT);
+    const pkgGroups = identifies.filter(i => i.groupType === 'ds_package');
+    expect(pkgGroups).toHaveLength(2);
+  });
+
+  it('deduplicates packages when same package appears in multiple repos', () => {
+    const reportWithDupe: ScanReport = {
+      ...FIXTURE_REPORT,
+      repositories: [
+        FIXTURE_REPORT.repositories[0],
+        {
+          ...FIXTURE_REPORT.repositories[0],
+          name: 'entur/another-app',
+          url: 'https://github.com/entur/another-app',
+        },
+      ],
+    };
+
+    const identifies = buildGroupIdentifies(reportWithDupe);
+    const pkgGroups = identifies.filter(i => i.groupType === 'ds_package');
+    const pkgKeys = pkgGroups.map(g => g.groupKey);
+    const uniqueKeys = new Set(pkgKeys);
+    expect(pkgKeys.length).toBe(uniqueKeys.size);
+  });
+
+  it('creates ds_component groups', () => {
+    const identifies = buildGroupIdentifies(FIXTURE_REPORT);
+    const compGroups = identifies.filter(i => i.groupType === 'ds_component');
+    expect(compGroups).toHaveLength(1);
+    expect(compGroups[0].groupKey).toBe('@entur/button::PrimaryButton');
+  });
+
+  it('creates ds_symbol groups', () => {
+    const identifies = buildGroupIdentifies(FIXTURE_REPORT);
+    const symbolGroups = identifies.filter(i => i.groupType === 'ds_symbol');
+    expect(symbolGroups).toHaveLength(1);
+    expect(symbolGroups[0].groupKey).toBe('@entur/tokens::colors');
+  });
+});
+
+describe('sendScanReport', () => {
+  it('calls capture for each event and groupIdentify for each group', async () => {
+    const capturedEvents: unknown[] = [];
+    const capturedGroups: unknown[] = [];
+
+    const mockClient = {
+      capture: (payload: unknown) => capturedEvents.push(payload),
+      groupIdentify: (payload: unknown) => capturedGroups.push(payload),
+    };
+
+    const count = await sendScanReport(FIXTURE_REPORT, {
+      client: mockClient,
+      scannerVersion: '0.2.0',
+    });
+
+    expect(count).toBeGreaterThan(0);
+    expect(capturedEvents.length).toBe(count);
+    expect(capturedGroups.length).toBeGreaterThan(0);
+  });
+
+  it('returns the number of events sent', async () => {
+    const events = buildScanEvents(FIXTURE_REPORT, { scannerVersion: '0.2.0' });
+    const mockClient = { capture: jest.fn(), groupIdentify: jest.fn() };
+
+    const count = await sendScanReport(FIXTURE_REPORT, {
+      client: mockClient,
+      scannerVersion: '0.2.0',
+    });
+
+    expect(count).toBe(events.length);
+  });
+});
+
+describe('createDryRunClient', () => {
+  it('routes capture events through the sink', () => {
+    const lines: string[] = [];
+    const client = createDryRunClient(line => lines.push(line));
+
+    client.capture({
+      distinctId: 'test-id',
+      event: 'ds_scan_run',
+      properties: { foo: 'bar' },
+    });
+
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.type).toBe('capture');
+    expect(parsed.event).toBe('ds_scan_run');
+    expect(parsed.properties.foo).toBe('bar');
+  });
+
+  it('routes groupIdentify calls through the sink', () => {
+    const lines: string[] = [];
+    const client = createDryRunClient(line => lines.push(line));
+
+    client.groupIdentify({
+      groupType: 'repo',
+      groupKey: 'entur/test',
+      properties: { name: 'entur/test' },
+    });
+
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.type).toBe('groupIdentify');
+    expect(parsed.groupType).toBe('repo');
+  });
+});

--- a/tools/design-system-scanner/src/export/posthogClient.ts
+++ b/tools/design-system-scanner/src/export/posthogClient.ts
@@ -26,6 +26,7 @@ import type {
 export interface PostHogLike {
   capture(payload: CapturePayload): void;
   groupIdentify(payload: GroupIdentifyPayload): void;
+  flush?(): Promise<void>;
 }
 
 export interface CapturePayload {
@@ -162,25 +163,54 @@ export function buildGroupIdentifies(
 export interface SendScanReportOptions {
   client: PostHogLike;
   scannerVersion?: string;
+  /**
+   * Flush the client every N calls (group identifies + captures combined).
+   * Prevents posthog-node's internal queue from overflowing on large scans.
+   * Default: 500.
+   */
+  flushBatchSize?: number;
 }
 
 /**
  * Send a scan report to PostHog. Returns the number of events sent.
+ *
+ * Flushes in batches to avoid overwhelming posthog-node's internal queue,
+ * which defaults to maxQueueSize=1000. Without batched flushing, large scans
+ * (85+ repos) silently drop events that exceed the queue.
  */
 export async function sendScanReport(
   report: ScanReport,
   opts: SendScanReportOptions,
 ): Promise<number> {
-  const { client, scannerVersion } = opts;
+  const { client, scannerVersion, flushBatchSize = 500 } = opts;
+  const canFlush = typeof client.flush === 'function';
+
+  let pending = 0;
+
+  async function flushIfNeeded(): Promise<void> {
+    if (canFlush && pending >= flushBatchSize) {
+      await client.flush!();
+      pending = 0;
+    }
+  }
 
   const identifies = buildGroupIdentifies(report);
   for (const id of identifies) {
     client.groupIdentify(id);
+    pending++;
+    await flushIfNeeded();
   }
 
   const events = buildScanEvents(report, { scannerVersion });
   for (const event of events) {
     client.capture(event);
+    pending++;
+    await flushIfNeeded();
+  }
+
+  // Final flush for any remaining events
+  if (canFlush && pending > 0) {
+    await client.flush!();
   }
 
   return events.length;

--- a/tools/design-system-scanner/src/export/posthogClient.ts
+++ b/tools/design-system-scanner/src/export/posthogClient.ts
@@ -1,0 +1,363 @@
+/**
+ * PostHog export client for the design system usage scanner.
+ *
+ * Provides a pure `buildScanEvents` function for testing, and a `sendScanReport`
+ * function that drives a PostHog client (or test double) to emit events.
+ *
+ * Events emitted per scan:
+ *   ds_scan_run         — one per scan execution
+ *   ds_repo_scanned     — one per repository (stable distinctId for weekly timelines)
+ *   ds_package_used     — one per (repo, @entur/* package)
+ *   ds_component_used   — one per (repo, JSX component) from react-scanner
+ *   ds_symbol_used      — one per (repo, non-JSX symbol) from import analyzer
+ *   ds_css_override     — one per (repo, .eds-* CSS override)
+ */
+
+import type {
+  ScanReport,
+  RepositoryUsage,
+  ComponentUsage,
+  ImportUsage,
+  CssOverrideFinding,
+  PackageUsage,
+} from '../types';
+
+/** Minimal PostHog client interface — satisfied by posthog-node and the dry-run double. */
+export interface PostHogLike {
+  capture(payload: CapturePayload): void;
+  groupIdentify(payload: GroupIdentifyPayload): void;
+}
+
+export interface CapturePayload {
+  distinctId: string;
+  event: string;
+  properties: Record<string, unknown>;
+}
+
+export interface GroupIdentifyPayload {
+  groupType: string;
+  groupKey: string;
+  properties: Record<string, unknown>;
+}
+
+const DEFAULT_POSTHOG_HOST = 'https://eu.i.posthog.com';
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Build all PostHog capture payloads for a scan report without sending them.
+ * Useful for tests and dry-run validation.
+ */
+export function buildScanEvents(
+  report: ScanReport,
+  opts: { scannerVersion?: string } = {},
+): CapturePayload[] {
+  const scannerVersion = opts.scannerVersion ?? 'unknown';
+  const events: CapturePayload[] = [];
+
+  const scanId = report.scanRun?.scanId ?? 'scan-unknown';
+  const ts = report.timestamp;
+
+  // ds_scan_run — one per execution
+  events.push({
+    distinctId: `scan-run:${scanId}`,
+    event: 'ds_scan_run',
+    properties: {
+      $timestamp: ts,
+      scan_id: scanId,
+      total_repos_scanned: report.totalReposScanned,
+      repos_with_usage: report.reposWithUsage,
+      scanner_version: scannerVersion,
+      source: report.source,
+      scan_status: report.scanRun?.scanStatus ?? 'success',
+    },
+  });
+
+  for (const repo of report.repositories) {
+    events.push(...buildRepoEvents(repo, ts));
+  }
+
+  return events;
+}
+
+/**
+ * Build all group identify payloads for a scan report.
+ * Deduplicates packages across repos.
+ */
+export function buildGroupIdentifies(
+  report: ScanReport,
+): GroupIdentifyPayload[] {
+  const identifies: GroupIdentifyPayload[] = [];
+  const seenPackages = new Set<string>();
+  const seenComponents = new Set<string>();
+  const seenSymbols = new Set<string>();
+
+  for (const repo of report.repositories) {
+    // Repo group
+    identifies.push({
+      groupType: 'repo',
+      groupKey: repo.name,
+      properties: {
+        name: repo.name,
+        url: repo.url,
+        default_branch: repo.defaultBranch,
+        last_commit_date: repo.lastCommitDate,
+        visibility: repo.repoMetadata?.visibility ?? null,
+        archived: repo.repoMetadata?.archived ?? false,
+        framework: repo.repoMetadata?.framework ?? null,
+        primary_language: repo.repoMetadata?.primaryLanguage ?? null,
+        is_monorepo: repo.repoMetadata?.isMonorepo ?? false,
+      },
+    });
+
+    // Package groups (deduplicated)
+    for (const pkg of repo.designSystemPackages) {
+      if (!seenPackages.has(pkg.name)) {
+        seenPackages.add(pkg.name);
+        identifies.push({
+          groupType: 'ds_package',
+          groupKey: pkg.name,
+          properties: { name: pkg.name },
+        });
+      }
+    }
+
+    // Component groups (deduplicated across repos)
+    for (const comp of repo.componentUsage) {
+      const key = `${comp.packageName}::${comp.componentName}`;
+      if (!seenComponents.has(key)) {
+        seenComponents.add(key);
+        identifies.push({
+          groupType: 'ds_component',
+          groupKey: key,
+          properties: {
+            package_name: comp.packageName,
+            component_name: comp.componentName,
+          },
+        });
+      }
+    }
+
+    // Symbol groups (deduplicated)
+    for (const imp of repo.importUsage) {
+      const key = `${imp.packageName}::${imp.symbolName}`;
+      if (!seenSymbols.has(key)) {
+        seenSymbols.add(key);
+        identifies.push({
+          groupType: 'ds_symbol',
+          groupKey: key,
+          properties: {
+            package_name: imp.packageName,
+            symbol_name: imp.symbolName,
+            symbol_type: imp.symbolType,
+          },
+        });
+      }
+    }
+  }
+
+  return identifies;
+}
+
+export interface SendScanReportOptions {
+  client: PostHogLike;
+  scannerVersion?: string;
+}
+
+/**
+ * Send a scan report to PostHog. Returns the number of events sent.
+ */
+export async function sendScanReport(
+  report: ScanReport,
+  opts: SendScanReportOptions,
+): Promise<number> {
+  const { client, scannerVersion } = opts;
+
+  const identifies = buildGroupIdentifies(report);
+  for (const id of identifies) {
+    client.groupIdentify(id);
+  }
+
+  const events = buildScanEvents(report, { scannerVersion });
+  for (const event of events) {
+    client.capture(event);
+  }
+
+  return events.length;
+}
+
+/**
+ * Create a dry-run PostHog client that prints events as JSON to a sink function.
+ * Useful for local testing without an API key.
+ */
+export function createDryRunClient(
+  sink: (line: string) => void = line => console.log(line),
+): PostHogLike {
+  return {
+    capture(payload: CapturePayload): void {
+      sink(JSON.stringify({ type: 'capture', ...payload }));
+    },
+    groupIdentify(payload: GroupIdentifyPayload): void {
+      sink(JSON.stringify({ type: 'groupIdentify', ...payload }));
+    },
+  };
+}
+
+/** Exported for documentation — default host used when POSTHOG_HOST is unset. */
+export { DEFAULT_POSTHOG_HOST };
+
+// ── Internal builders ───────────────────────────────────────────────────────
+
+function buildRepoEvents(repo: RepositoryUsage, ts: string): CapturePayload[] {
+  const events: CapturePayload[] = [];
+  const repoId = `repo:${repo.name}`;
+
+  // ds_repo_scanned — stable distinctId so weekly scans stitch into a timeline
+  events.push({
+    distinctId: repoId,
+    event: 'ds_repo_scanned',
+    properties: {
+      $timestamp: ts,
+      $groups: { repo: repo.name },
+      repo_name: repo.name,
+      url: repo.url,
+      default_branch: repo.defaultBranch,
+      last_commit_date: repo.lastCommitDate,
+      visibility: repo.repoMetadata?.visibility ?? null,
+      archived: repo.repoMetadata?.archived ?? false,
+      framework: repo.repoMetadata?.framework ?? null,
+      primary_language: repo.repoMetadata?.primaryLanguage ?? null,
+      is_monorepo: repo.repoMetadata?.isMonorepo ?? false,
+      workspace_count: repo.workspaces.length,
+      ds_package_count: repo.designSystemPackages.length,
+      component_instance_count: repo.componentUsage.reduce(
+        (sum, c) => sum + c.instanceCount,
+        0,
+      ),
+      import_usage_count: repo.importUsage.length,
+      css_override_count: (repo.cssOverrides ?? []).length,
+    },
+  });
+
+  // ds_package_used — one per @entur/* package
+  for (const pkg of repo.designSystemPackages) {
+    events.push(buildPackageEvent(repo.name, pkg, ts));
+  }
+
+  // ds_component_used — one per JSX component (react-scanner)
+  for (const comp of repo.componentUsage) {
+    events.push(buildComponentEvent(repo.name, comp, ts));
+  }
+
+  // ds_symbol_used — one per non-JSX import (import analyzer)
+  for (const imp of repo.importUsage) {
+    events.push(buildSymbolEvent(repo.name, imp, ts));
+  }
+
+  // ds_css_override — one per .eds-* override finding
+  for (const override of repo.cssOverrides ?? []) {
+    events.push(buildCssOverrideEvent(repo.name, override, ts));
+  }
+
+  return events;
+}
+
+function buildPackageEvent(
+  repoName: string,
+  pkg: PackageUsage,
+  ts: string,
+): CapturePayload {
+  return {
+    distinctId: `repo:${repoName}:package:${pkg.name}`,
+    event: 'ds_package_used',
+    properties: {
+      $timestamp: ts,
+      $groups: { repo: repoName, ds_package: pkg.name },
+      repo_name: repoName,
+      package_name: pkg.name,
+      version: pkg.version,
+      resolved_version: pkg.resolvedVersion ?? null,
+      is_dev: pkg.isDev,
+      is_imported: pkg.isImported,
+      files_importing_count: pkg.filesImportingCount,
+      symbol_count_used: pkg.symbolCountUsed,
+    },
+  };
+}
+
+function buildComponentEvent(
+  repoName: string,
+  comp: ComponentUsage,
+  ts: string,
+): CapturePayload {
+  const groupKey = `${comp.packageName}::${comp.componentName}`;
+  return {
+    distinctId: `repo:${repoName}:component:${groupKey}`,
+    event: 'ds_component_used',
+    properties: {
+      $timestamp: ts,
+      $groups: {
+        repo: repoName,
+        ds_package: comp.packageName,
+        ds_component: groupKey,
+      },
+      repo_name: repoName,
+      package_name: comp.packageName,
+      component_name: comp.componentName,
+      instance_count: comp.instanceCount,
+      file_count: comp.files.length,
+      import_style: comp.importStyle,
+      is_aliased: comp.isAliased,
+      deep_import_path: comp.deepImportPath ?? null,
+      props_spread_count: comp.propsSpreadCount,
+    },
+  };
+}
+
+function buildSymbolEvent(
+  repoName: string,
+  imp: ImportUsage,
+  ts: string,
+): CapturePayload {
+  const groupKey = `${imp.packageName}::${imp.symbolName}`;
+  return {
+    distinctId: `repo:${repoName}:symbol:${groupKey}`,
+    event: 'ds_symbol_used',
+    properties: {
+      $timestamp: ts,
+      $groups: {
+        repo: repoName,
+        ds_package: imp.packageName,
+        ds_symbol: groupKey,
+      },
+      repo_name: repoName,
+      package_name: imp.packageName,
+      symbol_name: imp.symbolName,
+      symbol_type: imp.symbolType,
+      reference_count: imp.referenceCount,
+      files_used_in: imp.filesUsedIn,
+      import_style: imp.importStyle,
+      is_aliased: imp.isAliased,
+    },
+  };
+}
+
+function buildCssOverrideEvent(
+  repoName: string,
+  override: CssOverrideFinding,
+  ts: string,
+): CapturePayload {
+  return {
+    distinctId: `repo:${repoName}:css:${override.filePath}:${override.lineNumber}`,
+    event: 'ds_css_override',
+    properties: {
+      $timestamp: ts,
+      $groups: { repo: repoName },
+      repo_name: repoName,
+      selector: override.selector,
+      file_path: override.filePath,
+      line_number: override.lineNumber,
+      file_extension: override.fileExtension,
+    },
+  };
+}

--- a/tools/design-system-scanner/src/index.ts
+++ b/tools/design-system-scanner/src/index.ts
@@ -643,14 +643,22 @@ async function exportToPostHog(args: ParsedArgs): Promise<void> {
   }
 
   const { PostHog } = await import('posthog-node');
-  const client = new PostHog(apiKey, { host });
+  const client = new PostHog(apiKey, {
+    host,
+    // Raise limits to handle large scans (85+ repos → thousands of events).
+    // Defaults (flushAt=20, maxQueueSize=1000) cause silent drops.
+    flushAt: 200,
+    maxQueueSize: 10000,
+    maxBatchSize: 500,
+  });
 
   const count = await sendScanReport(report, {
     client: client as unknown as PostHogLike,
     scannerVersion: SCANNER_VERSION,
   });
 
-  await client.shutdown();
+  // Give PostHog 60s to flush remaining events (default is 30s)
+  await client.shutdown(60_000);
   console.log(`Sent ${count} events to PostHog at ${host}`);
 }
 

--- a/tools/design-system-scanner/src/index.ts
+++ b/tools/design-system-scanner/src/index.ts
@@ -3,6 +3,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { scanRepository } from './scanner';
+import type { PostHogLike } from './export/posthogClient';
 import type {
   ScanReport,
   ScanRunMetadata,
@@ -615,7 +616,7 @@ async function exportToPostHog(args: ParsedArgs): Promise<void> {
 
   const report: ScanReport = JSON.parse(fs.readFileSync(reportPath, 'utf-8'));
   const { sendScanReport, createDryRunClient, DEFAULT_POSTHOG_HOST } =
-    await import('./export/posthogClient');
+    await import('./export/posthogClient.js');
 
   const host =
     args.posthogHost ?? process.env.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST;
@@ -642,14 +643,10 @@ async function exportToPostHog(args: ParsedArgs): Promise<void> {
   }
 
   const { PostHog } = await import('posthog-node');
-  const client = new PostHog(apiKey, {
-    host,
-    flushAt: 1,
-    flushInterval: 0,
-  });
+  const client = new PostHog(apiKey, { host });
 
   const count = await sendScanReport(report, {
-    client: client as unknown as Parameters<typeof sendScanReport>[1]['client'],
+    client: client as unknown as PostHogLike,
     scannerVersion: SCANNER_VERSION,
   });
 

--- a/tools/design-system-scanner/src/index.ts
+++ b/tools/design-system-scanner/src/index.ts
@@ -32,6 +32,7 @@ const SCAN_LIMITATIONS = [
  *   scanner --local /path/to/repo [--repo-name ...] [--output result.json]
  *   scanner --aggregate /path/to/results --total-repos N --output report.json
  *   scanner --bigquery-export report.json [--output bq-dir/]
+ *   scanner --posthog-export report.json [--posthog-dry-run] [--posthog-host <url>]
  */
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
@@ -47,9 +48,11 @@ async function main(): Promise<void> {
     await aggregateResults(args);
   } else if (args.bigqueryExport) {
     exportForBigQuery(args);
+  } else if (args.posthogExport) {
+    await exportToPostHog(args);
   } else {
     console.error(
-      'Error: Specify --local <path>, --aggregate <path>, or --bigquery-export <path>',
+      'Error: Specify --local <path>, --aggregate <path>, --bigquery-export <path>, or --posthog-export <path>',
     );
     printUsage();
     process.exit(1);
@@ -602,6 +605,58 @@ function emitCatalogZeroRows(
   }
 }
 
+async function exportToPostHog(args: ParsedArgs): Promise<void> {
+  const reportPath = path.resolve(args.posthogExport!);
+
+  if (!fs.existsSync(reportPath)) {
+    console.error(`Report file not found: ${reportPath}`);
+    process.exit(1);
+  }
+
+  const report: ScanReport = JSON.parse(fs.readFileSync(reportPath, 'utf-8'));
+  const { sendScanReport, createDryRunClient, DEFAULT_POSTHOG_HOST } =
+    await import('./export/posthogClient');
+
+  const host =
+    args.posthogHost ?? process.env.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST;
+
+  if (args.posthogDryRun) {
+    console.log('PostHog dry-run — events will be printed, not sent.\n');
+    const client = createDryRunClient();
+    const count = await sendScanReport(report, {
+      client,
+      scannerVersion: SCANNER_VERSION,
+    });
+    console.log(
+      `\nDry-run complete. Would have sent ${count} events to ${host}`,
+    );
+    return;
+  }
+
+  const apiKey = args.posthogApiKey ?? process.env.POSTHOG_API_KEY;
+  if (!apiKey) {
+    console.error(
+      'Error: POSTHOG_API_KEY is required. Set the env var or pass --posthog-key <key>',
+    );
+    process.exit(1);
+  }
+
+  const { PostHog } = await import('posthog-node');
+  const client = new PostHog(apiKey, {
+    host,
+    flushAt: 1,
+    flushInterval: 0,
+  });
+
+  const count = await sendScanReport(report, {
+    client: client as unknown as Parameters<typeof sendScanReport>[1]['client'],
+    scannerVersion: SCANNER_VERSION,
+  });
+
+  await client.shutdown();
+  console.log(`Sent ${count} events to PostHog at ${host}`);
+}
+
 function findJsonFiles(dir: string): string[] {
   const files: string[] = [];
   try {
@@ -713,6 +768,11 @@ interface ParsedArgs {
   // Feature flags
   includeFileFindings?: boolean;
   catalog?: string;
+  // PostHog export flags
+  posthogExport?: string;
+  posthogDryRun?: boolean;
+  posthogHost?: string;
+  posthogApiKey?: string;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -766,6 +826,18 @@ function parseArgs(argv: string[]): ParsedArgs {
       case '--catalog':
         args.catalog = argv[++i];
         break;
+      case '--posthog-export':
+        args.posthogExport = argv[++i];
+        break;
+      case '--posthog-dry-run':
+        args.posthogDryRun = true;
+        break;
+      case '--posthog-host':
+        args.posthogHost = argv[++i];
+        break;
+      case '--posthog-key':
+        args.posthogApiKey = argv[++i];
+        break;
       case '--help':
       case '-h':
         args.help = true;
@@ -786,6 +858,7 @@ Usage:
   scanner --local <path>                         Scan a local directory
   scanner --aggregate <path> --output <path>     Merge per-repo results
   scanner --bigquery-export <path> [--output <dir>]  Export report as NDJSON for BigQuery
+  scanner --posthog-export <path>                Send scan report events to PostHog
 
 Options:
   --local, -l <path>         Path to local repository to scan
@@ -797,6 +870,10 @@ Options:
   --total-repos <n>          Total repos discovered (for report metadata)
   --bigquery-export <path>   Path to scan-report.json to export as NDJSON
   --catalog <path>           Path to catalog.json for unused symbol detection
+  --posthog-export <path>    Path to scan-report.json to send to PostHog
+  --posthog-dry-run          Print PostHog events without sending (no API key needed)
+  --posthog-host <url>       PostHog host URL (default: https://eu.i.posthog.com)
+  --posthog-key <key>        PostHog API key (default: POSTHOG_API_KEY env var)
   --output <path>            Write results to file or directory
   --visibility <vis>         Repository visibility (public/private/internal)
   --archived <bool>          Whether repo is archived
@@ -817,6 +894,12 @@ Examples:
 
   # Export for BigQuery
   scanner --bigquery-export scan-report.json --output ./bq-export/
+
+  # Send scan results to PostHog (dry-run)
+  scanner --posthog-export scan-report.json --posthog-dry-run
+
+  # Send scan results to PostHog
+  POSTHOG_API_KEY=phc_xxx scanner --posthog-export scan-report.json
 `);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5841,6 +5841,7 @@ __metadata:
     "@yarnpkg/lockfile": "npm:^1.1.0"
     jest: "npm:^29.7.0"
     js-yaml: "npm:^4.1.0"
+    posthog-node: "npm:^4.18.0"
     react-scanner: "npm:1.1.0"
     ts-jest: "npm:^29.3.4"
     tsx: "npm:^4.19.4"
@@ -15608,6 +15609,17 @@ __metadata:
     form-data: "npm:^4.0.5"
     proxy-from-env: "npm:^2.1.0"
   checksum: 10c0/2541f4aa215a7d1842429dad006fc682d82bc0e74bd14500823f7d8cce3bbae0e0a8c328c8538946718f366ab8ce5a4c12e9ad40e5a0f3482ff8bff0cd115d45
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.8.2":
+  version: 1.15.0
+  resolution: "axios@npm:1.15.0"
+  dependencies:
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10c0/47e0f860e98d4d7aa145e89ce0cae00e1fb0f1d2485f065c21fce955ddb1dba4103a46bd0e47acd18a27208a7f62c96249e620db575521b92a968619ab133409
   languageName: node
   linkType: hard
 
@@ -33974,6 +33986,15 @@ __metadata:
     query-selector-shadow-dom: "npm:^1.0.1"
     web-vitals: "npm:^5.1.0"
   checksum: 10c0/f849251f4460d5155e7ab7c8c672aca756c2bd0e16058c4dbc5989ed84cc34299b80009b7ae5ce297342d45dc48be4e774e34f042bd99efb3043429d80dfa63b
+  languageName: node
+  linkType: hard
+
+"posthog-node@npm:^4.18.0":
+  version: 4.18.0
+  resolution: "posthog-node@npm:4.18.0"
+  dependencies:
+    axios: "npm:^1.8.2"
+  checksum: 10c0/aa30427599d15b98357b5a88096a8b38b0812c71af49eb54fce0a46164521c247c3b064973931c3471cf84cb7f0e391bfc5d6174cd038f75f8c02cb8a9626cff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds an optional PostHog sink to the design system usage scanner so scan data can be visualized in PostHog dashboards alongside the existing Firestore export and JSON artifact upload.

The scanner now emits one event per fact:

| Event | distinct_id | Groups |
|---|---|---|
| `ds_scan_run` | `scan:{ts}` | `organization` |
| `ds_repo_scanned` | `repo:{name}` | `organization`, `repo` |
| `ds_package_used` | `repo:{name}` | + `package` |
| `ds_component_used` | `repo:{name}` | + `package`, `component` |
| `ds_override_detected` | `repo:{name}` | + `package`, `component` |

All events stamped with the scan's timestamp (so a Monday 06:00 cron run attributes usage to the actual commit date, not scan time) and `disable_geoip: true`. Repos and packages are modelled as PostHog **Groups** (not persons), so dashboards can slice by either without contorting queries.

## How it activates

- Triggered when `POSTHOG_API_KEY` is set in the environment, OR `--posthog-key` is passed
- `--posthog-dry-run` prints the JSON payloads instead of sending — handy for local verification
- Runs **only** in the weekly org-scan workflow job; the PR smoke-test job is unchanged
- Errors are caught so a PostHog failure doesn't kill the scan; Firestore export remains independent

Default host is `https://eu.i.posthog.com` (EU cloud, for data residency). Override via `POSTHOG_HOST` env var or `--posthog-host`.

## Changes

- `tools/design-system-scanner/src/storage/posthogClient.ts` (new) — `buildScanEvents`, `buildGroupIdentifies`, `sendScanReport`, `createDryRunClient`. Narrow `PostHogLike` interface so the real `posthog-node` client can be mocked in tests.
- `tools/design-system-scanner/src/storage/posthogClient.test.ts` (new) — 12 tests covering event shape, distinct-id stability, groups, timestamps, geoip, dry-run, and shutdown.
- `tools/design-system-scanner/src/index.ts` — three CLI flags, env fallbacks, `exportToPostHog` step.
- `tools/design-system-scanner/src/types.ts` — `posthogApiKey` / `posthogHost` / `posthogDryRun` on `ScannerConfig`.
- `tools/design-system-scanner/package.json` — adds `posthog-node@^4.18.0` (loaded via dynamic import).
- `.github/workflows/design-system-usage-scan.yml` — passes `POSTHOG_API_KEY` to the scan job only.
- `README.md` / `SETUP.md` — usage docs, event-shape table, setup checklist.

## Test plan

- [x] `yarn workspace @entur/design-system-scanner build` (clean)
- [x] `yarn workspace @entur/design-system-scanner test` (5 suites, 35 tests, 12 new)
- [x] Workflow YAML re-parsed cleanly
- [x] `--help` prints the new flags
- [x] Add `POSTHOG_API_KEY` repo secret in GitHub
- [x] Manually dispatch the workflow with `max_repos: 5` and verify events arrive in PostHog **Activity**
- [ ] Build a Group Insight in PostHog grouped by `repo` to confirm the group model works as intended

## Notes

The local `copilot/add-component-usage-reporting` branch was diverged from origin (7 ahead, 20 behind) at the time this branch was cut. This PR is based on the local 7-ahead state. Some divergence reconciliation will likely be needed before this can land cleanly.

ETU-70128