### PR TITLE
feat(travelheader): add small travel header and new sizetokens

### DIFF
--- a/apps/documentation/src/data/props/travel-props.tsx
+++ b/apps/documentation/src/data/props/travel-props.tsx
@@ -44,8 +44,14 @@ export const travelheader = [
   {
     name: 'size',
     defaultValue: 'large',
-    options: ['medium', 'large'],
+    options: ['small', 'medium', 'large'],
     type: 'segmented',
+  },
+  {
+    name: 'noWrap',
+    defaultValue: false,
+    type: 'boolean',
+    label: 'Samme linje',
   },
   {
     name: 'from',

--- a/apps/documentation/src/data/props/travel-props.tsx
+++ b/apps/documentation/src/data/props/travel-props.tsx
@@ -44,7 +44,7 @@ export const travelheader = [
   {
     name: 'size',
     defaultValue: 'large',
-    options: ['small', 'medium', 'large'],
+    options: ['medium', 'large', 'extra-large'],
     type: 'segmented',
   },
   {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TravelHeader.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TravelHeader.json
@@ -65,7 +65,7 @@
       ],
       "required": false,
       "type": {
-        "name": "\"large\" | \"medium\" | undefined"
+        "name": "\"medium\" | \"large\" | \"xl\" | undefined"
       }
     },
     "noWrap": {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
@@ -549,7 +549,7 @@
     "outputs": ["LegLine.json"]
   },
   "travel/src/TravelHeader.tsx": {
-    "hash": "d67e7d0a622dcea4efcbaf36035ad993",
+    "hash": "33f6699b9b7a2c073b3c8434386628b9",
     "outputs": ["TravelHeader.json"]
   },
   "travel/src/TravelLeg.tsx": {

--- a/packages/tokens/src/component.json
+++ b/packages/tokens/src/component.json
@@ -12599,73 +12599,73 @@
         "color": [],
         "number": [
           {
-            "name": "Components/travel/Travel header/border/small",
+            "name": "Components/travel/Travel Header/border/small",
             "value": "0.125rem",
             "var": "size-2",
             "rootAlias": "size-2"
           },
           {
-            "name": "Components/travel/Travel header/border/large",
+            "name": "Components/travel/Travel Header/border/large",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel header/border/medium",
+            "name": "Components/travel/Travel Header/border/medium",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel header/gap/small",
+            "name": "Components/travel/Travel Header/gap/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/gap/medium",
+            "name": "Components/travel/Travel Header/gap/medium",
             "value": "0.75rem",
             "var": "size-6",
             "rootAlias": "size-6"
           },
           {
-            "name": "Components/travel/Travel header/gap/large",
+            "name": "Components/travel/Travel Header/gap/large",
             "value": "1rem",
             "var": "size-8",
             "rootAlias": "size-8"
           },
           {
-            "name": "Components/travel/Travel header/spacing/large",
+            "name": "Components/travel/Travel Header/spacing/large",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/spacing/medium",
+            "name": "Components/travel/Travel Header/spacing/medium",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/spacing/small",
+            "name": "Components/travel/Travel Header/spacing/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/width/small",
+            "name": "Components/travel/Travel Header/width/small",
             "value": "1.5rem",
             "var": "size-10",
             "rootAlias": "size-10"
           },
           {
-            "name": "Components/travel/Travel header/width/medium",
+            "name": "Components/travel/Travel Header/width/medium",
             "value": "2rem",
             "var": "size-12",
             "rootAlias": "size-12"
           },
           {
-            "name": "Components/travel/Travel header/width/large",
+            "name": "Components/travel/Travel Header/width/large",
             "value": "2.5rem",
             "var": "size-14",
             "rootAlias": "size-14"
@@ -13371,73 +13371,73 @@
         "color": [],
         "number": [
           {
-            "name": "Components/travel/Travel header/border/small",
+            "name": "Components/travel/Travel Header/border/small",
             "value": "0.125rem",
             "var": "size-2",
             "rootAlias": "size-2"
           },
           {
-            "name": "Components/travel/Travel header/border/large",
+            "name": "Components/travel/Travel Header/border/large",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel header/border/medium",
+            "name": "Components/travel/Travel Header/border/medium",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel header/gap/medium",
+            "name": "Components/travel/Travel Header/gap/medium",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/gap/small",
+            "name": "Components/travel/Travel Header/gap/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/gap/large",
+            "name": "Components/travel/Travel Header/gap/large",
             "value": "0.75rem",
             "var": "size-6",
             "rootAlias": "size-6"
           },
           {
-            "name": "Components/travel/Travel header/spacing/large",
+            "name": "Components/travel/Travel Header/spacing/large",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/spacing/medium",
+            "name": "Components/travel/Travel Header/spacing/medium",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/spacing/small",
+            "name": "Components/travel/Travel Header/spacing/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/width/small",
+            "name": "Components/travel/Travel Header/width/small",
             "value": "1.25rem",
             "var": "size-9",
             "rootAlias": "size-9"
           },
           {
-            "name": "Components/travel/Travel header/width/medium",
+            "name": "Components/travel/Travel Header/width/medium",
             "value": "1.75rem",
             "var": "size-11",
             "rootAlias": "size-11"
           },
           {
-            "name": "Components/travel/Travel header/width/large",
+            "name": "Components/travel/Travel Header/width/large",
             "value": "2rem",
             "var": "size-12",
             "rootAlias": "size-12"
@@ -14143,73 +14143,73 @@
         "color": [],
         "number": [
           {
-            "name": "Components/travel/Travel header/border/small",
+            "name": "Components/travel/Travel Header/border/small",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel header/border/medium",
+            "name": "Components/travel/Travel Header/border/medium",
             "value": "0.375rem",
             "var": "size-4",
             "rootAlias": "size-4"
           },
           {
-            "name": "Components/travel/Travel header/border/large",
+            "name": "Components/travel/Travel Header/border/large",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/gap/small",
+            "name": "Components/travel/Travel Header/gap/small",
             "value": "0.75rem",
             "var": "size-6",
             "rootAlias": "size-6"
           },
           {
-            "name": "Components/travel/Travel header/gap/medium",
+            "name": "Components/travel/Travel Header/gap/medium",
             "value": "1rem",
             "var": "size-8",
             "rootAlias": "size-8"
           },
           {
-            "name": "Components/travel/Travel header/gap/large",
+            "name": "Components/travel/Travel Header/gap/large",
             "value": "1.5rem",
             "var": "size-10",
             "rootAlias": "size-10"
           },
           {
-            "name": "Components/travel/Travel header/spacing/small",
+            "name": "Components/travel/Travel Header/spacing/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel header/spacing/medium",
+            "name": "Components/travel/Travel Header/spacing/medium",
             "value": "0.75rem",
             "var": "size-6",
             "rootAlias": "size-6"
           },
           {
-            "name": "Components/travel/Travel header/spacing/large",
+            "name": "Components/travel/Travel Header/spacing/large",
             "value": "1rem",
             "var": "size-8",
             "rootAlias": "size-8"
           },
           {
-            "name": "Components/travel/Travel header/width/small",
+            "name": "Components/travel/Travel Header/width/small",
             "value": "2.5rem",
             "var": "size-14",
             "rootAlias": "size-14"
           },
           {
-            "name": "Components/travel/Travel header/width/medium",
+            "name": "Components/travel/Travel Header/width/medium",
             "value": "3.5rem",
             "var": "size-18",
             "rootAlias": "size-18"
           },
           {
-            "name": "Components/travel/Travel header/width/large",
+            "name": "Components/travel/Travel Header/width/large",
             "value": "4.5rem",
             "var": "size-20",
             "rootAlias": "size-20"

--- a/packages/tokens/src/component.json
+++ b/packages/tokens/src/component.json
@@ -12599,73 +12599,73 @@
         "color": [],
         "number": [
           {
-            "name": "Components/travel/Travel Header/border/small",
+            "name": "Components/travel/Travel header/border/small",
             "value": "0.125rem",
             "var": "size-2",
             "rootAlias": "size-2"
           },
           {
-            "name": "Components/travel/Travel Header/border/large",
+            "name": "Components/travel/Travel header/border/large",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel Header/border/medium",
+            "name": "Components/travel/Travel header/border/medium",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel Header/gap/small",
+            "name": "Components/travel/Travel header/gap/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/gap/medium",
+            "name": "Components/travel/Travel header/gap/medium",
             "value": "0.75rem",
             "var": "size-6",
             "rootAlias": "size-6"
           },
           {
-            "name": "Components/travel/Travel Header/gap/large",
+            "name": "Components/travel/Travel header/gap/large",
             "value": "1rem",
             "var": "size-8",
             "rootAlias": "size-8"
           },
           {
-            "name": "Components/travel/Travel Header/spacing/large",
+            "name": "Components/travel/Travel header/spacing/large",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/spacing/medium",
+            "name": "Components/travel/Travel header/spacing/medium",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/spacing/small",
+            "name": "Components/travel/Travel header/spacing/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/width/small",
+            "name": "Components/travel/Travel header/width/small",
             "value": "1.5rem",
             "var": "size-10",
             "rootAlias": "size-10"
           },
           {
-            "name": "Components/travel/Travel Header/width/medium",
+            "name": "Components/travel/Travel header/width/medium",
             "value": "2rem",
             "var": "size-12",
             "rootAlias": "size-12"
           },
           {
-            "name": "Components/travel/Travel Header/width/large",
+            "name": "Components/travel/Travel header/width/large",
             "value": "2.5rem",
             "var": "size-14",
             "rootAlias": "size-14"
@@ -13371,73 +13371,73 @@
         "color": [],
         "number": [
           {
-            "name": "Components/travel/Travel Header/border/small",
+            "name": "Components/travel/Travel header/border/small",
             "value": "0.125rem",
             "var": "size-2",
             "rootAlias": "size-2"
           },
           {
-            "name": "Components/travel/Travel Header/border/large",
+            "name": "Components/travel/Travel header/border/large",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel Header/border/medium",
+            "name": "Components/travel/Travel header/border/medium",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel Header/gap/medium",
+            "name": "Components/travel/Travel header/gap/medium",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/gap/small",
+            "name": "Components/travel/Travel header/gap/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/gap/large",
+            "name": "Components/travel/Travel header/gap/large",
             "value": "0.75rem",
             "var": "size-6",
             "rootAlias": "size-6"
           },
           {
-            "name": "Components/travel/Travel Header/spacing/large",
+            "name": "Components/travel/Travel header/spacing/large",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/spacing/medium",
+            "name": "Components/travel/Travel header/spacing/medium",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/spacing/small",
+            "name": "Components/travel/Travel header/spacing/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/width/small",
+            "name": "Components/travel/Travel header/width/small",
             "value": "1.25rem",
             "var": "size-9",
             "rootAlias": "size-9"
           },
           {
-            "name": "Components/travel/Travel Header/width/medium",
+            "name": "Components/travel/Travel header/width/medium",
             "value": "1.75rem",
             "var": "size-11",
             "rootAlias": "size-11"
           },
           {
-            "name": "Components/travel/Travel Header/width/large",
+            "name": "Components/travel/Travel header/width/large",
             "value": "2rem",
             "var": "size-12",
             "rootAlias": "size-12"
@@ -14143,73 +14143,73 @@
         "color": [],
         "number": [
           {
-            "name": "Components/travel/Travel Header/border/small",
+            "name": "Components/travel/Travel header/border/small",
             "value": "0.25rem",
             "var": "size-3",
             "rootAlias": "size-3"
           },
           {
-            "name": "Components/travel/Travel Header/border/medium",
+            "name": "Components/travel/Travel header/border/medium",
             "value": "0.375rem",
             "var": "size-4",
             "rootAlias": "size-4"
           },
           {
-            "name": "Components/travel/Travel Header/border/large",
+            "name": "Components/travel/Travel header/border/large",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/gap/small",
+            "name": "Components/travel/Travel header/gap/small",
             "value": "0.75rem",
             "var": "size-6",
             "rootAlias": "size-6"
           },
           {
-            "name": "Components/travel/Travel Header/gap/medium",
+            "name": "Components/travel/Travel header/gap/medium",
             "value": "1rem",
             "var": "size-8",
             "rootAlias": "size-8"
           },
           {
-            "name": "Components/travel/Travel Header/gap/large",
+            "name": "Components/travel/Travel header/gap/large",
             "value": "1.5rem",
             "var": "size-10",
             "rootAlias": "size-10"
           },
           {
-            "name": "Components/travel/Travel Header/spacing/small",
+            "name": "Components/travel/Travel header/spacing/small",
             "value": "0.5rem",
             "var": "size-5",
             "rootAlias": "size-5"
           },
           {
-            "name": "Components/travel/Travel Header/spacing/medium",
+            "name": "Components/travel/Travel header/spacing/medium",
             "value": "0.75rem",
             "var": "size-6",
             "rootAlias": "size-6"
           },
           {
-            "name": "Components/travel/Travel Header/spacing/large",
+            "name": "Components/travel/Travel header/spacing/large",
             "value": "1rem",
             "var": "size-8",
             "rootAlias": "size-8"
           },
           {
-            "name": "Components/travel/Travel Header/width/small",
+            "name": "Components/travel/Travel header/width/small",
             "value": "2.5rem",
             "var": "size-14",
             "rootAlias": "size-14"
           },
           {
-            "name": "Components/travel/Travel Header/width/medium",
+            "name": "Components/travel/Travel header/width/medium",
             "value": "3.5rem",
             "var": "size-18",
             "rootAlias": "size-18"
           },
           {
-            "name": "Components/travel/Travel Header/width/large",
+            "name": "Components/travel/Travel header/width/large",
             "value": "4.5rem",
             "var": "size-20",
             "rootAlias": "size-20"

--- a/packages/travel/src/TravelHeader.scss
+++ b/packages/travel/src/TravelHeader.scss
@@ -1,20 +1,42 @@
 @use '@entur/tokens/dist/styles.scss' as t;
 
 .eds-travel-header {
+  align-items: flex-start;
   color: var(--components-travel-travelheader-standard-text);
   display: flex;
   flex-direction: column;
   font-weight: t.$font-weights-heading;
-  line-height: 1.5;
+  line-height: var(--font-line-height-heading-xl);
   max-width: 100%;
-  .eds-contrast & {
+  :where(.eds-contrast) & {
     color: var(--components-travel-travelheader-contrast-text);
   }
   &--large {
-    font-size: t.$font-sizes-extra-large2;
+    font-size: var(--font-size-heading-xl);
+    line-height: var(--font-line-height-heading-xl);
+    gap: var(--components-travel-travelheader-spacing-large);
+
+    &:where(.eds-travel-header--no-wrap) {
+      gap: var(--components-travel-travelheader-gap-large);
+    }
   }
   &--medium {
-    font-size: t.$font-sizes-large;
+    font-size: var(--font-size-heading-lg);
+    line-height: var(--font-line-height-heading-lg);
+    gap: var(--components-travel-travelheader-spacing-medium);
+
+    &:where(.eds-travel-header--no-wrap) {
+      gap: var(--components-travel-travelheader-gap-medium);
+    }
+  }
+  &--small {
+    font-size: var(--font-size-heading-s);
+    line-height: var(--font-line-height-heading-s);
+    gap: var(--components-travel-travelheader-spacing-small);
+
+    &:where(.eds-travel-header--no-wrap) {
+      gap: var(--components-travel-travelheader-gap-small);
+    }
   }
   &--no-wrap {
     flex-direction: row;
@@ -26,25 +48,39 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  &__from {
-    .eds-travel-header--no-wrap & {
-      margin-right: 0.5em;
-    }
-  }
   &__to {
-    padding-left: calc(4em / 3 + 0.5em);
+    padding-left: calc(var(--components-travel-travelheader-width-large) + var(--components-travel-travelheader-spacing-large));
     position: relative;
+
+    :where(.eds-travel-header--medium) & {
+      padding-left: calc(var(--components-travel-travelheader-width-medium) + var(--components-travel-travelheader-spacing-medium));
+    }
+
+    :where(.eds-travel-header--small) & {
+      padding-left: calc(var(--components-travel-travelheader-width-small) + var(--components-travel-travelheader-spacing-small));
+    }
+
     &::before {
       background-color: var(--components-travel-travelheader-standard-stroke-line);
       content: '';
       display: block;
-      height: calc(1em / 6);
+      height: var(--components-travel-travelheader-border-large);
+      width: var(--components-travel-travelheader-width-large);
       left: 0;
       position: absolute;
-      top: 0.65em;
-      width: calc(4em / 3);
+      top: 50%;
+      transform: translateY(-50%);
+      :where(.eds-travel-header--medium) & {
+        height: var(--components-travel-travelheader-border-medium);
+        width: var(--components-travel-travelheader-width-medium);
+      }
 
-      .eds-contrast & {
+      :where(.eds-travel-header--small) & {
+        height: var(--components-travel-travelheader-border-small);
+        width: var(--components-travel-travelheader-width-small);
+      }
+
+      :where(.eds-contrast) & {
         background-color: var(--components-travel-travelheader-contrast-stroke-line);
       }
     }

--- a/packages/travel/src/TravelHeader.scss
+++ b/packages/travel/src/TravelHeader.scss
@@ -5,39 +5,37 @@
   color: var(--components-travel-travelheader-standard-text);
   display: flex;
   flex-direction: column;
-  font-weight: t.$font-weights-heading;
-  line-height: var(--font-line-height-heading-xl);
+  font-weight: var(--font-weight-heading);
+  line-height: var(--font-line-height-heading-lg);
   max-width: 100%;
   :where(.eds-contrast) & {
     color: var(--components-travel-travelheader-contrast-text);
   }
-  &--large {
+  &--extra-large {
     font-size: var(--font-size-heading-xl);
     line-height: var(--font-line-height-heading-xl);
-    gap: var(--components-travel-travelheader-spacing-large);
+
+    &:where(.eds-travel-header--no-wrap) {
+      gap: var(--components-travel-travelheader-gap-xl);
+    }
+  }
+  &--large {
+    font-size: var(--font-size-heading-lg);
+    line-height: var(--font-line-height-heading-lg);
 
     &:where(.eds-travel-header--no-wrap) {
       gap: var(--components-travel-travelheader-gap-large);
     }
   }
   &--medium {
-    font-size: var(--font-size-heading-lg);
-    line-height: var(--font-line-height-heading-lg);
-    gap: var(--components-travel-travelheader-spacing-medium);
+    font-size: var(--font-size-heading-m);
+    line-height: var(--font-line-height-heading-m);
 
     &:where(.eds-travel-header--no-wrap) {
       gap: var(--components-travel-travelheader-gap-medium);
     }
   }
-  &--small {
-    font-size: var(--font-size-heading-s);
-    line-height: var(--font-line-height-heading-s);
-    gap: var(--components-travel-travelheader-spacing-small);
 
-    &:where(.eds-travel-header--no-wrap) {
-      gap: var(--components-travel-travelheader-gap-small);
-    }
-  }
   &--no-wrap {
     flex-direction: row;
   }
@@ -56,8 +54,8 @@
       padding-left: calc(var(--components-travel-travelheader-width-medium) + var(--components-travel-travelheader-spacing-medium));
     }
 
-    :where(.eds-travel-header--small) & {
-      padding-left: calc(var(--components-travel-travelheader-width-small) + var(--components-travel-travelheader-spacing-small));
+    :where(.eds-travel-header--extra-large) & {
+      padding-left: calc(var(--components-travel-travelheader-width-xl) + var(--components-travel-travelheader-spacing-xl));
     }
 
     &::before {
@@ -75,9 +73,9 @@
         width: var(--components-travel-travelheader-width-medium);
       }
 
-      :where(.eds-travel-header--small) & {
-        height: var(--components-travel-travelheader-border-small);
-        width: var(--components-travel-travelheader-width-small);
+      :where(.eds-travel-header--extra-large) & {
+        height: var(--components-travel-travelheader-border-xl);
+        width: var(--components-travel-travelheader-width-xl);
       }
 
       :where(.eds-contrast) & {

--- a/packages/travel/src/TravelHeader.test.tsx
+++ b/packages/travel/src/TravelHeader.test.tsx
@@ -25,4 +25,9 @@ test('TravelHeader renders with content, spread props and with correct classname
   );
   const componentMedium = getByTestId(testid);
   expect(componentMedium).toHaveClass('eds-travel-header--medium');
+  rerender(
+    <TravelHeader from={from} to={to} size="small" data-testid={testid} />,
+  );
+  const componentSmall = getByTestId(testid);
+  expect(componentSmall).toHaveClass('eds-travel-header--small');
 });

--- a/packages/travel/src/TravelHeader.test.tsx
+++ b/packages/travel/src/TravelHeader.test.tsx
@@ -26,8 +26,13 @@ test('TravelHeader renders with content, spread props and with correct classname
   const componentMedium = getByTestId(testid);
   expect(componentMedium).toHaveClass('eds-travel-header--medium');
   rerender(
-    <TravelHeader from={from} to={to} size="small" data-testid={testid} />,
+    <TravelHeader
+      from={from}
+      to={to}
+      size="extra-large"
+      data-testid={testid}
+    />,
   );
-  const componentSmall = getByTestId(testid);
-  expect(componentSmall).toHaveClass('eds-travel-header--small');
+  const componentXl = getByTestId(testid);
+  expect(componentXl).toHaveClass('eds-travel-header--extra-large');
 });

--- a/packages/travel/src/TravelHeader.tsx
+++ b/packages/travel/src/TravelHeader.tsx
@@ -14,7 +14,7 @@ export type TravelHeaderProps = {
   /**Størrelsen på komponenten
    * @default 'large'
    */
-  size?: 'large' | 'medium';
+  size?: 'small' | 'medium' | 'large';
   /** Plassere til og fra på samme linje */
   noWrap?: boolean;
   /**Ekstra klassenavn */
@@ -36,6 +36,7 @@ export const TravelHeader: React.FC<TravelHeaderProps> = ({
       className={classNames('eds-travel-header', className, {
         'eds-travel-header--large': size === 'large',
         'eds-travel-header--medium': size === 'medium',
+        'eds-travel-header--small': size === 'small',
         'eds-travel-header--no-wrap': noWrap,
       })}
       aria-label={`Fra ${from}, til ${to}`}

--- a/packages/travel/src/TravelHeader.tsx
+++ b/packages/travel/src/TravelHeader.tsx
@@ -14,7 +14,7 @@ export type TravelHeaderProps = {
   /**Størrelsen på komponenten
    * @default 'large'
    */
-  size?: 'small' | 'medium' | 'large';
+  size?: 'medium' | 'large' | 'extra-large';
   /** Plassere til og fra på samme linje */
   noWrap?: boolean;
   /**Ekstra klassenavn */
@@ -36,7 +36,7 @@ export const TravelHeader: React.FC<TravelHeaderProps> = ({
       className={classNames('eds-travel-header', className, {
         'eds-travel-header--large': size === 'large',
         'eds-travel-header--medium': size === 'medium',
-        'eds-travel-header--small': size === 'small',
+        'eds-travel-header--extra-large': size === 'extra-large',
         'eds-travel-header--no-wrap': noWrap,
       })}
       aria-label={`Fra ${from}, til ${to}`}

--- a/packages/travel/src/componentVariables.scss
+++ b/packages/travel/src/componentVariables.scss
@@ -638,46 +638,46 @@
 
 [data-view-mode='standard'],
 :root {
-  --components-travel-travelheader-border-small: #{$size-2};
+  --components-travel-travelheader-border-xl: #{$size-4};
   --components-travel-travelheader-border-large: #{$size-3};
   --components-travel-travelheader-border-medium: #{$size-3};
-  --components-travel-travelheader-gap-small: #{$size-5};
+  --components-travel-travelheader-gap-xl: #{$size-10};
   --components-travel-travelheader-gap-medium: #{$size-6};
   --components-travel-travelheader-gap-large: #{$size-8};
   --components-travel-travelheader-spacing-large: #{$size-5};
   --components-travel-travelheader-spacing-medium: #{$size-5};
-  --components-travel-travelheader-spacing-small: #{$size-5};
-  --components-travel-travelheader-width-small: #{$size-10};
+  --components-travel-travelheader-spacing-xl: #{$size-6};
+  --components-travel-travelheader-width-xl: #{$size-16};
   --components-travel-travelheader-width-medium: #{$size-12};
   --components-travel-travelheader-width-large: #{$size-14};
 }
 
 [data-view-mode='compact'] {
-  --components-travel-travelheader-border-small: #{$size-2};
+  --components-travel-travelheader-border-xl: #{$size-3};
   --components-travel-travelheader-border-large: #{$size-3};
   --components-travel-travelheader-border-medium: #{$size-3};
   --components-travel-travelheader-gap-medium: #{$size-5};
-  --components-travel-travelheader-gap-small: #{$size-5};
+  --components-travel-travelheader-gap-xl: #{$size-7};
   --components-travel-travelheader-gap-large: #{$size-6};
   --components-travel-travelheader-spacing-large: #{$size-5};
   --components-travel-travelheader-spacing-medium: #{$size-5};
-  --components-travel-travelheader-spacing-small: #{$size-5};
-  --components-travel-travelheader-width-small: #{$size-9};
+  --components-travel-travelheader-spacing-xl: #{$size-5};
+  --components-travel-travelheader-width-xl: #{$size-13};
   --components-travel-travelheader-width-medium: #{$size-11};
   --components-travel-travelheader-width-large: #{$size-12};
 }
 
 [data-view-mode='display'] {
-  --components-travel-travelheader-border-small: #{$size-3};
+  --components-travel-travelheader-border-xl: #{$size-6};
   --components-travel-travelheader-border-medium: #{$size-4};
   --components-travel-travelheader-border-large: #{$size-5};
-  --components-travel-travelheader-gap-small: #{$size-6};
+  --components-travel-travelheader-gap-xl: #{$size-12};
   --components-travel-travelheader-gap-medium: #{$size-8};
   --components-travel-travelheader-gap-large: #{$size-10};
-  --components-travel-travelheader-spacing-small: #{$size-5};
+  --components-travel-travelheader-spacing-xl: #{$size-10};
   --components-travel-travelheader-spacing-medium: #{$size-6};
   --components-travel-travelheader-spacing-large: #{$size-8};
-  --components-travel-travelheader-width-small: #{$size-14};
+  --components-travel-travelheader-width-xl: #{$size-22};
   --components-travel-travelheader-width-medium: #{$size-18};
   --components-travel-travelheader-width-large: #{$size-20};
 }

--- a/packages/travel/src/index.scss
+++ b/packages/travel/src/index.scss
@@ -1,5 +1,8 @@
 @use './componentVariables.scss';
 @use '@entur/tokens/dist/base.scss' as *;
+// Manually import typography tokens (to support dynamic text sizes) until these are out of beta
+@use '@entur/typography/src/beta/typographyTokens.scss' as *;
+
 @use '@entur/tokens/dist/transport.css';
 :root {
   --eds-travel: 1;


### PR DESCRIPTION
WIP - venter på avklaring om small av Wei

## 💡 Hvorfor?
- TravelHeader mangler size small og extra large og display mode


## 🔧 Hvordan?
- Lagt til size XL
- Variablene er nå lagt til i `data-view-mode`
- Oppdatert tokens og scss i TravelHeader med size variabler
- Oppdatert scss for TravelHeader slik at den gjenspeiler Figma mer

## 🧩 Type endring

- [ ] 🐞 Feilretting
- [x]  🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [x] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder
<img width="471" height="403" alt="Screenshot 2026-05-04 at 12 44 43" src="https://github.com/user-attachments/assets/0ae42352-35cb-463c-9049-049d8d1ca79c" />


## 💬 Tilleggsnotater
- Nå er det ikke gap-size på høyre side på den røde mellomlinjen ved `noWrap`, dette fordi det er en ::before. Kan det være sånn eller bør vi endre helt likt som Figma?

- [x] - `XL - extra-large`. hva er riktig for prop-verdi?

- Figma har small. De må gjøre det samme som i kode , legge til XL. Slik at vi får component size XL-variabler som nå mangler

## 💣 Breaking changes (om aktuelt)



## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre (se tilleggskommentar)
- [x] Dokumentasjonen er oppdatert
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [x] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden
