### PR TITLE
feat(menu/logo): add Logo component for standardized Entur product logos

### DIFF
--- a/apps/documentation/src/utils/componentProps/eds-component-props/Logo.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Logo.json
@@ -1,0 +1,106 @@
+{
+  "tags": {},
+  "description": "",
+  "displayName": "Logo",
+  "methods": [],
+  "props": {
+    "productName": {
+      "defaultValue": null,
+      "description": "Produktnavnet som vises etter Entur-logoen (f.eks. \"Tavla\", \"Partner\")",
+      "name": "productName",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/Logo.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "size": {
+      "defaultValue": {
+        "value": "medium"
+      },
+      "description": "Størrelsen på logoen",
+      "name": "size",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/Logo.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "\"small\" | \"medium\" | undefined"
+      }
+    },
+    "href": {
+      "defaultValue": null,
+      "description": "URL-en logoen lenker til. Gjør at komponenten rendres som en lenke",
+      "name": "href",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/Logo.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "as": {
+      "defaultValue": {
+        "value": "'div' (eller 'a' hvis href er satt)"
+      },
+      "description": "HTML-elementet eller React-komponenten som brukes\nAn override of the default HTML tag.\nCan also be another React component.",
+      "name": "as",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/Logo.tsx",
+          "name": "TypeLiteral"
+        },
+        {
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "(\"symbol\" & ElementType<any>) | (\"object\" & ElementType<any>) | (ComponentClass<any, any> & ElementType<any>) | ... 177 more ... | undefined"
+      }
+    },
+    "className": {
+      "defaultValue": null,
+      "description": "Ekstra klassenavn",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/Logo.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "ref": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ref",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "any"
+      }
+    }
+  }
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
@@ -687,5 +687,9 @@
   "utils/src/PolymorphicComponent.tsx": {
     "hash": "c98a4c8755ceb1b523f93006e5d8039f",
     "outputs": []
+  },
+  "menu/src/Logo.tsx": {
+    "hash": "b7e48ee2188e4631d7f7f8a4da7030d0",
+    "outputs": ["Logo.json"]
   }
 }

--- a/packages/menu/src/Logo.scss
+++ b/packages/menu/src/Logo.scss
@@ -1,0 +1,56 @@
+@use '@entur/tokens/dist/styles.scss' as t;
+@use '@entur/tokens/dist/primitive.scss' as p;
+
+.eds-logo {
+  --eds-logo-svg-height: #{p.$size-12};
+  --eds-logo-text-size: #{t.$font-sizes-extra-large4};
+  --eds-logo-text-padding-top: #{p.$size-4};
+
+  display: inline-flex;
+  align-items: flex-start;
+  text-decoration: none;
+  gap: #{p.$size-6};
+
+  &--small {
+    --eds-logo-svg-height: #{p.$size-10};
+    --eds-logo-text-size: #{t.$font-sizes-extra-large2};
+    --eds-logo-text-padding-top: 0.281rem;
+  }
+
+  &__svg {
+    flex-shrink: 0;
+    height: var(--eds-logo-svg-height);
+    width: auto;
+  }
+
+  &__entur-letter {
+    fill: var(--components-menu-logo-standard-entur-text);
+
+    :where(.eds-contrast .eds-logo) & {
+      fill: var(--components-menu-logo-contrast-entur-text);
+    }
+  }
+
+  &__entur-bar {
+    fill: var(--components-menu-logo-standard-entur-line);
+  }
+
+  &__product-name {
+    color: var(--components-menu-logo-standard-productname-text);
+    font-weight: var(--font-weight-body);
+    font-size: var(--eds-logo-text-size);
+    padding-top: var(--eds-logo-text-padding-top);
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  &:focus-visible {
+    outline: t.$outlines-focus;
+    outline-color: var(--basecolors-stroke-focus-standard);
+    outline-offset: t.$outline-offsets-focus;
+
+    .eds-contrast & {
+      outline-color: var(--basecolors-stroke-focus-contrast);
+    }
+  }
+}

--- a/packages/menu/src/Logo.test.tsx
+++ b/packages/menu/src/Logo.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Logo } from './Logo';
+
+test('renders the Entur svg SVG', () => {
+  const { container } = render(<Logo />);
+  expect(container.querySelector('svg')).toBeInTheDocument();
+  expect(container.querySelector('.eds-logo')).toBeInTheDocument();
+});
+
+test('renders with product name', () => {
+  const { getByText } = render(<Logo productName="Tavla" />);
+  expect(getByText('Tavla')).toBeInTheDocument();
+  expect(getByText('Tavla')).toHaveClass('eds-logo__product-name');
+});
+
+test('does not render product name span when omitted', () => {
+  const { container } = render(<Logo />);
+  expect(
+    container.querySelector('.eds-logo__product-name'),
+  ).not.toBeInTheDocument();
+});
+
+test('renders as div by default', () => {
+  const { container } = render(<Logo />);
+  expect(container.firstChild?.nodeName).toBe('DIV');
+});
+
+test('renders as anchor when href is provided', () => {
+  const { container } = render(<Logo href="/" />);
+  expect(container.firstChild?.nodeName).toBe('A');
+  expect(container.firstChild).toHaveAttribute('href', '/');
+});
+
+test('applies size class', () => {
+  const { container, rerender } = render(<Logo size="medium" />);
+  expect(container.querySelector('.eds-logo--medium')).toBeInTheDocument();
+
+  rerender(<Logo size="small" />);
+  expect(container.querySelector('.eds-logo--small')).toBeInTheDocument();
+});
+
+test('defaults to medium size', () => {
+  const { container } = render(<Logo />);
+  expect(container.querySelector('.eds-logo--medium')).toBeInTheDocument();
+});
+
+test('applies additional className', () => {
+  const { container } = render(<Logo className="custom-class" />);
+  expect(container.firstChild).toHaveClass('eds-logo');
+  expect(container.firstChild).toHaveClass('custom-class');
+});
+
+test('supports polymorphic as prop', () => {
+  const { container } = render(<Logo as="nav" />);
+  expect(container.firstChild?.nodeName).toBe('NAV');
+});
+
+test('forwards additional props', () => {
+  const { container } = render(<Logo data-testid="logo" />);
+  expect(container.firstChild).toHaveAttribute('data-testid', 'logo');
+});

--- a/packages/menu/src/Logo.tsx
+++ b/packages/menu/src/Logo.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import classNames from 'classnames';
+import { PolymorphicComponentPropsWithRef, PolymorphicRef } from '@entur/utils';
+import './Logo.scss';
+
+export type LogoOwnProps = {
+  /** Produktnavnet som vises etter Entur-logoen (f.eks. "Tavla", "Partner") */
+  productName?: string;
+  /** Størrelsen på logoen
+   * @default 'medium'
+   */
+  size?: 'medium' | 'small';
+  /** URL-en logoen lenker til. Gjør at komponenten rendres som en lenke */
+  href?: string;
+  /** HTML-elementet eller React-komponenten som brukes
+   * @default 'div' (eller 'a' hvis href er satt)
+   */
+  as?: React.ElementType;
+  /** Ekstra klassenavn */
+  className?: string;
+  children?: never;
+};
+
+export type LogoProps<T extends React.ElementType = typeof defaultElement> =
+  PolymorphicComponentPropsWithRef<T, LogoOwnProps>;
+
+export type LogoComponent = <
+  E extends React.ElementType = typeof defaultElement,
+>(
+  props: LogoProps<E>,
+) => React.ReactElement | null;
+
+const defaultElement = 'div';
+
+export const Logo: LogoComponent = React.forwardRef(
+  <E extends React.ElementType = typeof defaultElement>(
+    {
+      productName,
+      size = 'medium',
+      href,
+      as,
+      className,
+      ...rest
+    }: LogoProps<E>,
+    ref: PolymorphicRef<E>,
+  ) => {
+    const Element: React.ElementType = as || (href ? 'a' : defaultElement);
+
+    return (
+      <Element
+        className={classNames('eds-logo', `eds-logo--${size}`, className)}
+        ref={ref}
+        href={typeof Element !== 'string' || Element === 'a' ? href : undefined}
+        {...rest}
+      >
+        <EnturSvgLogo className="eds-logo__svg" />
+        {productName && (
+          <span className="eds-logo__product-name">{productName}</span>
+        )}
+      </Element>
+    );
+  },
+);
+
+const EnturSvgLogo: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    className={className}
+    viewBox="0 0 68.625 20.8254"
+    xmlns="http://www.w3.org/2000/svg"
+    role="img"
+    aria-label="Entur"
+    focusable="false"
+  >
+    {/* E */}
+    <polygon
+      className="eds-logo__entur-letter"
+      points="10.422 14.49 10.422 12.036 2.707 12.036 2.707 8.533 9.552 8.533 9.552 6.079 2.707 6.079 2.707 2.455 10.422 2.455 10.422 0 0 0 0 14.49"
+    />
+    {/* n */}
+    <polygon
+      className="eds-logo__entur-letter"
+      points="13.495 0 13.205 0 13.205 14.49 15.912 14.49 15.912 5.881 25.212 14.49 25.502 14.49 25.502 0 22.794 0 22.794 8.77"
+    />
+    {/* Red bar under EN */}
+    <polygon
+      className="eds-logo__entur-bar"
+      points="25.501 17.824 0 17.824 0 20.052 25.501 20.052"
+    />
+    {/* T */}
+    <polygon
+      className="eds-logo__entur-letter"
+      points="32.607 8.532 32.607 20.567 35.313 20.567 35.313 8.532 39.354 8.532 39.354 6.077 28.546 6.077 28.546 8.532"
+    />
+    {/* U */}
+    <path
+      className="eds-logo__entur-letter"
+      d="M50.935 6.076v8.651c0 .726-.116 1.326-.348 1.802-.232.475-.519.85-.861 1.127-.341.278-.708.469-1.102.574-.392.107-.744.158-1.053.158-.309 0-.661-.051-1.054-.158-.393-.105-.76-.296-1.101-.574-.343-.277-.629-.652-.861-1.127-.232-.476-.348-1.076-.348-1.802v-8.651H41.5v8.651c0 .924.144 1.762.435 2.515.289.751.699 1.389 1.227 1.918.529.53 1.168.938 1.916 1.23.746.288 1.577.435 2.493.435.928 0 1.765-.147 2.513-.435.747-.292 1.384-.7 1.914-1.23.529-.529.935-1.167 1.218-1.918.284-.753.425-1.591.425-2.515v-8.651z"
+    />
+    {/* R */}
+    <path
+      className="eds-logo__entur-letter"
+      d="M56.734 6.076v14.49h2.708v-4.612h2.679l3.277 4.612h3.227l-3.524-4.869c.438-.12.843-.328 1.211-.624.368-.296.678-.65.93-1.059.252-.41.448-.869.59-1.376.142-.507.214-1.033.214-1.573 0-.726-.121-1.397-.36-2.01-.238-.614-.57-1.141-.997-1.583-.425-.442-.939-.784-1.54-1.028-.503-.247-1.165-.369-1.888-.369zm2.708 2.456h3.083c.501 0 .929.065 1.281.198.354.13.642.309.866.533.227.225.394.489.503.792.108.304.163.632.163.991 0 .303-.038.603-.116.899-.076.298-.22.566-.433.802-.211.239-.501.43-.866.574-.368.145-.832.218-1.398.218h-3.083z"
+    />
+  </svg>
+);

--- a/packages/menu/src/componentVariables.scss
+++ b/packages/menu/src/componentVariables.scss
@@ -9,6 +9,12 @@
   --components-menu-breadcrumb-contrast-text: #{$text-light};
   --components-menu-breadcrumb-standard-icon: #{$shape-accent};
   --components-menu-breadcrumb-standard-text: #{$text-accent};
+  --components-menu-logo-contrast-entur-line: #{$shape-highlight};
+  --components-menu-logo-contrast-entur-text: #{$shape-light};
+  --components-menu-logo-contrast-productname-text: #{$text-highlight};
+  --components-menu-logo-standard-entur-line: #{$shape-highlight};
+  --components-menu-logo-standard-entur-text: #{$shape-accent};
+  --components-menu-logo-standard-productname-text: #{$text-highlight};
   --components-menu-navigationbar-contrast-background: #{$fill-background-contrast-lightalt};
   --components-menu-navigationbar-contrast-divide: #{$stroke-colorless};
   --components-menu-navigationbar-contrast-icon-selected: #{$shape-light};
@@ -106,6 +112,12 @@
   --components-menu-breadcrumb-contrast-text: #{$text-lightalt};
   --components-menu-breadcrumb-standard-icon: #{$shape-lightalt};
   --components-menu-breadcrumb-standard-text: #{$text-lightalt};
+  --components-menu-logo-contrast-entur-line: #{$shape-highlight};
+  --components-menu-logo-contrast-entur-text: #{$shape-light};
+  --components-menu-logo-contrast-productname-text: #{$text-highlight};
+  --components-menu-logo-standard-entur-line: #{$shape-highlight};
+  --components-menu-logo-standard-entur-text: #{$shape-light};
+  --components-menu-logo-standard-productname-text: #{$text-highlight};
   --components-menu-navigationbar-contrast-background: #{$fill-background-overlay-solid};
   --components-menu-navigationbar-contrast-divide: #{$stroke-colorless};
   --components-menu-navigationbar-contrast-icon-selected: #{$shape-lightalt};

--- a/packages/menu/src/index.scss
+++ b/packages/menu/src/index.scss
@@ -1,6 +1,9 @@
 // Used to register the styles as loaded!
 @use './componentVariables.scss';
 @use '@entur/tokens/dist/base.scss' as *;
+// Manually import typography tokens (to support dynamic text sizes) until these are out of beta
+@use '@entur/typography/src/beta/typographyTokens.scss' as *;
+
 :root {
   --eds-menu: 1;
   --reach-menu-button: 1;

--- a/packages/menu/src/index.tsx
+++ b/packages/menu/src/index.tsx
@@ -14,6 +14,7 @@ warnAboutMissingStyles(
 export * from './BreadcrumbNavigation';
 export * from './BreadcrumbItem';
 export * from './CollapsibleSideNavigation';
+export * from './Logo';
 export * from './OverflowMenu';
 export * from './Pagination';
 export * from './SideNavigation';

--- a/packages/tokens/src/component.json
+++ b/packages/tokens/src/component.json
@@ -3117,6 +3117,42 @@
             "rootAlias": "Lavender/90"
           },
           {
+            "name": "Components/menu/Logo/Contrast/Entur/Line",
+            "value": "#ff5959",
+            "var": "Shape/Highlight",
+            "rootAlias": "Coral/40"
+          },
+          {
+            "name": "Components/menu/Logo/Contrast/Entur/Text",
+            "value": "#ffffff",
+            "var": "Shape/Light",
+            "rootAlias": "White/Alpha-100"
+          },
+          {
+            "name": "Components/menu/Logo/Contrast/ProductName/Text",
+            "value": "#ff5959",
+            "var": "Text/Highlight",
+            "rootAlias": "Coral/40"
+          },
+          {
+            "name": "Components/menu/Logo/Standard/Entur/Line",
+            "value": "#ff5959",
+            "var": "Shape/Highlight",
+            "rootAlias": "Coral/40"
+          },
+          {
+            "name": "Components/menu/Logo/Standard/Entur/Text",
+            "value": "#181c56",
+            "var": "Shape/Accent",
+            "rootAlias": "Lavender/90"
+          },
+          {
+            "name": "Components/menu/Logo/Standard/ProductName/Text",
+            "value": "#ff5959",
+            "var": "Text/Highlight",
+            "rootAlias": "Coral/40"
+          },
+          {
             "name": "Components/menu/Navigation Bar/Contrast/Background",
             "value": "#393d79",
             "var": "Fill/Background/Contrast/LightAlt",
@@ -9407,6 +9443,42 @@
             "value": "#e5e5e9",
             "var": "Text/LightAlt",
             "rootAlias": "Ebony/10"
+          },
+          {
+            "name": "Components/menu/Logo/Contrast/Entur/Line",
+            "value": "#ff5959",
+            "var": "Shape/Highlight",
+            "rootAlias": "Coral/40"
+          },
+          {
+            "name": "Components/menu/Logo/Contrast/Entur/Text",
+            "value": "#ffffff",
+            "var": "Shape/Light",
+            "rootAlias": "White/Alpha-100"
+          },
+          {
+            "name": "Components/menu/Logo/Contrast/ProductName/Text",
+            "value": "#ff5959",
+            "var": "Text/Highlight",
+            "rootAlias": "Coral/40"
+          },
+          {
+            "name": "Components/menu/Logo/Standard/Entur/Line",
+            "value": "#ff5959",
+            "var": "Shape/Highlight",
+            "rootAlias": "Coral/40"
+          },
+          {
+            "name": "Components/menu/Logo/Standard/Entur/Text",
+            "value": "#ffffff",
+            "var": "Shape/Light",
+            "rootAlias": "White/Alpha-100"
+          },
+          {
+            "name": "Components/menu/Logo/Standard/ProductName/Text",
+            "value": "#ff5959",
+            "var": "Text/Highlight",
+            "rootAlias": "Coral/40"
           },
           {
             "name": "Components/menu/Navigation Bar/Contrast/Background",


### PR DESCRIPTION
New <Logo> component renders the Entur wordmark with an optional product name. Use `productName` to display your product name next to the logo, `size` to choose between medium and small, and `href` to make it a link.

Usage: <Logo productName="Partner" size="medium" href="/" />

AI-assistant: Claude Code (claude-opus-4-6)

## 💡 Hvorfor?

Det er behov for en Logokomponent

## 🔧 Hvordan?

Lagt til Logo under Menu pakken
- [x] Legge inn fargevariabler for Logo fra Figma

## 🧩 Type endring

- [ ] 🐞 Feilretting
- [x] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder
<img width="656" height="414" alt="Screenshot 2026-05-27 at 10 36 28" src="https://github.com/user-attachments/assets/c8ae8f0e-ed2e-480d-99cc-6b152513bde7" />



## 💬 Tilleggsnotater

Todos:

- [x] Venter på riktige fargetokens fra Figma - må oppdatere Components.json. Tenkte å vente til denne er merget: [ETU-69632-update-colortokens](https://github.com/entur/design-system/pull/349)
- [x] Dokumentasjon i Sanity med componentDoc (draft)

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [x] Testet med skjermleser
- [x] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden
