### PR TITLE
feat(layout/beta): rename LayoutWrapper to LayoutProvider og oppdater breakpoints

### DIFF
--- a/packages/layout/src/beta/Grid/index.ts
+++ b/packages/layout/src/beta/Grid/index.ts
@@ -30,5 +30,5 @@ export type { GridProps, GridOwnProps } from './Grid';
 export type { GridSpacingValue, ResponsiveValue } from '../LayoutWrapper/utils';
 export type { GridItemProps, GridItemOwnProps } from './GridItem';
 export { GridComponent as Grid, GridItem };
-export { LayoutWrapper } from '../LayoutWrapper/LayoutWrapper';
+export { LayoutProvider } from '../LayoutWrapper/LayoutWrapper';
 export { useLayoutValues } from '../LayoutWrapper/useLayoutValues';

--- a/packages/layout/src/beta/LayoutWrapper/LayoutWrapper.tsx
+++ b/packages/layout/src/beta/LayoutWrapper/LayoutWrapper.tsx
@@ -7,17 +7,32 @@ export type LayoutValues = {
 
 const LayoutContext = createContext<LayoutValues | null>(null);
 
-export type LayoutWrapperProps = {
-  /** Custom breakpoint values to override defaults */
+export type LayoutProviderProps = {
+  /**
+   * Custom breakpoint values (in px) to override the defaults.
+   *
+   * Breakpoints are **min-width** based: a breakpoint activates when the
+   * viewport is at least that wide and stays active until the next breakpoint.
+   *
+   * Default values:
+   * - `s`: 0px — always active below `m` (not configurable)
+   * - `m`: 800px — active from 800px up to (but not including) `lg`
+   * - `lg`: 1200px — active from 1200px up to (but not including) `xl`
+   * - `xl`: 1400px — active from 1400px and above
+   *
+   * @example
+   * <LayoutProvider breakpoints={{ m: 600, lg: 1024, xl: 1280 }}>
+   *   ...
+   * </LayoutProvider>
+   */
   breakpoints?: Partial<Breakpoints>;
-  /** Children components that can use layout values */
   children: React.ReactNode;
 };
 
-export const LayoutWrapper = ({
+export const LayoutProvider = ({
   breakpoints: customBreakpoints,
   children,
-}: LayoutWrapperProps): JSX.Element => {
+}: LayoutProviderProps): JSX.Element => {
   const breakpoints = useMemo<Breakpoints>(
     () => ({
       ...DEFAULT_BREAKPOINTS,

--- a/packages/layout/src/beta/LayoutWrapper/index.ts
+++ b/packages/layout/src/beta/LayoutWrapper/index.ts
@@ -1,6 +1,6 @@
-export { LayoutWrapper } from './LayoutWrapper';
+export { LayoutProvider } from './LayoutWrapper';
 export { useLayoutValues } from './useLayoutValues';
 export { useResponsiveValue } from './useResponsiveValue';
-export type { LayoutValues, LayoutWrapperProps } from './LayoutWrapper';
+export type { LayoutValues, LayoutProviderProps } from './LayoutWrapper';
 export type { Breakpoints, GridSpacingValue, ResponsiveValue } from './utils';
 export { DEFAULT_BREAKPOINTS, getSpacingValue } from './utils';

--- a/packages/layout/src/beta/LayoutWrapper/useResponsiveValue.ts
+++ b/packages/layout/src/beta/LayoutWrapper/useResponsiveValue.ts
@@ -4,26 +4,29 @@ import type { ResponsiveValue } from './utils';
 
 const isResponsiveObject = <T>(
   value: ResponsiveValue<T>,
-): value is { sm?: T; md?: T; lg?: T } => {
+): value is { s?: T; m?: T; lg?: T; xl?: T } => {
   return (
     typeof value === 'object' &&
     value !== null &&
     !Array.isArray(value) &&
-    ('sm' in value || 'md' in value || 'lg' in value)
+    ('s' in value || 'm' in value || 'lg' in value || 'xl' in value)
   );
 };
 
 const getCurrentBreakpoint = (
-  breakpoints: { sm: number; md: number; lg: number },
+  breakpoints: { m: number; lg: number; xl: number },
   windowWidth: number,
-): 'sm' | 'md' | 'lg' => {
+): 's' | 'm' | 'lg' | 'xl' => {
+  if (windowWidth >= breakpoints.xl) {
+    return 'xl';
+  }
   if (windowWidth >= breakpoints.lg) {
     return 'lg';
   }
-  if (windowWidth >= breakpoints.md) {
-    return 'md';
+  if (windowWidth >= breakpoints.m) {
+    return 'm';
   }
-  return 'sm';
+  return 's';
 };
 
 export const useResponsiveValue = <T>(
@@ -31,10 +34,10 @@ export const useResponsiveValue = <T>(
 ): T | undefined => {
   const { breakpoints } = useLayoutValues();
   const [currentBreakpoint, setCurrentBreakpoint] = useState<
-    'sm' | 'md' | 'lg'
+    's' | 'm' | 'lg' | 'xl'
   >(() => {
     if (typeof window === 'undefined') {
-      return 'sm';
+      return 's';
     }
     return getCurrentBreakpoint(breakpoints, window.innerWidth);
   });
@@ -54,8 +57,9 @@ export const useResponsiveValue = <T>(
     };
 
     const mediaQueries = [
-      window.matchMedia(`(min-width: ${breakpoints.md}px)`),
+      window.matchMedia(`(min-width: ${breakpoints.m}px)`),
       window.matchMedia(`(min-width: ${breakpoints.lg}px)`),
+      window.matchMedia(`(min-width: ${breakpoints.xl}px)`),
     ];
 
     updateBreakpoint();
@@ -96,12 +100,14 @@ export const useResponsiveValue = <T>(
     return responsiveValue;
   }
 
-  const fallbackOrder: Array<'lg' | 'md' | 'sm'> =
-    currentBreakpoint === 'lg'
-      ? ['lg', 'md', 'sm']
-      : currentBreakpoint === 'md'
-      ? ['md', 'sm']
-      : ['sm'];
+  const fallbackOrder: Array<'xl' | 'lg' | 'm' | 's'> =
+    currentBreakpoint === 'xl'
+      ? ['xl', 'lg', 'm', 's']
+      : currentBreakpoint === 'lg'
+      ? ['lg', 'm', 's']
+      : currentBreakpoint === 'm'
+      ? ['m', 's']
+      : ['s'];
 
   for (const bp of fallbackOrder) {
     if (value[bp] !== undefined) {

--- a/packages/layout/src/beta/LayoutWrapper/utils.ts
+++ b/packages/layout/src/beta/LayoutWrapper/utils.ts
@@ -25,21 +25,32 @@ export type GridSpacingValue = (typeof VALID_SPACING_VALUES)[number];
 export type ResponsiveValue<T> =
   | T
   | {
-      sm?: T;
-      md?: T;
+      s?: T;
+      m?: T;
       lg?: T;
+      xl?: T;
     };
 
+/**
+ * Configurable min-width breakpoints (in px).
+ *
+ * `s` is always 0 and is not configurable — it is the base (mobile-first)
+ * fallback that activates below `m`.
+ *
+ * - `m`: activates at this width and above (default: 800px)
+ * - `lg`: activates at this width and above (default: 1200px)
+ * - `xl`: activates at this width and above (default: 1400px)
+ */
 export type Breakpoints = {
-  sm: number;
-  md: number;
+  m: number;
   lg: number;
+  xl: number;
 };
 
 export const DEFAULT_BREAKPOINTS: Breakpoints = {
-  sm: 0,
-  md: 800,
+  m: 800,
   lg: 1200,
+  xl: 1400,
 };
 
 const isValidSpacingValue = (value: unknown): value is GridSpacingValue => {

--- a/packages/layout/src/beta/index.tsx
+++ b/packages/layout/src/beta/index.tsx
@@ -4,7 +4,8 @@
 import './index.scss';
 
 export { Grid, GridItem } from './Grid';
-export { LayoutWrapper, useLayoutValues } from './LayoutWrapper';
+export { LayoutProvider, useLayoutValues } from './LayoutWrapper';
+export type { LayoutProviderProps } from './LayoutWrapper';
 export { Flex, FlexSpacer } from './Flex';
 export { Template } from './templates';
 export type {


### PR DESCRIPTION
## 💡 Hvorfor?

ETU-70738 — `LayoutWrapper` er mer en provider enn en wrapper. Samtidig ble breakpoint-nøklene oppdatert til å følge semantisk størrelsesformat (`s/m/lg/xl`), og `xl`-breakpoint ble lagt til.

## 🔧 Hvordan?

- `LayoutWrapper` → `LayoutProvider`, `LayoutWrapperProps` → `LayoutProviderProps`
- Breakpoint-nøkler endret fra `sm/md/lg` til `s/m/lg/xl`
- `s` er alltid 0px og kan ikke konfigureres — det er den implisitte basen (mobile-first fallback)
- `xl` lagt til med standardverdi 1400px
- `Breakpoints`-typen inneholder nå kun konfigurerbare verdier: `m`, `lg`, `xl`
- `ResponsiveValue` støtter alle delsettet av breakpoints — manglende nøkler cascader ned til nærmeste mindre breakpoint
- `LayoutProvider` og `useLayoutValues` fjernet som re-eksporter fra `Grid/index.ts` — eksporteres nå kun fra beta-barrel direkte

## 🧩 Type endring

- [ ] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [x] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

Ikke aktuelt.

## 💬 Tilleggsnotater

Beta-komponent — breaking changes er forventet. Versjonsbump håndteres manuelt med `lerna version minor` ved release for å unngå major-bump for beta-endringer.

## 💣 Breaking changes

**`LayoutWrapper` → `LayoutProvider`**
```tsx
// Før
import { LayoutWrapper } from '@entur/layout/beta';
<LayoutWrapper>...</LayoutWrapper>

// Etter
import { LayoutProvider } from '@entur/layout/beta';
<LayoutProvider>...</LayoutProvider>
```

**Breakpoint-nøkler: `sm/md/lg` → `s/m/lg/xl`**
```tsx
// Før
<Grid colSpan={{ sm: 12, md: 6, lg: 4 }} />

// Etter
<Grid colSpan={{ s: 12, m: 6, lg: 4 }} />
```

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden