### PR TITLE
fix(alert/copyable text): respect onClick prop passed by consumer

### DIFF
--- a/packages/alert/src/CopyableText.tsx
+++ b/packages/alert/src/CopyableText.tsx
@@ -33,6 +33,7 @@ export const CopyableText = ({
   successMessage,
   textToCopy,
   className,
+  onClick,
   'aria-label': ariaLabel = `Kopier ${
     textToCopy ?? children
   } til utklippstavlen`,
@@ -43,12 +44,13 @@ export const CopyableText = ({
   const _textToCopy = textToCopy ?? children;
   const _successMessage =
     successMessage ?? `${_textToCopy} ble kopiert til utklippstavlen.`;
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     buttonRef.current &&
       copy(_textToCopy, {
         target: buttonRef.current,
       }) &&
       addToast({ title: successHeading, content: _successMessage });
+    onClick?.(e);
   };
   return (
     <div


### PR DESCRIPTION
## 💡 Hvorfor?

Om man sender inn `onClick` overskrives kopiering fra `CopyableText`

## 🔧 Hvordan?

Om man sender inn `onClick` kalles funksjonen etter `CopyableText` sin click-handler 

## 🧩 Type endring

<!-- Kryss av det som passer -->

- [X] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## ✅ Sjekkliste

<!-- Kryss av når punktene er oppfylt -->

- [X] Navnestandarder følges
- [X] Kode og Figma reflekterer hverandre
- [X] Dokumentasjonen er oppdatert (hvis aktuelt)
- [X] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

<!-- Hvordan er endringen testet og verifisert? -->

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden
