### PR TITLE
feat(layout/beta): rename LayoutWrapper to LayoutProvider og oppdater breakpoints

### DIFF
--- a/packages/layout/src/beta/Flex/Flex.tsx
+++ b/packages/layout/src/beta/Flex/Flex.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { PolymorphicComponentProps } from '@entur/utils';
 import classNames from 'classnames';
-import { getSpacingValue } from '../LayoutWrapper/utils';
-import type { GridSpacingValue, ResponsiveValue } from '../LayoutWrapper/utils';
-import { useResponsiveValue } from '../LayoutWrapper/useResponsiveValue';
+import { getSpacingValue } from '../LayoutProvider/utils';
+import type {
+  GridSpacingValue,
+  ResponsiveValue,
+} from '../LayoutProvider/utils';
+import { useResponsiveValue } from '../LayoutProvider/useResponsiveValue';
 
 import './Flex.scss';
 

--- a/packages/layout/src/beta/Grid/Grid.tsx
+++ b/packages/layout/src/beta/Grid/Grid.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { PolymorphicComponentProps } from '@entur/utils';
-import { getSpacingValue } from '../LayoutWrapper/utils';
-import type { GridSpacingValue, ResponsiveValue } from '../LayoutWrapper/utils';
-import { useResponsiveValue } from '../LayoutWrapper/useResponsiveValue';
+import { getSpacingValue } from '../LayoutProvider/utils';
+import type {
+  GridSpacingValue,
+  ResponsiveValue,
+} from '../LayoutProvider/utils';
+import { useResponsiveValue } from '../LayoutProvider/useResponsiveValue';
 import classNames from 'classnames';
 
 import './Grid.scss';

--- a/packages/layout/src/beta/Grid/GridItem.tsx
+++ b/packages/layout/src/beta/Grid/GridItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PolymorphicComponentProps } from '@entur/utils';
-import { useResponsiveValue } from '../LayoutWrapper/useResponsiveValue';
-import type { ResponsiveValue } from '../LayoutWrapper/utils';
+import { useResponsiveValue } from '../LayoutProvider/useResponsiveValue';
+import type { ResponsiveValue } from '../LayoutProvider/utils';
 import classNames from 'classnames';
 
 import './GridItem.scss';

--- a/packages/layout/src/beta/Grid/index.ts
+++ b/packages/layout/src/beta/Grid/index.ts
@@ -27,8 +27,9 @@ export const GridComponent: Grid = Object.assign(GridParent, {
 GridComponent.Item.displayName = 'Grid.Item';
 
 export type { GridProps, GridOwnProps } from './Grid';
-export type { GridSpacingValue, ResponsiveValue } from '../LayoutWrapper/utils';
+export type {
+  GridSpacingValue,
+  ResponsiveValue,
+} from '../LayoutProvider/utils';
 export type { GridItemProps, GridItemOwnProps } from './GridItem';
 export { GridComponent as Grid, GridItem };
-export { LayoutWrapper } from '../LayoutWrapper/LayoutWrapper';
-export { useLayoutValues } from '../LayoutWrapper/useLayoutValues';

--- a/packages/layout/src/beta/LayoutProvider/LayoutProvider.tsx
+++ b/packages/layout/src/beta/LayoutProvider/LayoutProvider.tsx
@@ -7,17 +7,32 @@ export type LayoutValues = {
 
 const LayoutContext = createContext<LayoutValues | null>(null);
 
-export type LayoutWrapperProps = {
-  /** Custom breakpoint values to override defaults */
+export type LayoutProviderProps = {
+  /**
+   * Custom breakpoint values (in px) to override the defaults.
+   *
+   * Breakpoints are **min-width** based: a breakpoint activates when the
+   * viewport is at least that wide and stays active until the next breakpoint.
+   *
+   * Default values:
+   * - `s`: 0px — always active below `m` (not configurable)
+   * - `m`: 800px — active from 800px up to (but not including) `lg`
+   * - `lg`: 1200px — active from 1200px up to (but not including) `xl`
+   * - `xl`: 1400px — active from 1400px and above
+   *
+   * @example
+   * <LayoutProvider breakpoints={{ m: 600, lg: 1024, xl: 1280 }}>
+   *   ...
+   * </LayoutProvider>
+   */
   breakpoints?: Partial<Breakpoints>;
-  /** Children components that can use layout values */
   children: React.ReactNode;
 };
 
-export const LayoutWrapper = ({
+export const LayoutProvider = ({
   breakpoints: customBreakpoints,
   children,
-}: LayoutWrapperProps): JSX.Element => {
+}: LayoutProviderProps): JSX.Element => {
   const breakpoints = useMemo<Breakpoints>(
     () => ({
       ...DEFAULT_BREAKPOINTS,

--- a/packages/layout/src/beta/LayoutProvider/index.ts
+++ b/packages/layout/src/beta/LayoutProvider/index.ts
@@ -1,6 +1,6 @@
-export { LayoutWrapper } from './LayoutWrapper';
+export { LayoutProvider } from './LayoutProvider';
 export { useLayoutValues } from './useLayoutValues';
 export { useResponsiveValue } from './useResponsiveValue';
-export type { LayoutValues, LayoutWrapperProps } from './LayoutWrapper';
+export type { LayoutValues, LayoutProviderProps } from './LayoutProvider';
 export type { Breakpoints, GridSpacingValue, ResponsiveValue } from './utils';
 export { DEFAULT_BREAKPOINTS, getSpacingValue } from './utils';

--- a/packages/layout/src/beta/LayoutProvider/useLayoutValues.ts
+++ b/packages/layout/src/beta/LayoutProvider/useLayoutValues.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_BREAKPOINTS } from './utils';
-import { type LayoutValues, useLayoutContext } from './LayoutWrapper';
+import { type LayoutValues, useLayoutContext } from './LayoutProvider';
 
 export const useLayoutValues = (): LayoutValues => {
   const context = useLayoutContext();

--- a/packages/layout/src/beta/LayoutProvider/useResponsiveValue.ts
+++ b/packages/layout/src/beta/LayoutProvider/useResponsiveValue.ts
@@ -4,26 +4,29 @@ import type { ResponsiveValue } from './utils';
 
 const isResponsiveObject = <T>(
   value: ResponsiveValue<T>,
-): value is { sm?: T; md?: T; lg?: T } => {
+): value is { s?: T; m?: T; lg?: T; xl?: T } => {
   return (
     typeof value === 'object' &&
     value !== null &&
     !Array.isArray(value) &&
-    ('sm' in value || 'md' in value || 'lg' in value)
+    ('s' in value || 'm' in value || 'lg' in value || 'xl' in value)
   );
 };
 
 const getCurrentBreakpoint = (
-  breakpoints: { sm: number; md: number; lg: number },
+  breakpoints: { m: number; lg: number; xl: number },
   windowWidth: number,
-): 'sm' | 'md' | 'lg' => {
+): 's' | 'm' | 'lg' | 'xl' => {
+  if (windowWidth >= breakpoints.xl) {
+    return 'xl';
+  }
   if (windowWidth >= breakpoints.lg) {
     return 'lg';
   }
-  if (windowWidth >= breakpoints.md) {
-    return 'md';
+  if (windowWidth >= breakpoints.m) {
+    return 'm';
   }
-  return 'sm';
+  return 's';
 };
 
 export const useResponsiveValue = <T>(
@@ -31,10 +34,10 @@ export const useResponsiveValue = <T>(
 ): T | undefined => {
   const { breakpoints } = useLayoutValues();
   const [currentBreakpoint, setCurrentBreakpoint] = useState<
-    'sm' | 'md' | 'lg'
+    's' | 'm' | 'lg' | 'xl'
   >(() => {
     if (typeof window === 'undefined') {
-      return 'sm';
+      return 's';
     }
     return getCurrentBreakpoint(breakpoints, window.innerWidth);
   });
@@ -54,8 +57,9 @@ export const useResponsiveValue = <T>(
     };
 
     const mediaQueries = [
-      window.matchMedia(`(min-width: ${breakpoints.md}px)`),
+      window.matchMedia(`(min-width: ${breakpoints.m}px)`),
       window.matchMedia(`(min-width: ${breakpoints.lg}px)`),
+      window.matchMedia(`(min-width: ${breakpoints.xl}px)`),
     ];
 
     updateBreakpoint();
@@ -96,12 +100,14 @@ export const useResponsiveValue = <T>(
     return responsiveValue;
   }
 
-  const fallbackOrder: Array<'lg' | 'md' | 'sm'> =
-    currentBreakpoint === 'lg'
-      ? ['lg', 'md', 'sm']
-      : currentBreakpoint === 'md'
-      ? ['md', 'sm']
-      : ['sm'];
+  const fallbackOrder: Array<'xl' | 'lg' | 'm' | 's'> =
+    currentBreakpoint === 'xl'
+      ? ['xl', 'lg', 'm', 's']
+      : currentBreakpoint === 'lg'
+      ? ['lg', 'm', 's']
+      : currentBreakpoint === 'm'
+      ? ['m', 's']
+      : ['s'];
 
   for (const bp of fallbackOrder) {
     if (value[bp] !== undefined) {

--- a/packages/layout/src/beta/LayoutProvider/utils.ts
+++ b/packages/layout/src/beta/LayoutProvider/utils.ts
@@ -25,21 +25,32 @@ export type GridSpacingValue = (typeof VALID_SPACING_VALUES)[number];
 export type ResponsiveValue<T> =
   | T
   | {
-      sm?: T;
-      md?: T;
+      s?: T;
+      m?: T;
       lg?: T;
+      xl?: T;
     };
 
+/**
+ * Configurable min-width breakpoints (in px).
+ *
+ * `s` is always 0 and is not configurable — it is the base (mobile-first)
+ * fallback that activates below `m`.
+ *
+ * - `m`: activates at this width and above (default: 800px)
+ * - `lg`: activates at this width and above (default: 1200px)
+ * - `xl`: activates at this width and above (default: 1400px)
+ */
 export type Breakpoints = {
-  sm: number;
-  md: number;
+  m: number;
   lg: number;
+  xl: number;
 };
 
 export const DEFAULT_BREAKPOINTS: Breakpoints = {
-  sm: 0,
-  md: 800,
+  m: 800,
   lg: 1200,
+  xl: 1400,
 };
 
 const isValidSpacingValue = (value: unknown): value is GridSpacingValue => {

--- a/packages/layout/src/beta/index.tsx
+++ b/packages/layout/src/beta/index.tsx
@@ -4,7 +4,8 @@
 import './index.scss';
 
 export { Grid, GridItem } from './Grid';
-export { LayoutWrapper, useLayoutValues } from './LayoutWrapper';
+export { LayoutProvider, useLayoutValues } from './LayoutProvider';
+export type { LayoutProviderProps } from './LayoutProvider';
 export { Flex, FlexSpacer } from './Flex';
 export { Template } from './templates';
 export type {


### PR DESCRIPTION
## 💡 Hvorfor?

`LayoutWrapper` kommuniserer ikke tydelig nok at komponenten er en context provider. Breakpoint-navnene `sm/md/lg` er heller ikke konsistente med designsystemets semantiske skala.

## 🔧 Hvordan?

- Renamed `LayoutWrapper` → `LayoutProvider` (og tilhørende props-type)
- Oppdatert breakpoints fra `sm/md/lg` til `s/m/lg/xl`, lagt til `xl`-støtte
- Oppdatert `useResponsiveValue` for nye breakpoints og fallback-logikk
- Oppdatert alle beta-eksporter

## 🧩 Type endring

- [ ] 🐞 Feilretting
- [x] 🚀 Ny funksjonalitet
- [x] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

N/A

## 💬 Tilleggsnotater

Erstatter PR #373 (GitHub-feil hindret merge).

## 💣 Breaking changes (om aktuelt)

- `LayoutWrapper` er nå `LayoutProvider`
- `LayoutWrapperProps` er nå `LayoutProviderProps`
- Breakpoints endret fra `sm/md/lg` til `s/m/lg/xl`

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [x] Testet med skjermleser
- [x] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden