### PR TITLE
fix(layout/beta/flex): fix props leaking into nested Flex components

### DIFF
--- a/packages/layout/src/beta/Flex/Flex.scss
+++ b/packages/layout/src/beta/Flex/Flex.scss
@@ -1,4 +1,24 @@
 .eds-layout-flex {
+  --flex-display: initial;
+  --flex-direction: initial;
+  --flex-wrap: initial;
+  --flex-align-items: initial;
+  --flex-justify-content: initial;
+  --flex-align-content: initial;
+  --flex-gap: initial;
+  --flex-row-gap: initial;
+  --flex-column-gap: initial;
+  --flex: initial;
+  --flex-grow: initial;
+  --flex-shrink: initial;
+  --flex-basis: initial;
+  --flex-width: initial;
+  --flex-height: initial;
+  --flex-min-width: initial;
+  --flex-min-height: initial;
+  --flex-max-width: initial;
+  --flex-max-height: initial;
+
   :where(&) {
     display: var(--flex-display, flex);
     flex-direction: var(--flex-direction, row);


### PR DESCRIPTION
## 💡 Hvorfor?

Nøstede `<Flex>`-komponenter arvet CSS-variabler fra forelderen. F.eks. ville et `<Flex gap="l">` sette `--flex-gap`, og et barneelement `<Flex>` uten `gap`-prop ville plukke opp variabelen istedenfor å bruke sin standard.

Løser [ETU-71750](https://entur.atlassian.net/browse/ETU-71750).

## 🔧 Hvordan?

La til `--flex-*: initial;`-resett øverst i `.eds-layout-flex`-selektoren i `Flex.scss`. Samme løsning ble tidligere brukt for `Grid`.

## 🧩 Type endring

- [x] 🐞 Feilretting

## 🖼️ Skjermbilder

N/A

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden

[ETU-71750]: https://entur.atlassian.net/browse/ETU-71750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ