### PR TITLE
Add support for beta and other tags to both componentDoc and page documents in Sanity

### DIFF
--- a/apps/documentation/gatsby-config.ts
+++ b/apps/documentation/gatsby-config.ts
@@ -140,7 +140,7 @@ const config: GatsbyConfig = {
             id: 'id',
             index: [
               'title',
-              'tags',
+              'tag',
               'description',
               'npmPackage',
               'body',
@@ -176,7 +176,7 @@ const config: GatsbyConfig = {
         ref: 'id',
         index: [
           'title',
-          'tags',
+          'tag',
           'description',
           'npmPackage',
           'body',
@@ -189,7 +189,7 @@ const config: GatsbyConfig = {
           'title',
           'description',
           'npmPackage',
-          'isBeta',
+          'tag',
           'category',
           'subcategory',
         ],
@@ -230,7 +230,7 @@ const config: GatsbyConfig = {
               tags: node.frontmatter?.tags,
               description: node.frontmatter?.description,
               npmPackage: node.frontmatter?.npmPackage,
-              isBeta: false,
+              tags: [],
               body: node.body,
               category: null,
               subcategory: null,
@@ -256,16 +256,17 @@ const config: GatsbyConfig = {
               category: node.category,
               subcategory: node.subcategory,
               isCategoryLandingPage: node.isCategoryLandingPage,
+              tag: node.tag ?? undefined,
             });
 
             return {
               id: node.id,
               path: path,
               title: node.title,
+              tag: node.tag ?? null,
               tags: [],
               description: node.description,
               npmPackage: null,
-              isBeta: node.isBeta,
               body: node.content?._rawItems
                 ? JSON.stringify(node.content._rawItems)
                 : '',
@@ -280,7 +281,7 @@ const config: GatsbyConfig = {
                 title: node.title,
                 category: node.category,
                 subcategory: node.subcategory,
-                isBeta: node.isBeta,
+                tag: node.tag ?? undefined,
               });
 
               const tabsContent =
@@ -313,10 +314,10 @@ const config: GatsbyConfig = {
                 id: node.id,
                 path,
                 title: node.title,
+                tag: node.tag ?? null,
                 tags: [],
                 description: node.description,
                 npmPackage: node.npmPackage ?? null,
-                isBeta: node.isBeta,
                 body: combinedContent,
                 category: node.category,
                 subcategory: node.subcategory,
@@ -334,7 +335,7 @@ const config: GatsbyConfig = {
               description:
                 'Analyse av brukerundersøkelser for Entur Linje designsystem 2022–2025.',
               npmPackage: null,
-              isBeta: false,
+              tags: [],
               body: 'Designsystemets brukerundersøkelser brukerundersøkelse survey analyse tilfredshet trender respondenter kvalitative tilbakemeldinger forbedringsforslag',
               category: 'Ressurser',
               subcategory: 'Innsikt',
@@ -390,7 +391,7 @@ const config: GatsbyConfig = {
                 category
                 subcategory
                 isCategoryLandingPage
-                isBeta
+                tag
                 content {
                   _rawItems
                 }
@@ -404,7 +405,7 @@ const config: GatsbyConfig = {
                 category
                 subcategory
                 npmPackage
-                isBeta
+                tag
                 beskrivelse {
                   _rawItems
                 }

--- a/apps/documentation/gatsby-config.ts
+++ b/apps/documentation/gatsby-config.ts
@@ -265,7 +265,7 @@ const config: GatsbyConfig = {
               tags: [],
               description: node.description,
               npmPackage: null,
-              isBeta: false,
+              isBeta: node.isBeta,
               body: node.content?._rawItems
                 ? JSON.stringify(node.content._rawItems)
                 : '',
@@ -390,6 +390,7 @@ const config: GatsbyConfig = {
                 category
                 subcategory
                 isCategoryLandingPage
+                isBeta
                 content {
                   _rawItems
                 }

--- a/apps/documentation/gatsby-config.ts
+++ b/apps/documentation/gatsby-config.ts
@@ -152,7 +152,7 @@ const config: GatsbyConfig = {
               title: {
                 weight: 5, // Highest weight - most important for exact matches
               },
-              tags: {
+              tag: {
                 weight: 4, // High weight - contains specific, curated keywords
               },
               description: {
@@ -227,10 +227,10 @@ const config: GatsbyConfig = {
               id: node.id,
               path: node.frontmatter?.route,
               title: node.frontmatter?.title,
+              tag: null,
               tags: node.frontmatter?.tags,
               description: node.frontmatter?.description,
               npmPackage: node.frontmatter?.npmPackage,
-              tags: [],
               body: node.body,
               category: null,
               subcategory: null,
@@ -331,11 +331,10 @@ const config: GatsbyConfig = {
               id: 'brukerundersokelse',
               path: '/ressurser/innsikt/brukerundersokelse',
               title: 'Designsystemets brukerundersøkelser',
-              tags: ['undersøkelse', 'innsikt', 'survey'],
+              tag: null,
               description:
                 'Analyse av brukerundersøkelser for Entur Linje designsystem 2022–2025.',
               npmPackage: null,
-              tags: [],
               body: 'Designsystemets brukerundersøkelser brukerundersøkelse survey analyse tilfredshet trender respondenter kvalitative tilbakemeldinger forbedringsforslag',
               category: 'Ressurser',
               subcategory: 'Innsikt',

--- a/apps/documentation/gatsby-node.js
+++ b/apps/documentation/gatsby-node.js
@@ -89,6 +89,7 @@ async function createDocumentationPagesFromSanity(graphql, actions, reporter) {
           category
           subcategory
           isCategoryLandingPage
+          tag
         }
       }
       allSanityComponentDoc {
@@ -98,7 +99,7 @@ async function createDocumentationPagesFromSanity(graphql, actions, reporter) {
           category
           subcategory
           npmPackage
-          isBeta
+          tag
         }
       }
     }
@@ -116,6 +117,7 @@ async function createDocumentationPagesFromSanity(graphql, actions, reporter) {
       category: page.category,
       subcategory: page.subcategory,
       isCategoryLandingPage: page.isCategoryLandingPage,
+      tag: page.tag ?? undefined,
     });
 
     createPage({
@@ -132,7 +134,7 @@ async function createDocumentationPagesFromSanity(graphql, actions, reporter) {
       title: doc.title,
       category: doc.category,
       subcategory: doc.subcategory,
-      isBeta: doc.isBeta,
+      tag: doc.tag ?? undefined,
     });
 
     createPage({

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
@@ -95,9 +95,12 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
       >
         <Flex justify="space-between">
           {item.title}{' '}
-          {item.isBeta && (
-            <Badge type="status" variant="warning">
-              beta
+          {item.tag && (
+            <Badge
+              type="status"
+              variant={item.tag === 'beta' ? 'warning' : 'positive'}
+            >
+              {item.tag}
             </Badge>
           )}
         </Flex>

--- a/apps/documentation/src/components/Navigations/SideNavigation/utils.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/utils.tsx
@@ -6,7 +6,7 @@ const { getSanitizedPath } = require('../../../utils/getSanitizedPath') as {
     title?: string;
     categoryIndex?: number;
     isCategoryLandingPage?: boolean;
-    isBeta?: boolean;
+    tag?: string;
   }) => string | undefined;
 };
 
@@ -17,7 +17,7 @@ export interface MenuItem {
   subcategory?: string;
   categoryIndex?: number;
   isCategoryLandingPage?: boolean;
-  isBeta?: boolean;
+  tag?: string;
   path?: string;
   order?: number;
 }

--- a/apps/documentation/src/components/PageHeader/BasePageHeader.tsx
+++ b/apps/documentation/src/components/PageHeader/BasePageHeader.tsx
@@ -17,7 +17,7 @@ export type BasePageHeaderProps = {
   npmPackage?: string;
   isCategoryLandingPage?: boolean;
   figmaLink?: string;
-  isBeta?: boolean;
+  tag?: string;
 };
 
 export const BasePageHeader: React.FC<BasePageHeaderProps> = ({
@@ -26,7 +26,7 @@ export const BasePageHeader: React.FC<BasePageHeaderProps> = ({
   description,
   npmPackage,
   figmaLink,
-  isBeta,
+  tag,
 }) => {
   return (
     <header className="page-header">
@@ -49,14 +49,17 @@ export const BasePageHeader: React.FC<BasePageHeaderProps> = ({
           <Heading1 margin="none" className="page-header__heading">
             {title}
           </Heading1>
-          {isBeta && (
-            <Badge variant="warning" type="status">
-              beta
+          {tag && (
+            <Badge
+              variant={tag === 'beta' ? 'warning' : 'positive'}
+              type="status"
+            >
+              {tag}
             </Badge>
           )}
         </Grid.Item>
         <Grid.Item colSpan="1 / 2" rowSpan="2 / -1">
-          {npmPackage && <NpmTag packageName={npmPackage} isBeta={isBeta} />}
+          {npmPackage && <NpmTag packageName={npmPackage} tag={tag} />}
         </Grid.Item>
         <Grid.Item colSpan="2 / -1" rowSpan="1 / -1">
           <Flex direction="column" align="end" gap="xs">
@@ -87,7 +90,7 @@ export const BasePageHeader: React.FC<BasePageHeaderProps> = ({
                   className="ds-npm-tag"
                   href={`https://github.com/entur/design-system/tree/main/packages/${sanitizeEnturPackageName(
                     npmPackage,
-                  )}${isBeta ? '/src/beta' : ''}`}
+                  )}${tag === 'beta' ? '/src/beta' : ''}`}
                 >
                   <ActionChip>
                     Github <GithubIcon aria-hidden="true" />

--- a/apps/documentation/src/components/PageHeader/NpmTag.tsx
+++ b/apps/documentation/src/components/PageHeader/NpmTag.tsx
@@ -6,9 +6,9 @@ import { sanitizeEnturPackageName } from 'src/utils/utils';
 
 import './NpmTag.scss';
 
-export const NpmTag: React.FC<{ packageName: string; isBeta?: boolean }> = ({
+export const NpmTag: React.FC<{ packageName: string; tag?: string }> = ({
   packageName,
-  isBeta,
+  tag,
 }) => {
   const packageKey = sanitizeEnturPackageName(packageName);
   const fullPackageName = `@entur/${packageKey}`;
@@ -31,7 +31,7 @@ export const NpmTag: React.FC<{ packageName: string; isBeta?: boolean }> = ({
     <Flex gap="s">
       <Tag>
         {fullPackageName}
-        {isBeta ? '/beta' : ''}
+        {tag === 'beta' ? '/beta' : ''}
       </Tag>
       <Tag>v{currentPackage?.version}</Tag>
     </Flex>

--- a/apps/documentation/src/components/Search/Search.tsx
+++ b/apps/documentation/src/components/Search/Search.tsx
@@ -37,7 +37,7 @@ type StoreResult = {
   title: string | null;
   description: string | null;
   npmPackage?: string | null;
-  isBeta?: boolean;
+  tag?: string;
   icon?: any;
 };
 
@@ -327,9 +327,12 @@ const ListElement = (props: {
         >
           <Flex gap="s">
             {result.title}
-            {result.isBeta && (
-              <Badge type="status" variant="warning">
-                beta
+            {result.tag && (
+              <Badge
+                type="status"
+                variant={result.tag === 'beta' ? 'warning' : 'positive'}
+              >
+                {result.tag}
               </Badge>
             )}
           </Flex>

--- a/apps/documentation/src/components/sanity/types.ts
+++ b/apps/documentation/src/components/sanity/types.ts
@@ -118,7 +118,7 @@ export type PageType = {
   subcategory?: string;
   npmPackage?: string;
   isCategoryLandingPage?: boolean;
-  isBeta?: boolean;
+  tag?: string;
   content: PortableTextProps['value'];
 };
 

--- a/apps/documentation/src/components/sanity/types.ts
+++ b/apps/documentation/src/components/sanity/types.ts
@@ -118,6 +118,7 @@ export type PageType = {
   subcategory?: string;
   npmPackage?: string;
   isCategoryLandingPage?: boolean;
+  isBeta?: boolean;
   content: PortableTextProps['value'];
 };
 

--- a/apps/documentation/src/layouts/SideNavigationLayout.tsx
+++ b/apps/documentation/src/layouts/SideNavigationLayout.tsx
@@ -44,6 +44,7 @@ const SideNavigationLayout = ({
           category
           title
           isCategoryLandingPage
+          isBeta
         }
       }
       allSanityComponentDoc {

--- a/apps/documentation/src/layouts/SideNavigationLayout.tsx
+++ b/apps/documentation/src/layouts/SideNavigationLayout.tsx
@@ -44,7 +44,7 @@ const SideNavigationLayout = ({
           category
           title
           isCategoryLandingPage
-          isBeta
+          tag
         }
       }
       allSanityComponentDoc {
@@ -53,7 +53,7 @@ const SideNavigationLayout = ({
           subcategory
           category
           title
-          isBeta
+          tag
         }
       }
     }
@@ -92,7 +92,7 @@ function mergeMdxAndSanityPageData(mdxPageData: any[], sanityPageData: any[]) {
         order: page.frontmatter.order,
         categoryIndex: page.frontmatter.categoryIndex,
         isCategoryLandingPage: false, // MDX pages don't have this field
-        isBeta: false,
+        tag: undefined,
       } as MenuItem;
     });
   const sanityPages = sanityPageData.map(page => {
@@ -101,11 +101,10 @@ function mergeMdxAndSanityPageData(mdxPageData: any[], sanityPageData: any[]) {
       title: page.title,
       category: page.category,
       subcategory: page.subcategory,
-      tags: page?.tags ?? null,
       order: page.order ?? null,
       categoryIndex: page.categoryIndex ?? null,
       isCategoryLandingPage: page.isCategoryLandingPage ?? false,
-      isBeta: page.isBeta ?? false,
+      tag: page.tag ?? undefined,
     } as MenuItem;
   });
   // Add custom menu items

--- a/apps/documentation/src/templates/ComponentDocTemplate.tsx
+++ b/apps/documentation/src/templates/ComponentDocTemplate.tsx
@@ -16,7 +16,7 @@ type ComponentDoc = {
   description?: string;
   npmPackage?: string;
   figmaLink?: string;
-  isBeta?: boolean;
+  tag?: string;
   intro?: any;
   beskrivelse?: any;
   utvikling?: any;
@@ -41,7 +41,7 @@ export default function ComponentDocTemplate({
     npmPackage,
     figmaLink,
     intro,
-    isBeta,
+    tag,
     beskrivelse,
     utvikling,
     tabs,
@@ -62,7 +62,7 @@ export default function ComponentDocTemplate({
     description,
     npmPackage,
     figmaLink,
-    isBeta,
+    tag,
   };
 
   return (
@@ -154,7 +154,7 @@ export const query = graphql`
       description
       npmPackage
       figmaLink
-      isBeta
+      tag
       intro {
         ...TextBlockFragment
       }

--- a/apps/documentation/src/templates/ContentTemplate.tsx
+++ b/apps/documentation/src/templates/ContentTemplate.tsx
@@ -20,7 +20,7 @@ export default function ContentTemplate({
     description,
     npmPackage,
     isCategoryLandingPage,
-    isBeta,
+    tag,
   } = page;
 
   return (
@@ -32,7 +32,7 @@ export default function ContentTemplate({
         description={description}
         npmPackage={npmPackage}
         isCategoryLandingPage={isCategoryLandingPage}
-        isBeta={isBeta}
+        tag={tag}
       />
       <PortableText value={content} />
     </>
@@ -48,7 +48,7 @@ export const Head = (
         category: string;
         subcategory: string;
         isCategoryLandingPage: boolean;
-        isBeta: boolean;
+        tag: string;
       };
     };
   },
@@ -61,7 +61,7 @@ export const Head = (
         category,
         subcategory,
         isCategoryLandingPage,
-        isBeta,
+        tag,
       },
     },
   } = props;
@@ -74,7 +74,7 @@ export const Head = (
         category,
         subcategory,
         isCategoryLandingPage,
-        isBeta,
+        tag,
       })}
     />
   );
@@ -88,7 +88,7 @@ export const query = graphql`
       subcategory
       description
       isCategoryLandingPage
-      isBeta
+      tag
       content {
         ...TextBlockFragment
       }

--- a/apps/documentation/src/templates/ContentTemplate.tsx
+++ b/apps/documentation/src/templates/ContentTemplate.tsx
@@ -20,6 +20,7 @@ export default function ContentTemplate({
     description,
     npmPackage,
     isCategoryLandingPage,
+    isBeta,
   } = page;
 
   return (
@@ -31,6 +32,7 @@ export default function ContentTemplate({
         description={description}
         npmPackage={npmPackage}
         isCategoryLandingPage={isCategoryLandingPage}
+        isBeta={isBeta}
       />
       <PortableText value={content} />
     </>
@@ -46,6 +48,7 @@ export const Head = (
         category: string;
         subcategory: string;
         isCategoryLandingPage: boolean;
+        isBeta: boolean;
       };
     };
   },
@@ -58,6 +61,7 @@ export const Head = (
         category,
         subcategory,
         isCategoryLandingPage,
+        isBeta,
       },
     },
   } = props;
@@ -70,6 +74,7 @@ export const Head = (
         category,
         subcategory,
         isCategoryLandingPage,
+        isBeta,
       })}
     />
   );
@@ -83,6 +88,7 @@ export const query = graphql`
       subcategory
       description
       isCategoryLandingPage
+      isBeta
       content {
         ...TextBlockFragment
       }

--- a/apps/documentation/src/templates/ContentTemplate.tsx
+++ b/apps/documentation/src/templates/ContentTemplate.tsx
@@ -48,7 +48,7 @@ export const Head = (
         category: string;
         subcategory: string;
         isCategoryLandingPage: boolean;
-        tag: string;
+        tag?: string | null;
       };
     };
   },

--- a/apps/documentation/src/utils/getSanitizedPath.js
+++ b/apps/documentation/src/utils/getSanitizedPath.js
@@ -17,7 +17,7 @@ function getSanitizedPath({
   title,
   categoryIndex,
   isCategoryLandingPage,
-  isBeta,
+  tag,
 }) {
   const sanitizedCategory = sanitizeText(category);
 
@@ -30,7 +30,9 @@ function getSanitizedPath({
     return `/${sanitizedCategory}`;
   }
 
-  const sanitizedTitle = `${sanitizeText(title)}${isBeta ? '/beta' : ''}`;
+  const sanitizedTitle = `${sanitizeText(title)}${
+    tag === 'beta' ? '/beta' : ''
+  }`;
   if (!subcategory) return `/${sanitizedCategory}/${sanitizedTitle}`;
 
   const sanitizedSubcategory = sanitizeText(subcategory);

--- a/apps/documentation/src/utils/getSanitizedPath.ts
+++ b/apps/documentation/src/utils/getSanitizedPath.ts
@@ -4,7 +4,7 @@ export type GetSanitizedPathInput = {
   title?: string;
   categoryIndex?: number;
   isCategoryLandingPage?: boolean;
-  isBeta?: boolean;
+  tag?: string;
 };
 
 // Re-export JS implementation for Node/Gatsby compatibility.

--- a/apps/studio-linje/components/AutocompleteTagInput.tsx
+++ b/apps/studio-linje/components/AutocompleteTagInput.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from 'react';
+import { useClient } from 'sanity';
+import { StringInputProps, set, unset } from 'sanity';
+
+export const AutocompleteTagInput = (props: StringInputProps) => {
+  const client = useClient({ apiVersion: '2025-02-10' });
+  const [options, setOptions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  useEffect(() => {
+    const fetchOptions = async () => {
+      try {
+        const result = await client.fetch<Array<{ tag?: string }>>(
+          `*[_type in ["page", "componentDoc"] && defined(tag)] { tag }`,
+        );
+        const allTags = result
+          .map(doc => doc.tag)
+          .filter((t): t is string => Boolean(t));
+        setOptions([...new Set(allTags)].sort());
+      } catch (error) {
+        console.error('Error fetching tags:', error);
+        setOptions([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchOptions();
+  }, [client]);
+
+  useEffect(() => {
+    if (props.value && !searchTerm) {
+      setSearchTerm(props.value);
+    }
+  }, [props.value, searchTerm]);
+
+  const handleSelect = (tag: string) => {
+    props.onChange(set(tag));
+    setSearchTerm(tag);
+    setShowDropdown(false);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchTerm(value);
+    setShowDropdown(true);
+    if (value) {
+      props.onChange(set(value));
+    } else {
+      props.onChange(unset());
+    }
+  };
+
+  const handleInputFocus = () => {
+    setShowDropdown(true);
+    if (props.value && !searchTerm) {
+      setSearchTerm(props.value);
+    }
+  };
+
+  const handleInputBlur = () => {
+    setTimeout(() => setShowDropdown(false), 200);
+  };
+
+  const filteredOptions = options.filter(tag =>
+    tag.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
+
+  if (loading) {
+    return <div>Laster tags …</div>;
+  }
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <input
+        type="text"
+        value={searchTerm}
+        onChange={handleInputChange}
+        onFocus={handleInputFocus}
+        onBlur={handleInputBlur}
+        placeholder="Søk eller skriv inn en ny tag …"
+        style={{
+          width: '100%',
+          padding: '8px',
+          border: '1px solid #ccc',
+          borderRadius: '4px',
+          fontSize: '14px',
+          boxSizing: 'border-box',
+        }}
+      />
+
+      {showDropdown && (
+        <div
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            right: 0,
+            backgroundColor: 'white',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+            maxHeight: '200px',
+            overflowY: 'auto',
+            zIndex: 1000,
+            boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+          }}
+        >
+          {filteredOptions.length > 0 ? (
+            filteredOptions.map(tag => (
+              <div
+                key={tag}
+                onClick={() => handleSelect(tag)}
+                style={{
+                  padding: '8px 12px',
+                  cursor: 'pointer',
+                  borderBottom: '1px solid #f0f0f0',
+                  fontSize: '14px',
+                }}
+                onMouseEnter={e => {
+                  e.currentTarget.style.backgroundColor = '#f5f5f5';
+                }}
+                onMouseLeave={e => {
+                  e.currentTarget.style.backgroundColor = 'white';
+                }}
+              >
+                {tag}
+              </div>
+            ))
+          ) : searchTerm ? (
+            <div
+              style={{
+                padding: '8px 12px',
+                color: '#666',
+                fontSize: '14px',
+                fontStyle: 'italic',
+              }}
+            >
+              Ingen eksisterende tags funnet. &ldquo;{searchTerm}&rdquo; blir
+              lagt til som en ny tag.
+            </div>
+          ) : (
+            <div
+              style={{
+                padding: '8px 12px',
+                color: '#666',
+                fontSize: '14px',
+                fontStyle: 'italic',
+              }}
+            >
+              {options.length > 0
+                ? `${options.length} tags finnes. Skriv for å filtrere.`
+                : 'Ingen tags finnes ennå. Skriv for å legge til en ny.'}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/studio-linje/schemaTypes/documents/componentDoc.tsx
+++ b/apps/studio-linje/schemaTypes/documents/componentDoc.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { defineArrayMember, defineField, defineType } from 'sanity';
 import { AutocompletePageFieldInput } from '../../components/AutocompletePageFieldInput';
+import { AutocompleteTagInput } from '../../components/AutocompleteTagInput';
 
 import { StringInputProps } from 'sanity';
 
@@ -89,11 +90,11 @@ export const componentDoc = defineType({
       readOnly: true,
     }),
     defineField({
-      name: 'isBeta',
-      title: 'Beta',
-      type: 'boolean',
-      description: 'Markerer komponentdokumentasjonen som beta.',
-      initialValue: false,
+      name: 'tag',
+      title: 'Tag',
+      type: 'string',
+      components: { input: AutocompleteTagInput },
+      description: 'Valgfri tag som vises på komponentsiden.',
     }),
     defineField({
       name: 'intro',
@@ -143,11 +144,11 @@ export const componentDoc = defineType({
       title: 'title',
       category: 'category',
       subcategory: 'subcategory',
-      isBeta: 'isBeta',
+      tag: 'tag',
     },
-    prepare({ title, category, subcategory, isBeta }) {
+    prepare({ title, category, subcategory, tag }) {
       return {
-        title: `${title || 'Ingen tittel'}${isBeta ? ' (beta)' : ''}`,
+        title: `${title || 'Ingen tittel'}${tag ? ` (${tag})` : ''}`,
         subtitle: subcategory ? `${category} > ${subcategory}` : category,
       };
     },

--- a/apps/studio-linje/schemaTypes/documents/page.tsx
+++ b/apps/studio-linje/schemaTypes/documents/page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { defineField, defineType } from 'sanity';
 import { AutocompletePageFieldInput } from '../../components/AutocompletePageFieldInput';
+import { AutocompleteTagInput } from '../../components/AutocompleteTagInput';
 
 import { StringInputProps } from 'sanity';
 
@@ -64,11 +65,11 @@ export const page = defineType({
       },
     }),
     defineField({
-      name: 'isBeta',
-      title: 'Beta',
-      type: 'boolean',
-      description: 'Markerer siden som beta.',
-      initialValue: false,
+      name: 'tag',
+      title: 'Tag',
+      type: 'string',
+      components: { input: AutocompleteTagInput },
+      description: 'Valgfri tag som vises på siden.',
     }),
     defineField({
       name: 'isCategoryLandingPage',
@@ -119,9 +120,9 @@ export const page = defineType({
       category: 'category',
       subcategory: 'subcategory',
       isCategoryLandingPage: 'isCategoryLandingPage',
-      isBeta: 'isBeta',
+      tag: 'tag',
     },
-    prepare({ title, category, subcategory, isCategoryLandingPage, isBeta }) {
+    prepare({ title, category, subcategory, isCategoryLandingPage, tag }) {
       const subtitle = isCategoryLandingPage
         ? `${category} (Landingsside)`
         : subcategory
@@ -129,7 +130,7 @@ export const page = defineType({
         : category;
 
       return {
-        title: `${title || 'Ingen tittel'}${isBeta ? ' (beta)' : ''}`,
+        title: `${title || 'Ingen tittel'}${tag ? ` (${tag})` : ''}`,
         subtitle,
       };
     },

--- a/apps/studio-linje/schemaTypes/documents/page.tsx
+++ b/apps/studio-linje/schemaTypes/documents/page.tsx
@@ -64,6 +64,13 @@ export const page = defineType({
       },
     }),
     defineField({
+      name: 'isBeta',
+      title: 'Beta',
+      type: 'boolean',
+      description: 'Markerer siden som beta.',
+      initialValue: false,
+    }),
+    defineField({
       name: 'isCategoryLandingPage',
       title: 'Er kategorilandingsside',
       description:
@@ -112,8 +119,9 @@ export const page = defineType({
       category: 'category',
       subcategory: 'subcategory',
       isCategoryLandingPage: 'isCategoryLandingPage',
+      isBeta: 'isBeta',
     },
-    prepare({ title, category, subcategory, isCategoryLandingPage }) {
+    prepare({ title, category, subcategory, isCategoryLandingPage, isBeta }) {
       const subtitle = isCategoryLandingPage
         ? `${category} (Landingsside)`
         : subcategory
@@ -121,7 +129,7 @@ export const page = defineType({
         : category;
 
       return {
-        title: title || 'Ingen tittel',
+        title: `${title || 'Ingen tittel'}${isBeta ? ' (beta)' : ''}`,
         subtitle,
       };
     },


### PR DESCRIPTION
Erstatter `isBeta`-boolean på artikkelsider og komponentdokumentasjon med et fritekst `tag`-felt med autocomplete, slik at redaktører kan merke sider med valgfrie tags (f.eks. «beta» eller «ny»).

## 💡 Hvorfor?

Komponentdokumentasjon hadde et `isBeta`-boolean-felt for å markere beta-komponenter. Artikkelsider manglet tilsvarende. I stedet for å kopiere boolean-feltet er dette løst med et fleksibelt `tag`-felt som støtter fritekst, slik at nye merkelapper kan legges til uten skjemaendringer.

## 🔧 Hvordan?

**Sanity Studio** (`page.tsx`, `componentDoc.tsx`):
- `isBeta: boolean` erstattet med `tag: string` på begge dokumenttyper.
- Ny `AutocompleteTagInput`-komponent: tekstfelt med nedtrekksmeny som viser eksisterende tags fra alle `page`- og `componentDoc`-dokumenter i databasen. Fungerer som hoved-/underkategori-feltene — velg blant eksisterende eller skriv inn en ny.
- Forhåndsvisningen i Studio viser `(tag)` etter tittelen når feltet er satt.

**Dokumentasjonsside** (alle relevante filer):
- `tag?: string` erstatter `isBeta?: boolean` i TypeScript-typer, GraphQL-spørringer og komponentprops gjennom hele kodebasen.
- `BasePageHeader`: viser merkelappen som `<Badge>` ved siden av tittelen (`warning`-variant for «beta», `positive` for andre).
- `NpmTag`: legger til `/beta` i pakkenavnet hvis tag er «beta».
- Sidenavigasjon og søkeresultater: viser merkelapp-badge.
- `getSanitizedPath`: legger til `/beta` i URL-stien hvis tag er «beta», for bakoverkompatibilitet med eksisterende beta-komponentlenker.

## 🧩 Type endring

- [ ] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [x] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

<!-- Legg ved hvis det hjelper å forstå endringen -->

## 💬 Tilleggsnotater

Eksisterende dokumenter som hadde `isBeta: true` vil ikke automatisk få `tag: beta` — disse må oppdateres manuelt i Sanity Studio. URL-stier med `/beta` er bakoverkompatible: sider som settes til tag «beta» vil fortsatt bruke `/beta`-suffikset i URL-en.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden