### PR TITLE
Add CODEOWNERS parsing to design system scanner

### DIFF
--- a/tools/design-system-scanner/src/analyzers/codeOwnersAnalyzer.test.ts
+++ b/tools/design-system-scanner/src/analyzers/codeOwnersAnalyzer.test.ts
@@ -1,0 +1,47 @@
+import { parseCodeOwners } from './codeOwnersAnalyzer';
+
+describe('parseCodeOwners', () => {
+  it('extracts unique owners from standard CODEOWNERS format', () => {
+    const content = `* @entur/team-designsystem
+packages/sanity/ @entur/team-designsystem @entur/team-selvbetjent`;
+
+    expect(parseCodeOwners(content)).toEqual([
+      '@entur/team-designsystem',
+      '@entur/team-selvbetjent',
+    ]);
+  });
+
+  it('ignores comments and blank lines', () => {
+    const content = `# This is a comment
+
+# Another comment
+* @entur/team-a
+`;
+    expect(parseCodeOwners(content)).toEqual(['@entur/team-a']);
+  });
+
+  it('handles individual user owners', () => {
+    const content = `* @someuser @entur/team-a`;
+    expect(parseCodeOwners(content)).toEqual(['@entur/team-a', '@someuser']);
+  });
+
+  it('returns empty array for empty file', () => {
+    expect(parseCodeOwners('')).toEqual([]);
+  });
+
+  it('returns empty array for comments-only file', () => {
+    expect(parseCodeOwners('# just comments\n# nothing else')).toEqual([]);
+  });
+
+  it('deduplicates owners across multiple patterns', () => {
+    const content = `* @entur/team-a @entur/team-b
+src/ @entur/team-a @entur/team-c
+docs/ @entur/team-b`;
+
+    expect(parseCodeOwners(content)).toEqual([
+      '@entur/team-a',
+      '@entur/team-b',
+      '@entur/team-c',
+    ]);
+  });
+});

--- a/tools/design-system-scanner/src/analyzers/codeOwnersAnalyzer.ts
+++ b/tools/design-system-scanner/src/analyzers/codeOwnersAnalyzer.ts
@@ -1,0 +1,50 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CODEOWNERS_PATHS = [
+  '.github/CODEOWNERS',
+  'CODEOWNERS',
+  'docs/CODEOWNERS',
+];
+
+/**
+ * Parse a CODEOWNERS file and return all unique owners mentioned.
+ * Owners are GitHub usernames or team slugs (e.g. "@entur/team-x").
+ */
+export function analyzeCodeOwners(repoDir: string): string[] {
+  let content: string | null = null;
+
+  for (const relative of CODEOWNERS_PATHS) {
+    const fullPath = path.join(repoDir, relative);
+    if (fs.existsSync(fullPath)) {
+      content = fs.readFileSync(fullPath, 'utf-8');
+      break;
+    }
+  }
+
+  if (!content) return [];
+
+  return parseCodeOwners(content);
+}
+
+/** Extract unique owners from CODEOWNERS file content. */
+export function parseCodeOwners(content: string): string[] {
+  const owners = new Set<string>();
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    // Format: <pattern> <owner1> <owner2> ...
+    // Owners start with @ — split on whitespace and collect them
+    const tokens = trimmed.split(/\s+/);
+    for (let i = 1; i < tokens.length; i++) {
+      const token = tokens[i];
+      if (token.startsWith('@')) {
+        owners.add(token);
+      }
+    }
+  }
+
+  return [...owners].sort();
+}

--- a/tools/design-system-scanner/src/export/posthogClient.test.ts
+++ b/tools/design-system-scanner/src/export/posthogClient.test.ts
@@ -38,6 +38,7 @@ const FIXTURE_REPORT: ScanReport = {
         isMonorepo: false,
         framework: 'next',
         reactVersion: '18.3.1',
+        codeOwners: ['@entur/team-app'],
       },
       workspaces: [],
       designSystemPackages: [

--- a/tools/design-system-scanner/src/export/posthogClient.ts
+++ b/tools/design-system-scanner/src/export/posthogClient.ts
@@ -109,6 +109,7 @@ export function buildGroupIdentifies(
         react_version: repo.repoMetadata?.reactVersion ?? null,
         primary_language: repo.repoMetadata?.primaryLanguage ?? null,
         is_monorepo: repo.repoMetadata?.isMonorepo ?? false,
+        code_owners: repo.repoMetadata?.codeOwners ?? [],
       },
     });
 
@@ -268,6 +269,7 @@ function buildRepoEvents(repo: RepositoryUsage, ts: string): CapturePayload[] {
       ),
       import_usage_count: repo.importUsage.length,
       css_override_count: (repo.cssOverrides ?? []).length,
+      code_owners: repo.repoMetadata?.codeOwners ?? [],
     },
   });
 

--- a/tools/design-system-scanner/src/index.ts
+++ b/tools/design-system-scanner/src/index.ts
@@ -89,6 +89,7 @@ async function scanLocal(args: ParsedArgs): Promise<void> {
           isMonorepo: false, // Will be detected by scanner
           framework: null, // Will be detected by scanner
           reactVersion: null, // Will be detected by scanner
+          codeOwners: [], // Will be detected by scanner
         }
       : undefined;
 
@@ -265,6 +266,7 @@ function exportForBigQuery(args: ParsedArgs): void {
         is_monorepo: repo.repoMetadata?.isMonorepo || false,
         framework: repo.repoMetadata?.framework || null,
         react_version: repo.repoMetadata?.reactVersion || null,
+        code_owners: repo.repoMetadata?.codeOwners || [],
         ds_package_count: repo.designSystemPackages.length,
         ui_library_count: repo.otherUILibraries.length,
         component_count: repo.componentUsage.length,
@@ -693,6 +695,7 @@ function printSummary(usage: RepositoryUsage): void {
       m.framework && `Framework: ${m.framework}`,
       m.isMonorepo && 'Monorepo',
       m.visibility,
+      m.codeOwners.length > 0 && `Owners: ${m.codeOwners.join(', ')}`,
     ].filter(Boolean);
     if (meta.length > 0) console.log(`  ${meta.join(' | ')}\n`);
   }

--- a/tools/design-system-scanner/src/scanner.test.ts
+++ b/tools/design-system-scanner/src/scanner.test.ts
@@ -142,6 +142,7 @@ describe('scanner', () => {
           isMonorepo: false,
           framework: null,
           reactVersion: null,
+          codeOwners: [],
         },
       );
 
@@ -191,6 +192,7 @@ describe('scanner', () => {
           isMonorepo: false,
           framework: null,
           reactVersion: null,
+          codeOwners: [],
         },
       );
 

--- a/tools/design-system-scanner/src/scanner.ts
+++ b/tools/design-system-scanner/src/scanner.ts
@@ -9,6 +9,7 @@ import { analyzeComponents } from './analyzers/reactScannerAnalyzer';
 import { analyzeImports } from './analyzers/importAnalyzer';
 import { resolveVersions } from './analyzers/lockfileResolver';
 import { analyzeCssOverrides } from './analyzers/cssOverrideAnalyzer';
+import { analyzeCodeOwners } from './analyzers/codeOwnersAnalyzer';
 import type {
   RepositoryUsage,
   RepoMetadata,
@@ -62,6 +63,9 @@ export async function scanRepository(
     }
   }
 
+  // Analyze CODEOWNERS
+  const codeOwners = analyzeCodeOwners(repoDir);
+
   // Enrich repo metadata — react version resolved from lockfile below (alongside DS packages)
   const enrichedMetadata: RepoMetadata | undefined = repoMetadata
     ? {
@@ -69,6 +73,7 @@ export async function scanRepository(
         isMonorepo,
         framework: repoMetadata.framework || framework,
         reactVersion: repoMetadata.reactVersion ?? reactVersionRange,
+        codeOwners,
       }
     : undefined;
 

--- a/tools/design-system-scanner/src/types.ts
+++ b/tools/design-system-scanner/src/types.ts
@@ -38,6 +38,8 @@ export interface RepoMetadata {
   framework: string | null;
   /** Resolved React version from lockfile, or declared range if unresolvable (e.g. "18.3.1") */
   reactVersion: string | null;
+  /** Unique code owners from CODEOWNERS file (e.g. ["@entur/team-x"]) */
+  codeOwners: string[];
 }
 
 /** Information about a workspace/package inside a monorepo. */


### PR DESCRIPTION
## Summary
- Adds a new `codeOwnersAnalyzer` that reads `CODEOWNERS` from scanned repos (`.github/CODEOWNERS`, `CODEOWNERS`, or `docs/CODEOWNERS`)
- Extracts all unique `@`-prefixed owners and includes them in scan output
- Surfaces `code_owners` in BigQuery `repos.ndjson` export and PostHog events (`ds_repo_scanned` + repo group identify)

## Companion PR
- BigQuery schema: https://github.com/entur/design-system-infrastructure/pull/11 (must be applied first)

## Test plan
- [x] 79 tests pass (6 new for `codeOwnersAnalyzer`)
- [ ] Verify locally with `--local` on a repo with CODEOWNERS
- [ ] Verify BigQuery export includes `code_owners` array in `repos.ndjson`

🤖 Generated with [Claude Code](https://claude.com/claude-code)