### PR TITLE
Filter CODEOWNERS to @entur/ teams only

### DIFF
--- a/tools/design-system-scanner/src/analyzers/codeOwnersAnalyzer.test.ts
+++ b/tools/design-system-scanner/src/analyzers/codeOwnersAnalyzer.test.ts
@@ -20,9 +20,9 @@ packages/sanity/ @entur/team-designsystem @entur/team-selvbetjent`;
     expect(parseCodeOwners(content)).toEqual(['@entur/team-a']);
   });
 
-  it('handles individual user owners', () => {
+  it('filters out non-entur owners', () => {
     const content = `* @someuser @entur/team-a`;
-    expect(parseCodeOwners(content)).toEqual(['@entur/team-a', '@someuser']);
+    expect(parseCodeOwners(content)).toEqual(['@entur/team-a']);
   });
 
   it('returns empty array for empty file', () => {

--- a/tools/design-system-scanner/src/analyzers/codeOwnersAnalyzer.ts
+++ b/tools/design-system-scanner/src/analyzers/codeOwnersAnalyzer.ts
@@ -40,7 +40,7 @@ export function parseCodeOwners(content: string): string[] {
     const tokens = trimmed.split(/\s+/);
     for (let i = 1; i < tokens.length; i++) {
       const token = tokens[i];
-      if (token.startsWith('@')) {
+      if (token.startsWith('@entur/')) {
         owners.add(token);
       }
     }


### PR DESCRIPTION
## Summary
- Filters CODEOWNERS parser to only collect `@entur/` team handles, excluding individual GitHub usernames
- Follow-up to #395 which inadvertently stored personal usernames in PostHog

## Test plan
- [x] 79 tests pass
- [ ] Next scan run should only show `@entur/team-*` entries in `code_owners`

🤖 Generated with [Claude Code](https://claude.com/claude-code)