### PR TITLE
feat(travel/travel tag): add tag type duration with smaller text size

### DIFF
--- a/apps/documentation/src/data/props/travel-props.tsx
+++ b/apps/documentation/src/data/props/travel-props.tsx
@@ -151,6 +151,12 @@ export const traveltag = [
     label: 'Label',
   },
   {
+    name: 'type',
+    defaultValue: 'publicCode',
+    options: ['publicCode', 'duration'],
+    type: 'segmented',
+  },
+  {
     name: 'labelPlacement',
     defaultValue: 'right',
     options: ['right', 'bottom'],

--- a/packages/travel/src/TravelTag.scss
+++ b/packages/travel/src/TravelTag.scss
@@ -17,7 +17,7 @@
   background-color: var(--background-color);
   color: var(--text-color);
 
-  .eds-contrast & {
+  :where(.eds-contrast) & {
     --background-color: var(--components-travel-traveltag-contrast-fill-walk); //Default
     --text-color: var(--components-travel-traveltag-contrast-text-default);
   }
@@ -27,7 +27,7 @@
     &--error {
       background-color: var(--background-color);
       color: var(--text-color);
-      .eds-contrast &.eds-travel-tag {
+      :where(.eds-contrast) &:where(.eds-travel-tag) {
         background-color: var(--background-color);
         color: var(--text-color);
       }
@@ -40,11 +40,11 @@
     line-height: 1;
   }
 
-  &--icon-and-text > .eds-icon {
+  &--icon-and-text > :where(.eds-icon) {
     margin-right: t.$space-extra-small;
   }
 
-  > .eds-icon {
+  > :where(.eds-icon) {
     font-size: t.$font-sizes-extra-large2;
     color: var(--text-color);
   }
@@ -61,29 +61,29 @@
     top: calc((t.$space-extra-large - (t.$space-default + t.$border-widths-medium)) / 2);
     right: calc(-1 * (t.$space-default - t.$border-widths-medium) / 2 - t.$space-extra-small2);
     background: var(--components-form-feedbacktext-information-standard-stroke);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       background: var(--components-form-feedbacktext-information-contrast-stroke);
     }
 
     &-exclamation-icon {
       color: var(--components-form-feedbacktext-warning-standard-icon-fill);
-      .svg-validation-circlefilled-exclamation {
+      :where(.svg-validation-circlefilled-exclamation) {
         fill: var(--components-form-feedbacktext-warning-standard-icon-symbol);
       }
-      .eds-contrast & {
+      :where(.eds-contrast) & {
         color: var(--components-form-feedbacktext-warning-contrast-icon-fill);
       }
     }
     &-error-icon {
       font-size: t.$font-sizes-medium;
       color: var(--components-form-feedbacktext-negative-standard-icon-fill);
-      .eds-contrast & {
+      :where(.eds-contrast) & {
         color: var(--components-form-feedbacktext-negative-contrast-icon-fill);
       }
     }
     &-info-icon {
       color: var(--components-form-feedbacktext-information-standard-icon-fill);
-      .eds-contrast & {
+      :where(.eds-contrast) & {
         color: var(--components-form-feedbacktext-information-contrast-icon-fill);
       }
     }
@@ -104,7 +104,7 @@
   &__label {
     color: var(--components-travel-traveltag-standard-text-label);
     font-size: t.$font-sizes-large;
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--components-travel-traveltag-contrast-text-label);
     }
     &--right {
@@ -141,18 +141,18 @@
     font-size: t.$font-sizes-medium;
     line-height: t.$space-large;
 
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       background-color: var(--components-travel-traveltag-contrast-fill-details);
       color: var(--components-travel-traveltag-contrast-text-details);
       border-color: var(--components-travel-traveltag-contrast-stroke-details);
     }
 
-    .eds-travel-tag--alert--error & {
+    :where(.eds-travel-tag--alert--error) & {
       border-color: var(--components-travel-traveltag-standard-stroke-details-cancelled);
       background-color: var(--components-travel-traveltag-standard-fill-details-cancelled);
       color: var(--components-travel-traveltag-standard-text-cancelled);
 
-      .eds-contrast & {
+      :where(.eds-contrast) & {
         border-color: var(--components-travel-traveltag-contrast-stroke-details-cancelled);
         background-color: var(--components-travel-traveltag-contrast-fill-details-cancelled);
         color: var(--components-travel-traveltag-contrast-text-cancelled);
@@ -171,11 +171,11 @@
     height: t.$space-large;
     width: t.$space-large;
     font-size: t.$font-sizes-large;
-    .eds-icon {
+    :where(.eds-icon) {
       color: var(--text-color);
       font-size: t.$font-sizes-medium;
     }
-    &:has(:focus-visible) {
+    &:has(:where(:focus-visible)) {
       outline-offset: t.$outline-offsets-focus;
       outline: t.$outlines-focus-contrast;
     }

--- a/packages/travel/src/TravelTag.scss
+++ b/packages/travel/src/TravelTag.scss
@@ -33,6 +33,13 @@
       }
     }
   }
+
+  &--type-duration {
+    align-items: flex-end;
+    font-size: t.$font-sizes-extra-small;
+    line-height: 1;
+  }
+
   &--icon-and-text > .eds-icon {
     margin-right: t.$space-extra-small;
   }

--- a/packages/travel/src/TravelTag.test.tsx
+++ b/packages/travel/src/TravelTag.test.tsx
@@ -18,3 +18,9 @@ test('TravelTag renders with content, spread props and with correct classnames, 
   fireEvent.click(closeButton);
   expect(spy).toHaveBeenCalledTimes(1);
 });
+test('TravelTag renders with duration type', () => {
+  const { getByText } = render(<TravelTag type="duration">12</TravelTag>);
+  expect(getByText('12').closest('.eds-travel-tag')).toHaveClass(
+    'eds-travel-tag--type-duration',
+  );
+});

--- a/packages/travel/src/TravelTag.tsx
+++ b/packages/travel/src/TravelTag.tsx
@@ -27,6 +27,8 @@ export type TravelTagProps = {
    * @default "none"
    */
   alert?: 'none' | 'error' | 'warning' | 'info';
+  /** Duration brukes når man viser tid dette "transportmiddelet" bruker, anbefales hovedsaklig til gange og delingsmobilitet. publicCode brukes for å vise ID-en til linjen. */
+  type?: 'publicCode' | 'duration';
   /** Legger til farge og ikon tilpasset valgt transportmiddel */
   transport?: Transport;
   /** Element ved siden av eller under TravelTag.  */
@@ -48,6 +50,7 @@ export const TravelTag: React.FC<TravelTagProps> = ({
   children,
   className,
   alert = 'none',
+  type = 'publicCode',
   transport = 'none',
   label,
   labelPlacement = 'right',
@@ -92,6 +95,7 @@ export const TravelTag: React.FC<TravelTagProps> = ({
         'eds-travel-tag--alert': alertIsSet,
         'eds-travel-tag--alert--error': alert === 'error',
         'eds-travel-tag--transport': transportIsSet,
+        'eds-travel-tag--type-duration': type === 'duration',
         'eds-travel-tag--icon-and-text':
           numberOfChildren > 1 || (transportIsSet && numberOfChildren > 0),
       })}


### PR DESCRIPTION
## 💡 Hvorfor?

For å vise hvor lang tid et transportmiddel bruker.

## 🔧 Hvordan?

- Ny prop: `type?: 'publicCode' | 'duration'`
- `publicCode` default
- Hvis type er `'duration'`, får `children` mindre text-størrelse 
## 🧩 Type endring

<!-- Kryss av det som passer -->

- [ ] 🐞 Feilretting
- [x] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [x] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

**Før**:
<img width="94" height="66" alt="Screenshot 2026-04-30 at 10 27 54" src="https://github.com/user-attachments/assets/bbc6ac8c-4b7f-4648-896f-96c7ba1edc8d" />

**Nå:**

<img width="123" height="88" alt="Screenshot 2026-04-30 at 10 27 14" src="https://github.com/user-attachments/assets/aabc8fc4-47ad-40d7-a027-9dce18051e67" />


## 💬 Tilleggsnotater


## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden
