### PR TITLE
refactor(layout/beta): fix prop docs for polymorphic components

### DIFF
--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
@@ -98,7 +98,9 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
           {item.tag && (
             <Badge
               type="status"
-              variant={item.tag === 'beta' ? 'warning' : 'positive'}
+              variant={
+                item.tag.toLowerCase() === 'beta' ? 'warning' : 'success'
+              }
             >
               {item.tag}
             </Badge>

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Flex.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Flex.json
@@ -328,6 +328,21 @@
       "type": {
         "name": "ReactNode"
       }
+    },
+    "ref": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ref",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "Ref<Element> | undefined"
+      }
     }
   }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Grid.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Grid.json
@@ -210,6 +210,21 @@
       "type": {
         "name": "ReactNode"
       }
+    },
+    "ref": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ref",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "Ref<Element> | undefined"
+      }
     }
   }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/GridItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/GridItem.json
@@ -86,6 +86,21 @@
       "type": {
         "name": "ReactNode"
       }
+    },
+    "ref": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ref",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/Grid/GridItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "Ref<Element> | undefined"
+      }
     }
   }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.Sidebar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.Sidebar.json
@@ -115,6 +115,21 @@
         "name": "CSSProperties | undefined"
       }
     },
+    "children": {
+      "defaultValue": null,
+      "description": "Content of the sidebar",
+      "name": "children",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
     "as": {
       "defaultValue": null,
       "description": "An override of the default HTML tag.\nCan also be another React component.",

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.Sidebar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.Sidebar.json
@@ -20,6 +20,130 @@
       "type": {
         "name": "boolean | undefined"
       }
+    },
+    "collapsed": {
+      "defaultValue": null,
+      "description": "Controlled collapsed state. When provided, the sidebar becomes\ncollapsible and a toggle button is rendered.",
+      "name": "collapsed",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "onCollapseToggle": {
+      "defaultValue": null,
+      "description": "Callback when the collapse toggle is clicked",
+      "name": "onCollapseToggle",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((collapsed: boolean) => void) | undefined"
+      }
+    },
+    "openSidebarAriaLabel": {
+      "defaultValue": {
+        "value": "Åpne sidemeny"
+      },
+      "description": "aria-label for the toggle button when the sidebar is collapsed",
+      "name": "openSidebarAriaLabel",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "closeSidebarAriaLabel": {
+      "defaultValue": {
+        "value": "Lukk sidemeny"
+      },
+      "description": "aria-label for the toggle button when the sidebar is expanded",
+      "name": "closeSidebarAriaLabel",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "className": {
+      "defaultValue": null,
+      "description": "",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "style": {
+      "defaultValue": null,
+      "description": "",
+      "name": "style",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "CSSProperties | undefined"
+      }
+    },
+    "as": {
+      "defaultValue": null,
+      "description": "An override of the default HTML tag.\nCan also be another React component.",
+      "name": "as",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ElementType<any> | undefined"
+      }
+    },
+    "ref": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ref",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "Ref<Element> | undefined"
+      }
     }
   }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.json
@@ -3,5 +3,66 @@
   "description": "",
   "displayName": "Template.Portal",
   "methods": [],
-  "props": {}
+  "props": {
+    "className": {
+      "defaultValue": null,
+      "description": "",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "style": {
+      "defaultValue": null,
+      "description": "",
+      "name": "style",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "CSSProperties | undefined"
+      }
+    },
+    "as": {
+      "defaultValue": null,
+      "description": "An override of the default HTML tag.\nCan also be another React component.",
+      "name": "as",
+      "declarations": [
+        {
+          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ElementType<any> | undefined"
+      }
+    },
+    "ref": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ref",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "Ref<Element> | undefined"
+      }
+    }
+  }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.json
@@ -34,6 +34,21 @@
         "name": "CSSProperties | undefined"
       }
     },
+    "children": {
+      "defaultValue": null,
+      "description": "Content of the portal layout",
+      "name": "children",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
     "as": {
       "defaultValue": null,
       "description": "An override of the default HTML tag.\nCan also be another React component.",

--- a/apps/documentation/src/utils/getSanitizedPath.js
+++ b/apps/documentation/src/utils/getSanitizedPath.js
@@ -31,7 +31,7 @@ function getSanitizedPath({
   }
 
   const sanitizedTitle = `${sanitizeText(title)}${
-    tag === 'beta' ? '/beta' : ''
+    tag?.toLowerCase() === 'beta' ? '/beta' : ''
   }`;
   if (!subcategory) return `/${sanitizedCategory}/${sanitizedTitle}`;
 

--- a/packages/layout/src/beta/Flex/Flex.tsx
+++ b/packages/layout/src/beta/Flex/Flex.tsx
@@ -71,9 +71,15 @@ export type FlexOwnProps = {
 export type FlexProps<T extends React.ElementType = typeof defaultElement> =
   PolymorphicComponentProps<T, FlexOwnProps>;
 
+export type FlexComponent = (<
+  E extends React.ElementType = typeof defaultElement,
+>(
+  props: FlexProps<E> & { ref?: React.Ref<Element> },
+) => React.ReactElement | null) & { displayName?: string };
+
 const defaultElement = 'div';
 
-export const Flex = React.forwardRef(
+export const Flex: FlexComponent = React.forwardRef(
   <E extends React.ElementType = typeof defaultElement>(
     {
       direction,

--- a/packages/layout/src/beta/Flex/FlexSpacer.tsx
+++ b/packages/layout/src/beta/Flex/FlexSpacer.tsx
@@ -17,9 +17,15 @@ export type FlexSpacerProps<
   T extends React.ElementType = typeof defaultElement,
 > = PolymorphicComponentProps<T, FlexSpacerOwnProps>;
 
+export type FlexSpacerComponent = (<
+  E extends React.ElementType = typeof defaultElement,
+>(
+  props: FlexSpacerProps<E>,
+) => React.ReactElement | null) & { displayName?: string };
+
 const defaultElement = 'div';
 
-export const FlexSpacer = <
+export const FlexSpacer: FlexSpacerComponent = <
   E extends React.ElementType = typeof defaultElement,
 >({
   as,

--- a/packages/layout/src/beta/Grid/Grid.tsx
+++ b/packages/layout/src/beta/Grid/Grid.tsx
@@ -59,9 +59,15 @@ export type GridOwnProps = {
 export type GridProps<T extends React.ElementType = typeof defaultElement> =
   PolymorphicComponentProps<T, GridOwnProps>;
 
+export type GridComponent = (<
+  E extends React.ElementType = typeof defaultElement,
+>(
+  props: GridProps<E> & { ref?: React.Ref<Element> },
+) => React.ReactElement | null) & { displayName?: string };
+
 const defaultElement = 'div';
 
-export const Grid = React.forwardRef(
+export const Grid: GridComponent = React.forwardRef(
   <E extends React.ElementType = typeof defaultElement>(
     {
       templateColumns,

--- a/packages/layout/src/beta/Grid/GridItem.tsx
+++ b/packages/layout/src/beta/Grid/GridItem.tsx
@@ -31,6 +31,12 @@ export type GridItemOwnProps = {
 export type GridItemProps<T extends React.ElementType = typeof defaultElement> =
   PolymorphicComponentProps<T, GridItemOwnProps>;
 
+export type GridItemComponent = (<
+  E extends React.ElementType = typeof defaultElement,
+>(
+  props: GridItemProps<E> & { ref?: React.Ref<Element> },
+) => React.ReactElement | null) & { displayName?: string };
+
 const defaultElement = 'div';
 
 const formatGridSpan = (
@@ -47,7 +53,7 @@ const formatGridSpan = (
   return value;
 };
 
-export const GridItem = React.forwardRef(
+export const GridItem: GridItemComponent = React.forwardRef(
   <E extends React.ElementType = typeof defaultElement>(
     {
       colSpan,

--- a/packages/layout/src/beta/templates/Sidebar.tsx
+++ b/packages/layout/src/beta/templates/Sidebar.tsx
@@ -46,7 +46,19 @@ export type SidebarSectionProps<
   T extends React.ElementType = typeof defaultSectionElement,
 > = PolymorphicComponentProps<T, SidebarSectionOwnProps>;
 
-const SidebarLogo = React.forwardRef(
+type SidebarRootComponent = (<
+  E extends React.ElementType = typeof defaultSidebarElement,
+>(
+  props: SidebarProps<E> & { ref?: React.Ref<Element> },
+) => React.ReactElement | null) & { displayName?: string };
+
+type SidebarSectionComponent<
+  Default extends React.ElementType = typeof defaultSectionElement,
+> = (<E extends React.ElementType = Default>(
+  props: SidebarSectionProps<E> & { ref?: React.Ref<Element> },
+) => React.ReactElement | null) & { displayName?: string };
+
+const SidebarLogo: SidebarSectionComponent = React.forwardRef(
   <E extends React.ElementType = typeof defaultSectionElement>(
     { children, as, ...rest }: SidebarSectionProps<E>,
     ref?: React.Ref<Element>,
@@ -60,7 +72,7 @@ const SidebarLogo = React.forwardRef(
   },
 );
 
-const SidebarUser = React.forwardRef(
+const SidebarUser: SidebarSectionComponent = React.forwardRef(
   <E extends React.ElementType = typeof defaultSectionElement>(
     { children, as, ...rest }: SidebarSectionProps<E>,
     ref?: React.Ref<Element>,
@@ -74,12 +86,13 @@ const SidebarUser = React.forwardRef(
   },
 );
 
-const SidebarData = React.forwardRef(
+const SidebarData: SidebarSectionComponent = React.forwardRef(
   <E extends React.ElementType = typeof defaultSectionElement>(
     { children, as, ...rest }: SidebarSectionProps<E>,
     ref?: React.Ref<Element>,
   ) => {
     return (
+      // @ts-expect-error generic prop forwarding through polymorphic Flex
       <Flex
         ref={ref}
         as={as || defaultSectionElement}
@@ -93,7 +106,9 @@ const SidebarData = React.forwardRef(
   },
 );
 
-const SidebarNavigation = React.forwardRef(
+const SidebarNavigation: SidebarSectionComponent<
+  typeof defaultNavigationElement
+> = React.forwardRef(
   <E extends React.ElementType = typeof defaultNavigationElement>(
     { children, className, as, ...rest }: SidebarSectionProps<E>,
     ref?: React.Ref<Element>,
@@ -114,23 +129,27 @@ const SidebarNavigation = React.forwardRef(
   },
 );
 
-const SidebarFooter = React.forwardRef(
-  <E extends React.ElementType = typeof defaultFooterElement>(
-    { children, className, as, ...rest }: SidebarSectionProps<E>,
-    ref?: React.Ref<Element>,
-  ) => {
-    const Element: React.ElementType = as || defaultFooterElement;
-    return (
-      <Element
-        ref={ref}
-        className={classNames('eds-layout-template-sidebar__footer', className)}
-        {...rest}
-      >
-        {children}
-      </Element>
-    );
-  },
-);
+const SidebarFooter: SidebarSectionComponent<typeof defaultFooterElement> =
+  React.forwardRef(
+    <E extends React.ElementType = typeof defaultFooterElement>(
+      { children, className, as, ...rest }: SidebarSectionProps<E>,
+      ref?: React.Ref<Element>,
+    ) => {
+      const Element: React.ElementType = as || defaultFooterElement;
+      return (
+        <Element
+          ref={ref}
+          className={classNames(
+            'eds-layout-template-sidebar__footer',
+            className,
+          )}
+          {...rest}
+        >
+          {children}
+        </Element>
+      );
+    },
+  );
 
 const CollapseToggle: React.FC<{
   isCollapsed: boolean;
@@ -149,7 +168,7 @@ const CollapseToggle: React.FC<{
   </button>
 );
 
-const SidebarRoot = React.forwardRef(
+const SidebarRoot: SidebarRootComponent = React.forwardRef(
   <E extends React.ElementType = typeof defaultSidebarElement>(
     {
       children,
@@ -189,6 +208,7 @@ const SidebarRoot = React.forwardRef(
     if (!collapsible) {
       return (
         <Grid.Item className={wrapperClassNames} colSpan="1 / 2">
+          {/* @ts-expect-error generic prop forwarding through polymorphic Flex */}
           <Flex
             ref={ref}
             as={as || defaultSidebarElement}
@@ -210,6 +230,7 @@ const SidebarRoot = React.forwardRef(
 
     return (
       <Grid.Item className={wrapperClassNames} colSpan="1 / 2">
+        {/* @ts-expect-error generic prop forwarding through polymorphic Flex */}
         <Flex
           ref={ref}
           as={as || defaultSidebarElement}

--- a/packages/layout/src/beta/templates/Sidebar.tsx
+++ b/packages/layout/src/beta/templates/Sidebar.tsx
@@ -24,6 +24,7 @@ type SidebarOwnProps = {
   closeSidebarAriaLabel?: string;
   className?: string;
   style?: React.CSSProperties;
+  /** Content of the sidebar */
   children?: React.ReactNode;
 };
 
@@ -208,18 +209,20 @@ const SidebarRoot: SidebarRootComponent = React.forwardRef(
     if (!collapsible) {
       return (
         <Grid.Item className={wrapperClassNames} colSpan="1 / 2">
-          {/* @ts-expect-error generic prop forwarding through polymorphic Flex */}
-          <Flex
-            ref={ref}
-            as={as || defaultSidebarElement}
-            direction="column"
-            gap="m"
-            className={sidebarClassNames}
-            style={style}
-            {...rest}
-          >
-            {children}
-          </Flex>
+          {
+            // @ts-expect-error generic prop forwarding through polymorphic Flex
+            <Flex
+              ref={ref}
+              as={as || defaultSidebarElement}
+              direction="column"
+              gap="m"
+              className={sidebarClassNames}
+              style={style}
+              {...rest}
+            >
+              {children}
+            </Flex>
+          }
         </Grid.Item>
       );
     }
@@ -230,18 +233,22 @@ const SidebarRoot: SidebarRootComponent = React.forwardRef(
 
     return (
       <Grid.Item className={wrapperClassNames} colSpan="1 / 2">
-        {/* @ts-expect-error generic prop forwarding through polymorphic Flex */}
-        <Flex
-          ref={ref}
-          as={as || defaultSidebarElement}
-          direction="column"
-          gap="m"
-          className={sidebarClassNames}
-          style={collapsedStyle}
-          {...rest}
-        >
-          <div className="eds-layout-template-sidebar__content">{children}</div>
-        </Flex>
+        {
+          // @ts-expect-error generic prop forwarding through polymorphic Flex
+          <Flex
+            ref={ref}
+            as={as || defaultSidebarElement}
+            direction="column"
+            gap="m"
+            className={sidebarClassNames}
+            style={collapsedStyle}
+            {...rest}
+          >
+            <div className="eds-layout-template-sidebar__content">
+              {children}
+            </div>
+          </Flex>
+        }
         {onCollapseToggle && (
           <CollapseToggle
             isCollapsed={isCollapsed}

--- a/packages/layout/src/beta/templates/portal/Portal.tsx
+++ b/packages/layout/src/beta/templates/portal/Portal.tsx
@@ -37,12 +37,29 @@ export type PortalMainProps<
   T extends React.ElementType = typeof defaultPortalMainElement,
 > = PolymorphicComponentProps<T, PortalMainOwnProps>;
 
-const PortalRoot = React.forwardRef(
+type PortalRootComponent = (<E extends React.ElementType = typeof Grid>(
+  props: PortalProps<E> & { ref?: React.Ref<Element> },
+) => React.ReactElement | null) & { displayName?: string };
+
+type PortalStatusBarComponent = (<
+  E extends React.ElementType = typeof defaultStatusBarElement,
+>(
+  props: PortalStatusBarProps<E> & { ref?: React.Ref<Element> },
+) => React.ReactElement | null) & { displayName?: string };
+
+type PortalMainComponent = (<
+  E extends React.ElementType = typeof defaultPortalMainElement,
+>(
+  props: PortalMainProps<E> & { ref?: React.Ref<Element> },
+) => React.ReactElement | null) & { displayName?: string };
+
+const PortalRoot: PortalRootComponent = React.forwardRef(
   <E extends React.ElementType = typeof Grid>(
     { children, className, style, as, ...rest }: PortalProps<E>,
     ref?: React.Ref<Element>,
   ) => {
     return (
+      // @ts-expect-error generic prop forwarding through polymorphic Grid
       <Grid
         ref={ref}
         as={as}
@@ -58,12 +75,13 @@ const PortalRoot = React.forwardRef(
   },
 );
 
-const PortalStatusBar = React.forwardRef(
+const PortalStatusBar: PortalStatusBarComponent = React.forwardRef(
   <E extends React.ElementType = typeof defaultStatusBarElement>(
     { children, className, as, ...rest }: PortalStatusBarProps<E>,
     ref?: React.Ref<Element>,
   ) => {
     return (
+      // @ts-expect-error generic prop forwarding through polymorphic Grid.Item
       <Grid.Item
         ref={ref}
         as={as || defaultStatusBarElement}
@@ -79,12 +97,13 @@ const PortalStatusBar = React.forwardRef(
   },
 );
 
-const PortalMain = React.forwardRef(
+const PortalMain: PortalMainComponent = React.forwardRef(
   <E extends React.ElementType = typeof defaultPortalMainElement>(
     { children, className, style, as, ...rest }: PortalMainProps<E>,
     ref?: React.Ref<Element>,
   ) => {
     return (
+      // @ts-expect-error generic prop forwarding through polymorphic Grid.Item
       <Grid.Item
         ref={ref}
         as={as || defaultPortalMainElement}

--- a/packages/layout/src/beta/templates/portal/Portal.tsx
+++ b/packages/layout/src/beta/templates/portal/Portal.tsx
@@ -8,18 +8,21 @@ import './Portal.scss';
 type PortalOwnProps = {
   className?: string;
   style?: React.CSSProperties;
+  /** Content of the portal layout */
   children?: React.ReactNode;
 };
 
 type PortalStatusBarOwnProps = {
   className?: string;
   style?: React.CSSProperties;
+  /** Content of the status bar */
   children?: React.ReactNode;
 };
 
 type PortalMainOwnProps = {
   className?: string;
   style?: React.CSSProperties;
+  /** Main content area */
   children?: React.ReactNode;
 };
 


### PR DESCRIPTION
## 💡 Hvorfor?

Prop-dokumentasjonen for `Template.Portal.Sidebar`, `Flex`, `Grid`, `GridItem` og `Template.Portal` ble generert tom. Årsaken er at `react-docgen-typescript` ikke klarer å resolve generics i `React.forwardRef(<E>(...))` når komponenten bruker `PolymorphicComponentProps<T, OwnProps>` uten en eksplisitt callable type-annotasjon — samme mønster som `PrimaryButton` allerede bruker for å unngå dette.

I tillegg fikser vi en feil i sidenav-tagvisningen i dokumentasjonssiden: tag-sammenligningen var case-sensitiv og brukte ugyldig Badge-variant `'positive'`.

## 🔧 Hvordan?

**`refactor(layout/beta)`** — Legger til `*Component`-type-aliaser som spesifiserer default for generic-parameteret. Dette gir docgen en konkret type å lese props fra. Mønsteret matcher `PrimaryButtonComponent`/`ButtonComponent` i `packages/button`.

- Nye eksporter/typer: `FlexComponent`, `FlexSpacerComponent`, `GridComponent`, `GridItemComponent`, samt interne `PortalRootComponent`/`PortalStatusBarComponent`/`PortalMainComponent` og `SidebarRootComponent`/`SidebarSectionComponent`.
- Hver type intersecter `& { displayName?: string }` slik at eksisterende `.displayName = '…'`-tilordninger kompilerer.
- 6 `@ts-expect-error` lagt til i Portal og Sidebar der én polymorf komponent rendrer en annen og generic `E` flyter mellom dem (TS klarer ikke å unifisere `PolymorphicComponentProps<E, A>` mot `PolymorphicComponentProps<E, B>`). Samme workaround som `PrimaryButton` bruker mot `Button`. Påvirker ikke konsumenter — de ser fremdeles full polymorf type med `as`-prop-autocomplete.

**`fix(website)`** — Endrer `item.tag === 'beta'` til `item.tag.toLowerCase() === 'beta'` og `'positive'` → `'success'` (gyldig Badge-variant).

## 🧩 Type endring

- [x] 🐞 Feilretting (manglende prop-docs, feil tag-variant)
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [x] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

- `Template.Portal.Sidebar.json` ble committed med tom `props: {}` i siste regenerering — denne PR-en gjenoppretter alle props (`contrast`, `collapsed`, `onCollapseToggle`, `openSidebarAriaLabel`, `closeSidebarAriaLabel`, …).
- Konsumenter ser ingen endring i runtime-oppførsel; bare prop-typene er nå strengere callable signatures (samme stil som `PrimaryButton`).
- `@ts-expect-error`-kommentarene gjelder kun ved generic-til-generic forwarding inni andre polymorfe komponenter — typisk app-kode med konkret `as="div"` el.l. blir ikke påvirket.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt) — prop-JSON-er regenerert
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [x] `tsc --noEmit` ren i `packages/layout`
- [x] `oxlint` 0 advarsler
- [x] `jest` 12/12 grønn i `packages/layout/src/beta`
- [x] `yarn generate-props` produserer korrekte JSON-er for alle berørte komponenter
- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden