### PR TITLE
fix(form/text area): keep the label legible on any background

### DIFF
--- a/packages/form/src/InputGroupLabel.scss
+++ b/packages/form/src/InputGroupLabel.scss
@@ -25,9 +25,7 @@ $label-top-large: 0.5rem;
   padding: 0;
 
   .eds-textarea__label & {
-    box-shadow: 0 -2px 0 4px var(--textarea-label-background);
-    background: var(--textarea-label-background);
-    width: calc(100% - #{t.$space-default} - #{t.$space-default} - 4px); // ~36px = margin-left + scrollbar-width + box-shadow blur
+    width: calc(100% - #{t.$space-default} - #{t.$space-default} - 4px); // margin-left + scrollbar-width
   }
 }
 

--- a/packages/form/src/TextArea.scss
+++ b/packages/form/src/TextArea.scss
@@ -1,24 +1,19 @@
 @use '@entur/tokens/dist/styles.scss' as t;
-@use '@entur/tokens/dist/base';
 
 .eds-textarea__wrapper {
-  // Quickfix for illegible label when input exceeds height of textarea
-  :not(.eds-form-control-wrapper--disabled, .eds-form-control-wrapper--readonly) .eds-textarea__label .eds-input-group__label {
-    background: var(--basecolors-frame-default);
-    width: fit-content;
-    height: fit-content;
-    padding: 0.15rem;
-    margin: -0.15rem;
-
-    *[data-color-mode='dark'] .eds-contrast & {
-      background-color: var(--basecolors-frame-contrast);
-    }
-  }
-
   textarea.eds-form-control.eds-textarea {
     min-height: 7.75rem;
     resize: vertical;
     line-height: t.$line-heights-extra-large;
+
+    // Fades out text scrolling under the overlaid label, so the label stays legible on any background.
+    // Second layer keeps the scrollbar gutter opaque, since the label does not reach it anyway.
+    $scrollbar-gutter: 20px; // same right-hand space the label already leaves free
+
+    mask-image: linear-gradient(to bottom, transparent 0, transparent 16px, black 20px), linear-gradient(black, black);
+    mask-size: calc(100% - #{$scrollbar-gutter}) 100%, $scrollbar-gutter 100%;
+    mask-position: top left, top right;
+    mask-repeat: no-repeat;
   }
 
   // No right side padding to make resize handle positioned in bottom right corner


### PR DESCRIPTION
## 💡 Hvorfor?

Label i TextArea har en egen bakgrunnsflate som ikke matcher underlaget. I dark mode blir den svart, og den ser like rar ut på alle flater som ikke er standard rotbakgrunn (kort, tint-flater, `Contrast`, eller egendefinert bakgrunn hos konsument).

Grunnen til at labelen har bakgrunn i det hele tatt: når TextArea har mye tekst, skroller teksten under labelen og de to blir uleselige oppå hverandre. Bakgrunnen var en quickfix for dette.

<img width="376" height="190" alt="Screenshot 2026-05-15 at 12 13 51" src="https://github.com/user-attachments/assets/eee158c7-62d3-4ee8-b425-0dfc3e710af4" />
<img width="378" height="206" alt="Screenshot 2026-05-15 at 12 13 45" src="https://github.com/user-attachments/assets/f4af129c-b185-42e7-bffa-e54b5856e0f6" />

## 🔧 Hvordan?

Å bytte til en annen bakgrunnsfarge løser ikke problemet – uansett hvilken token vi velger må den gjette hvilken flate feltet står på. Komponent-fargevariablene for skjemafelt er dessuten colorless i dark mode, så de kan ikke brukes til dette.

Løsningen fjerner behovet for å gjette: **labelen får ingen bakgrunn i det hele tatt**. I stedet fades teksten i tekstfeltet ut der den skroller under labelen, med en `mask-image` på selve `textarea`-elementet:

- Lag 1: `linear-gradient` som er gjennomsiktig de øverste 16px og opak fra 20px – akkurat der teksten starter (`padding-top` på `.eds-form-control` er 20px).
- Lag 2: et heldekkende lag over de høyre 20px, slik at rullefeltet ikke fades. Labelen strekker seg uansett ikke inn dit.

Masken ligger i elementkoordinater, så feltet fades i toppen mens innholdet skroller forbi. Dette virker likt i light mode, dark mode, inne i `Contrast` og på egendefinerte bakgrunner, uten en eneste hardkodet farge.

I tillegg er `--textarea-label-background` fjernet fra `InputGroupLabel.scss`. Variabelen var aldri definert noe sted, så både `box-shadow`- og `background`-deklarasjonen som brukte den var død kode.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

Skjermbildene over viser problemet før endringen. Etter endringen har labelen ingen egen flate – teksten som skroller under den fades ut, og rullefeltet står uberørt.

<img width="636" height="157" alt="Screenshot 2026-08-06 at 08 32 53" src="https://github.com/user-attachments/assets/dfbf2bf0-06a5-4489-b4a9-ec06dffd48cd" />
<img width="620" height="152" alt="Screenshot 2026-08-06 at 08 32 37" src="https://github.com/user-attachments/assets/a50f7f01-816b-40b0-8920-cd7c49ae7c6f" />

## 💬 Tilleggsnotater

- Autoprefixer legger på `-webkit-mask-*`, så Safari er dekket av byggesteget.
- Den opake stripen på høyre side er satt til 20px, som er samme plass labelen allerede lar stå fri (`width: calc(100% - 1rem - 1rem - 4px)`). Rullefelt er ~15px på macOS og ~17px på Windows, så begge får plass.
- Langsiktig plan er fortsatt å flytte labelen ut av feltet. Da kan masken fjernes helt.
- Funnet underveis, men **ikke** en del av denne PR-en: tekst i deaktivert skjemafelt er nesten uleselig inne i `Contrast` i light mode. `.eds-form-control` setter sin egen `color`, så deaktivert-fargen fra wrapperen slår aldri gjennom. Fikses separat.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

Verifisert i lekerommet med tom, kort og overflytende tekst, i light mode, dark mode og `Contrast`, samt på tint- og elevated-flater.

- [ ] Testet med skjermleser
- [x] Testet i Safari og Firefox (må verifiseres på nytt – `mask-image` på `textarea` er en ny teknikk her)
- [x] Testet i dokumentasjonsiden
