### PR TITLE
fix(website): fix cache corruption, SSR sidebar, and worktree compatibility

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -109,13 +109,6 @@ jobs:
           name: package-artifacts
           path: 'packages'
 
-      - name: Cache gatsby
-        uses: actions/cache@v5
-        with:
-          path: apps/documentation/.cache
-          key: gatsby-${{ runner.os }}-${{ github.run_id }}
-          restore-keys: gatsby-${{ runner.os }}
-
       - name: Build documentation
         run: yarn build:documentation:skip-packages-dependency
 

--- a/apps/code-playground/playroom.config.mjs
+++ b/apps/code-playground/playroom.config.mjs
@@ -1,6 +1,10 @@
 import { createRequire } from 'module';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(__dirname, '../..');
 
 export default {
   components: './src/components.ts',
@@ -38,8 +42,8 @@ export default {
             {
               test: /\.s?css$/,
               include: [
-                /design-system[\\/]apps[\\/]code-playground[\\/]/,
-                /design-system[\\/]packages[\\/][^\\/]+[\\/]dist[\\/]/,
+                path.resolve(repoRoot, 'apps/code-playground'),
+                path.resolve(repoRoot, 'packages'),
               ],
               use: [
                 'style-loader',

--- a/apps/documentation/src/components/Navigations/SideNavigation/MobileSideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/MobileSideNavigation.tsx
@@ -30,9 +30,8 @@ const MobileSideNavigation: React.FC<MobileMenuProps> = ({
       <Drawer
         open={openSidebar}
         onDismiss={() => setOpenSidebar(false)}
-        title={''}
+        title="Navigasjonsmeny"
         className="side-navigation__drawer"
-        overlay
       >
         <SideNavigation
           menuItems={menuItems}
@@ -48,6 +47,7 @@ const MobileSideNavigation: React.FC<MobileMenuProps> = ({
         })}
         onClick={() => setOpenSidebar(!openSidebar)}
         type="button"
+        aria-expanded={openSidebar}
         aria-label={openSidebar ? 'Lukk meny' : 'Åpne meny'}
       >
         {openSidebar ? (

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.scss
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.scss
@@ -3,6 +3,22 @@
 @use '@entur/tokens/dist/styles.scss' as eds;
 @use '@entur/utils/dist/breakpoints.scss' as *;
 
+.side-navigation--desktop {
+  display: block;
+
+  @media screen and (max-width: map.get(variables.$breakpoints, 'tablet')) {
+    display: none;
+  }
+}
+
+.side-navigation--mobile {
+  display: none;
+
+  @media screen and (max-width: map.get(variables.$breakpoints, 'tablet')) {
+    display: block;
+  }
+}
+
 .side-navigation {
   &__logo {
     width: 100%;
@@ -28,7 +44,15 @@
     background: var(--components-menu-sidenavigation-standard-background);
 
     h2 {
-      display: none; // hide Drawer heading
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
 
     &__wrapper {

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
@@ -114,7 +114,12 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
 
   return (
     <div className={classNames('side-navigation-wrapper', className)}>
-      <SearchBar onOpenSearch={openSearch} />
+      <SearchBar
+        onOpenSearch={() => {
+          onClickMenuItem?.();
+          openSearch();
+        }}
+      />
       <EnturSideNavigation style={{ marginTop: mobile ? '0rem' : '1.5rem' }}>
         {sortedGrouped.map(([subcategory, subcategoryMenuItems]) => (
           <SideNavigationGroup

--- a/apps/documentation/src/layouts/SideNavigationLayout.tsx
+++ b/apps/documentation/src/layouts/SideNavigationLayout.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { useWindowDimensions } from '@entur/utils';
 import MobileSideNavigation from '@components/Navigations/SideNavigation/MobileSideNavigation';
 import SideNavigation from '@components/Navigations/SideNavigation/SideNavigation';
 import { MenuItem } from '@components/Navigations/SideNavigation/utils';
 import { PageProps, graphql, useStaticQuery } from 'gatsby';
-import { pxToRem } from 'src/utils/utils';
 
 const SideNavigationLayout = ({
   location,
@@ -12,11 +10,6 @@ const SideNavigationLayout = ({
   location: PageProps['location'];
 }) => {
   const [openSidebar, setOpenSidebar] = React.useState(false);
-
-  const { width } = useWindowDimensions();
-  const remWidth = pxToRem(width);
-  const isSmallScreen = remWidth !== undefined && remWidth < 60;
-  const isLargeScreen = remWidth !== undefined && remWidth >= 60;
 
   const MenuData = useStaticQuery(graphql`
     query AllPages {
@@ -63,18 +56,22 @@ const SideNavigationLayout = ({
     ...MenuData.allSanityPage.nodes,
     ...MenuData.allSanityComponentDoc.nodes,
   ]);
-  if (isSmallScreen)
-    return (
-      <MobileSideNavigation
-        menuItems={menuItems}
-        openSidebar={openSidebar}
-        setOpenSidebar={setOpenSidebar}
-        currentLocation={location}
-      />
-    );
-  if (isLargeScreen)
-    return <SideNavigation menuItems={menuItems} currentLocation={location} />;
-  return <></>;
+
+  return (
+    <nav aria-label="Sidemeny">
+      <div className="side-navigation--desktop">
+        <SideNavigation menuItems={menuItems} currentLocation={location} />
+      </div>
+      <div className="side-navigation--mobile">
+        <MobileSideNavigation
+          menuItems={menuItems}
+          openSidebar={openSidebar}
+          setOpenSidebar={setOpenSidebar}
+          currentLocation={location}
+        />
+      </div>
+    </nav>
+  );
 };
 
 export default SideNavigationLayout;
@@ -91,7 +88,7 @@ function mergeMdxAndSanityPageData(mdxPageData: any[], sanityPageData: any[]) {
         tags: page.frontmatter.tags,
         order: page.frontmatter.order,
         categoryIndex: page.frontmatter.categoryIndex,
-        isCategoryLandingPage: false, // MDX pages don't have this field
+        isCategoryLandingPage: false,
         tag: undefined,
       } as MenuItem;
     });
@@ -107,14 +104,13 @@ function mergeMdxAndSanityPageData(mdxPageData: any[], sanityPageData: any[]) {
       tag: page.tag ?? undefined,
     } as MenuItem;
   });
-  // Add custom menu items
   const customMenuItems: MenuItem[] = [
     {
       id: 'code-playground',
       title: 'Sandkasse',
       category: 'Komponenter',
       subcategory: 'Oversikt',
-      order: 2, // Place it after the main "Komponenter" overview page
+      order: 2,
       path: '/sandkasse/',
     } as MenuItem,
     {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Accordion.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Accordion.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/Accordion.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/Accordion.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Accordion.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Accordion.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/Accordion.tsx",
+          "fileName": "packages/expand/src/Accordion.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/AccordionItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/AccordionItem.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/AccordionItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/AccordionItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/AccordionItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "contentStyle",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/AccordionItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "disableAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/AccordionItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/AccordionItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/AccordionItem.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
+          "fileName": "packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
+          "fileName": "packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
+          "fileName": "packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "contentStyle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
+          "fileName": "packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "disableAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/AccordionItem.tsx",
+          "fileName": "packages/expand/src/AccordionItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ActionChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ActionChip.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ActionChip.tsx",
+          "fileName": "packages/chip/src/ActionChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ActionChip.tsx",
+          "fileName": "packages/chip/src/ActionChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -50,7 +50,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ActionChip.tsx",
+          "fileName": "packages/chip/src/ActionChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -67,7 +67,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ActionChip.tsx",
+          "fileName": "packages/chip/src/ActionChip.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ActionChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ActionChip.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ActionChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ActionChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ActionChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ActionChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -50,7 +50,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ActionChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ActionChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -67,7 +67,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ActionChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ActionChip.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Badge.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Badge.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "showZero",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "max",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -112,7 +112,7 @@
       "name": "type",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -129,7 +129,7 @@
       "name": "invisible",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "hide",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -161,7 +161,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Badge.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Badge.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "showZero",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "max",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -112,7 +112,7 @@
       "name": "type",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -129,7 +129,7 @@
       "name": "invisible",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "hide",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/Badge.tsx",
+          "fileName": "packages/layout/src/Badge/Badge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -161,7 +161,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BannerAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BannerAlertBox.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BannerAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BannerAlertBox.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BannerExpandableAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BannerExpandableAlertBox.json
@@ -10,11 +10,11 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -48,15 +48,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -71,11 +71,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -92,7 +92,7 @@
       "name": "openLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -109,7 +109,7 @@
       "name": "closeLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -124,7 +124,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -139,7 +139,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -156,7 +156,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BannerExpandableAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BannerExpandableAlertBox.json
@@ -10,11 +10,11 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -48,15 +48,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -71,11 +71,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -92,7 +92,7 @@
       "name": "openLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -109,7 +109,7 @@
       "name": "closeLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -124,7 +124,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -139,7 +139,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -156,7 +156,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BannerAlertBox.tsx",
+          "fileName": "packages/alert/src/BannerAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseAlertBox.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,7 +80,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseAlertBox.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,7 +80,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/BaseAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/BaseAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseCard.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseCard.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/BaseCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/BaseCard.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/BaseCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/BaseCard.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseCard.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseCard.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/BaseCard.tsx",
+          "fileName": "packages/layout/src/BaseCard.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/BaseCard.tsx",
+          "fileName": "packages/layout/src/BaseCard.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseExpand.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseExpand.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/BaseExpand.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpand.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/BaseExpand.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpand.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseExpand.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseExpand.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpand.tsx",
+          "fileName": "packages/expand/src/BaseExpand.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpand.tsx",
+          "fileName": "packages/expand/src/BaseExpand.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseExpandablePanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseExpandablePanel.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "id",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "contentStyle",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "disableAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseExpandablePanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseExpandablePanel.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "id",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "contentStyle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "disableAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/BaseExpandablePanel.tsx",
+          "fileName": "packages/expand/src/BaseExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
@@ -12,7 +12,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -138,7 +138,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -155,7 +155,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -170,7 +170,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -185,7 +185,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -200,7 +200,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -215,7 +215,7 @@
       "name": "isFilled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -230,7 +230,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -247,7 +247,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -264,7 +264,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -279,7 +279,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -294,7 +294,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -311,7 +311,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/BaseFormControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
@@ -12,7 +12,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -138,7 +138,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -155,7 +155,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -170,7 +170,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -185,7 +185,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -200,7 +200,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -215,7 +215,7 @@
       "name": "isFilled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -230,7 +230,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -247,7 +247,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -264,7 +264,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -279,7 +279,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -294,7 +294,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -311,7 +311,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/BaseFormControl.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseGrid.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseGrid.json
@@ -12,7 +12,7 @@
       "name": "container",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "item",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "rowSpacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,7 +80,7 @@
       "name": "small",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "medium",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "large",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -127,11 +127,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -161,7 +161,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
+          "fileName": "packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseGrid.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseGrid.json
@@ -12,7 +12,7 @@
       "name": "container",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "item",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "rowSpacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,7 +80,7 @@
       "name": "small",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "medium",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "large",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -127,11 +127,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -161,7 +161,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/BaseGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/BaseGrid.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseHeading.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseHeading.json
@@ -10,11 +10,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/BaseHeading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/BaseHeading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/BaseHeading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/BaseHeading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "level",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/BaseHeading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseHeading.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseHeading.json
@@ -10,11 +10,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
+          "fileName": "packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
+          "fileName": "packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
+          "fileName": "packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
+          "fileName": "packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "level",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/BaseHeading.tsx",
+          "fileName": "packages/typography/src/BaseHeading.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseSkeleton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseSkeleton.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/BaseSkeleton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/BaseSkeleton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/BaseSkeleton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/BaseSkeleton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseSkeleton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseSkeleton.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/BaseSkeleton.tsx",
+          "fileName": "packages/loader/src/BaseSkeleton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/BaseSkeleton.tsx",
+          "fileName": "packages/loader/src/BaseSkeleton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Blockquote.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Blockquote.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Blockquote.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Blockquote.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Blockquote.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Blockquote.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Blockquote.tsx",
+          "fileName": "packages/typography/src/beta/components/Blockquote.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BlockquoteFooter.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BlockquoteFooter.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Blockquote.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Blockquote.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BlockquoteFooter.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BlockquoteFooter.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Blockquote.tsx",
+          "fileName": "packages/typography/src/beta/components/Blockquote.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BreadcrumbItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BreadcrumbItem.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/BreadcrumbItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/BreadcrumbItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/BreadcrumbItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BreadcrumbItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BreadcrumbItem.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbItem.tsx",
+          "fileName": "packages/menu/src/BreadcrumbItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbItem.tsx",
+          "fileName": "packages/menu/src/BreadcrumbItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbItem.tsx",
+          "fileName": "packages/menu/src/BreadcrumbItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BreadcrumbNavigation.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BreadcrumbNavigation.json
@@ -12,7 +12,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/BreadcrumbNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,11 +27,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/BreadcrumbNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbNavigation.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BreadcrumbNavigation.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BreadcrumbNavigation.json
@@ -12,7 +12,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbNavigation.tsx",
+          "fileName": "packages/menu/src/BreadcrumbNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,11 +27,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/BreadcrumbNavigation.tsx",
+          "fileName": "packages/menu/src/BreadcrumbNavigation.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BulletBadge.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BulletBadge.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "hide",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BulletBadge.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BulletBadge.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "hide",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/BulletBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/BulletBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Button.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Button.json
@@ -12,7 +12,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/Button.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/Button.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/Button.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/Button.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/Button.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/Button.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/Button.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -127,11 +127,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/Button.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/Button.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -161,7 +161,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Button.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Button.json
@@ -12,7 +12,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
+          "fileName": "packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
+          "fileName": "packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
+          "fileName": "packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
+          "fileName": "packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
+          "fileName": "packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
+          "fileName": "packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
+          "fileName": "packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -127,11 +127,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
+          "fileName": "packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/Button.tsx",
+          "fileName": "packages/button/src/Button.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -161,7 +161,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ButtonGroup.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ButtonGroup.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/ButtonGroup.tsx",
+          "fileName": "packages/button/src/ButtonGroup.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/ButtonGroup.tsx",
+          "fileName": "packages/button/src/ButtonGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/ButtonGroup.tsx",
+          "fileName": "packages/button/src/ButtonGroup.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ButtonGroup.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ButtonGroup.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/ButtonGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/ButtonGroup.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/ButtonGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/ButtonGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/ButtonGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/ButtonGroup.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Calendar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Calendar.json
@@ -10,7 +10,7 @@
       "name": "selectedDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "navigationDescription",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "onSelectedCellClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "onCellClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -119,7 +119,7 @@
       "name": "minDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -134,7 +134,7 @@
       "name": "maxDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "showWeekNumbers",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -168,7 +168,7 @@
       "name": "weekNumberHeader",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -185,7 +185,7 @@
       "name": "showOutsideMonth",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -202,7 +202,7 @@
       "name": "classNameForDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -219,7 +219,7 @@
       "name": "ariaLabelForDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -234,7 +234,7 @@
       "name": "onValidate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -249,7 +249,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -264,7 +264,7 @@
       "name": "locale",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -279,7 +279,7 @@
       "name": "calendarRef",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -294,7 +294,7 @@
       "name": "forcedReturnType",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Calendar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Calendar.json
@@ -10,7 +10,7 @@
       "name": "selectedDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "navigationDescription",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "onSelectedCellClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "onCellClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -119,7 +119,7 @@
       "name": "minDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -134,7 +134,7 @@
       "name": "maxDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "showWeekNumbers",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -168,7 +168,7 @@
       "name": "weekNumberHeader",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -185,7 +185,7 @@
       "name": "showOutsideMonth",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -202,7 +202,7 @@
       "name": "classNameForDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -219,7 +219,7 @@
       "name": "ariaLabelForDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -234,7 +234,7 @@
       "name": "onValidate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -249,7 +249,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -264,7 +264,7 @@
       "name": "locale",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -279,7 +279,7 @@
       "name": "calendarRef",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -294,7 +294,7 @@
       "name": "forcedReturnType",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/Calendar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/Calendar.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CalendarButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CalendarButton.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/shared/CalendarButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/CalendarButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/shared/CalendarButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/CalendarButton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CalendarButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CalendarButton.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/CalendarButton.tsx",
+          "fileName": "packages/datepicker/src/shared/CalendarButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/CalendarButton.tsx",
+          "fileName": "packages/datepicker/src/shared/CalendarButton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CalendarCell.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CalendarCell.json
@@ -10,7 +10,7 @@
       "name": "state",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "date",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "weekNumberString",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "showOutsideMonth",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "onSelectedCellClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "onCellClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "classNameForDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "ariaLabelForDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CalendarCell.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CalendarCell.json
@@ -10,7 +10,7 @@
       "name": "state",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "date",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "weekNumberString",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "showOutsideMonth",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "onSelectedCellClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "onCellClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "classNameForDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "ariaLabelForDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarCell.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CalendarGrid.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CalendarGrid.json
@@ -10,7 +10,7 @@
       "name": "state",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "navigationDescription",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "showWeekNumbers",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "weekNumberHeader",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "showOutsideMonth",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "onSelectedCellClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "onCellClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "classNameForDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "ariaLabelForDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CalendarGrid.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CalendarGrid.json
@@ -10,7 +10,7 @@
       "name": "state",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "navigationDescription",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "showWeekNumbers",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "weekNumberHeader",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "showOutsideMonth",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "onSelectedCellClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "onCellClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "classNameForDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "ariaLabelForDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/CalendarGrid.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Checkbox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Checkbox.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
+          "fileName": "packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
+          "fileName": "packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
+          "fileName": "packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,11 +63,11 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
+          "fileName": "packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,11 +84,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
+          "fileName": "packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -105,11 +105,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
+          "fileName": "packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -124,11 +124,11 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
+          "fileName": "packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -145,7 +145,7 @@
       "name": "reduceClickArea",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
+          "fileName": "packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -162,7 +162,7 @@
       "name": "disableAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
+          "fileName": "packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Checkbox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Checkbox.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Checkbox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Checkbox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Checkbox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,11 +63,11 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Checkbox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,11 +84,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Checkbox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -105,11 +105,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Checkbox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -124,11 +124,11 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Checkbox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -145,7 +145,7 @@
       "name": "reduceClickArea",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Checkbox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -162,7 +162,7 @@
       "name": "disableAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Checkbox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Checkbox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CheckboxPanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CheckboxPanel.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,11 +42,11 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -63,11 +63,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,11 +84,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -103,11 +103,11 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -122,11 +122,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -141,11 +141,11 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -160,11 +160,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -179,7 +179,7 @@
       "name": "secondaryLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -196,7 +196,7 @@
       "name": "hideCheckbox",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CheckboxPanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CheckboxPanel.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,11 +42,11 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -63,11 +63,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,11 +84,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -103,11 +103,11 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -122,11 +122,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -141,11 +141,11 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -160,11 +160,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -179,7 +179,7 @@
       "name": "secondaryLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -196,7 +196,7 @@
       "name": "hideCheckbox",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/CheckboxPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/CheckboxPanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChip.json
@@ -10,7 +10,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,11 +44,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -63,11 +63,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -82,11 +82,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChip.json
@@ -10,7 +10,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,11 +44,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -63,11 +63,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -82,11 +82,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChipGroup.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChipGroup.json
@@ -10,7 +10,7 @@
       "name": "name",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChipGroup.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ChoiceChipGroup.json
@@ -10,7 +10,7 @@
       "name": "name",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/ChoiceChipGroup.tsx",
+          "fileName": "packages/chip/src/ChoiceChipGroup.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ClearableButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ClearableButton.json
@@ -10,7 +10,7 @@
       "name": "onClear",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "labelClearSelectedItems",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "focusable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "ariaLabelClearItems",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ClearableButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ClearableButton.json
@@ -10,7 +10,7 @@
       "name": "onClear",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "labelClearSelectedItems",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "focusable",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "ariaLabelClearItems",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CodeText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CodeText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/CodeText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/CodeText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/CodeText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/CodeText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/CodeText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/CodeText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CodeText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CodeText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/CodeText.tsx",
+          "fileName": "packages/typography/src/CodeText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/CodeText.tsx",
+          "fileName": "packages/typography/src/CodeText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/CodeText.tsx",
+          "fileName": "packages/typography/src/CodeText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CollapsibleSideNavigation.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CollapsibleSideNavigation.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "collapsed",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "onCollapseToggle",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "collapsibleButtonPosition",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "openSideMenuAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "closeSideMenuAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CollapsibleSideNavigation.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CollapsibleSideNavigation.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigation.tsx",
+          "fileName": "packages/menu/src/SideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigation.tsx",
+          "fileName": "packages/menu/src/SideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "collapsed",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "onCollapseToggle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "collapsibleButtonPosition",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "openSideMenuAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "closeSideMenuAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/CollapsibleSideNavigation.tsx",
+          "fileName": "packages/menu/src/CollapsibleSideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ConditionalWrapper.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ConditionalWrapper.json
@@ -10,7 +10,7 @@
       "name": "condition",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/utils/src/ConditionalWrapper.tsx",
+          "fileName": "packages/utils/src/ConditionalWrapper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "wrapper",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/utils/src/ConditionalWrapper.tsx",
+          "fileName": "packages/utils/src/ConditionalWrapper.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ConditionalWrapper.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ConditionalWrapper.json
@@ -10,7 +10,7 @@
       "name": "condition",
       "declarations": [
         {
-          "fileName": "design-system/packages/utils/src/ConditionalWrapper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/utils/src/ConditionalWrapper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "wrapper",
       "declarations": [
         {
-          "fileName": "design-system/packages/utils/src/ConditionalWrapper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/utils/src/ConditionalWrapper.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Contrast.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Contrast.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Contrast.tsx",
+          "fileName": "packages/layout/src/Contrast.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Contrast.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Contrast.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Contrast.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Contrast.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CopyableText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CopyableText.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/CopyableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/CopyableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "textToCopy",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/CopyableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "successHeading",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/CopyableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "successMessage",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/CopyableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/CopyableText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/CopyableText.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
+          "fileName": "packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
+          "fileName": "packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "textToCopy",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
+          "fileName": "packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "successHeading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
+          "fileName": "packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "successMessage",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/CopyableText.tsx",
+          "fileName": "packages/alert/src/CopyableText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DataCell.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DataCell.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
+          "fileName": "packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "padding",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
+          "fileName": "packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "status",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
+          "fileName": "packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
+          "fileName": "packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,11 +76,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
+          "fileName": "packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DataCell.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DataCell.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/DataCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "padding",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/DataCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "status",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/DataCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/DataCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,11 +76,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/DataCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/DataCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
@@ -10,7 +10,7 @@
       "name": "selectedDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "locale",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "showTimeZone",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "granularity",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "showTime",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "minDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "maxDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "isDateUnavailable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -168,7 +168,7 @@
       "name": "forcedReturnType",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -183,7 +183,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -198,7 +198,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -215,7 +215,7 @@
       "name": "validationFeedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -232,7 +232,7 @@
       "name": "validationVariant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -247,7 +247,7 @@
       "name": "onValidate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -262,7 +262,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -277,7 +277,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -292,7 +292,7 @@
       "name": "fieldProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -307,7 +307,7 @@
       "name": "dateFieldRef",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -322,7 +322,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -337,7 +337,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -352,7 +352,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -367,7 +367,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -382,7 +382,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -397,7 +397,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -412,7 +412,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -427,7 +427,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -442,7 +442,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -457,7 +457,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -472,7 +472,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -487,7 +487,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -502,7 +502,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -517,7 +517,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -532,7 +532,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
@@ -10,7 +10,7 @@
       "name": "selectedDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "locale",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "showTimeZone",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "granularity",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "showTime",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "minDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "maxDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "isDateUnavailable",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -168,7 +168,7 @@
       "name": "forcedReturnType",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -183,7 +183,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -198,7 +198,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -215,7 +215,7 @@
       "name": "validationFeedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -232,7 +232,7 @@
       "name": "validationVariant",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -247,7 +247,7 @@
       "name": "onValidate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -262,7 +262,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -277,7 +277,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -292,7 +292,7 @@
       "name": "fieldProps",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -307,7 +307,7 @@
       "name": "dateFieldRef",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -322,7 +322,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -337,7 +337,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -352,7 +352,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -367,7 +367,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -382,7 +382,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -397,7 +397,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -412,7 +412,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -427,7 +427,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -442,7 +442,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -457,7 +457,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -472,7 +472,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -487,7 +487,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -502,7 +502,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -517,7 +517,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -532,7 +532,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DatePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DatePicker.json
@@ -10,7 +10,7 @@
       "name": "selectedDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "locale",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "showTimeZone",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "granularity",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "showTime",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "minDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "maxDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "isDateUnavailable",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -168,7 +168,7 @@
       "name": "forcedReturnType",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -183,7 +183,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -198,7 +198,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -215,7 +215,7 @@
       "name": "validationFeedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -232,7 +232,7 @@
       "name": "validationVariant",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -247,7 +247,7 @@
       "name": "onValidate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -262,7 +262,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -277,7 +277,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -292,7 +292,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -307,7 +307,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -324,7 +324,7 @@
       "name": "showWeekNumbers",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -341,7 +341,7 @@
       "name": "weekNumberHeader",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -358,7 +358,7 @@
       "name": "showOutsideMonth",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -375,7 +375,7 @@
       "name": "disableModal",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -392,7 +392,7 @@
       "name": "modalTreshold",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -407,7 +407,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -424,7 +424,7 @@
       "name": "navigationDescription",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -441,7 +441,7 @@
       "name": "classNameForDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -458,7 +458,7 @@
       "name": "ariaLabelForDate",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -473,7 +473,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -488,7 +488,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -503,7 +503,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -518,7 +518,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -533,7 +533,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -548,7 +548,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -563,7 +563,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -578,7 +578,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -593,7 +593,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -608,7 +608,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -623,7 +623,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DatePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DatePicker.json
@@ -10,7 +10,7 @@
       "name": "selectedDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "locale",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "showTimeZone",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "granularity",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "showTime",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "minDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "maxDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "isDateUnavailable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -168,7 +168,7 @@
       "name": "forcedReturnType",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -183,7 +183,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -198,7 +198,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -215,7 +215,7 @@
       "name": "validationFeedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -232,7 +232,7 @@
       "name": "validationVariant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -247,7 +247,7 @@
       "name": "onValidate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -262,7 +262,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -277,7 +277,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -292,7 +292,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -307,7 +307,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DateField.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DateField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -324,7 +324,7 @@
       "name": "showWeekNumbers",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -341,7 +341,7 @@
       "name": "weekNumberHeader",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -358,7 +358,7 @@
       "name": "showOutsideMonth",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -375,7 +375,7 @@
       "name": "disableModal",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -392,7 +392,7 @@
       "name": "modalTreshold",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -407,7 +407,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -424,7 +424,7 @@
       "name": "navigationDescription",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -441,7 +441,7 @@
       "name": "classNameForDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -458,7 +458,7 @@
       "name": "ariaLabelForDate",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/DatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/DatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -473,7 +473,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -488,7 +488,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -503,7 +503,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -518,7 +518,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -533,7 +533,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -548,7 +548,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -563,7 +563,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -578,7 +578,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -593,7 +593,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -608,7 +608,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -623,7 +623,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Drawer.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Drawer.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
+          "fileName": "packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
+          "fileName": "packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "closeLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
+          "fileName": "packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "contrast",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
+          "fileName": "packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "onDismiss",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
+          "fileName": "packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
+          "fileName": "packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
+          "fileName": "packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
+          "fileName": "packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -142,7 +142,7 @@
       "name": "overlay",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
+          "fileName": "packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Drawer.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Drawer.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Drawer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Drawer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "closeLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Drawer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "contrast",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Drawer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "onDismiss",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Drawer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Drawer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Drawer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Drawer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -142,7 +142,7 @@
       "name": "overlay",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Drawer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Drawer.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Dropdown.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Dropdown.json
@@ -10,7 +10,7 @@
       "name": "items",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "selectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "placeholder",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "selectOnTab",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -138,7 +138,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -155,7 +155,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -170,7 +170,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -185,7 +185,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -200,7 +200,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -217,7 +217,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -234,7 +234,7 @@
       "name": "noMatchesText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -251,7 +251,7 @@
       "name": "labelClearSelectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -266,7 +266,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -283,7 +283,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -298,7 +298,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -313,7 +313,7 @@
       "name": "listStyle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -328,7 +328,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -345,7 +345,7 @@
       "name": "ariaLabelCloseList",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -362,7 +362,7 @@
       "name": "ariaLabelOpenList",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -379,7 +379,7 @@
       "name": "ariaLabelChosenSingular",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -396,7 +396,7 @@
       "name": "ariaLabelSelectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Dropdown.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Dropdown.json
@@ -10,7 +10,7 @@
       "name": "items",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "selectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "placeholder",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "selectOnTab",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -138,7 +138,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -155,7 +155,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -170,7 +170,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -185,7 +185,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -200,7 +200,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -217,7 +217,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -234,7 +234,7 @@
       "name": "noMatchesText",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -251,7 +251,7 @@
       "name": "labelClearSelectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -266,7 +266,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -283,7 +283,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -298,7 +298,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -313,7 +313,7 @@
       "name": "listStyle",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -328,7 +328,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -345,7 +345,7 @@
       "name": "ariaLabelCloseList",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -362,7 +362,7 @@
       "name": "ariaLabelOpenList",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -379,7 +379,7 @@
       "name": "ariaLabelChosenSingular",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -396,7 +396,7 @@
       "name": "ariaLabelSelectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DropdownFieldAppendix.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DropdownFieldAppendix.json
@@ -10,7 +10,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "ariaLabelCloseList",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "ariaLabelOpenList",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "labelClearSelected",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "focusable",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "isOpen",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "onClear",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -166,7 +166,7 @@
       "name": "itemIsSelected",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DropdownFieldAppendix.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DropdownFieldAppendix.json
@@ -10,7 +10,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "ariaLabelCloseList",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "ariaLabelOpenList",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "labelClearSelected",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "focusable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "isOpen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "onClear",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -166,7 +166,7 @@
       "name": "itemIsSelected",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DropdownList.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DropdownList.json
@@ -12,7 +12,7 @@
       "name": "ariaLabelChosenSingular",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "ariaLabelSelectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "getItemProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "highlightedIndex",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "isOpen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "listItems",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "floatingStyles",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -119,7 +119,7 @@
       "name": "innerRef",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -153,7 +153,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -170,7 +170,7 @@
       "name": "noMatchesText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -185,7 +185,7 @@
       "name": "selectAllCheckboxState",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -200,7 +200,7 @@
       "name": "selectAllItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -215,7 +215,7 @@
       "name": "selectedItems",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -230,7 +230,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -247,7 +247,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DropdownList.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DropdownList.json
@@ -12,7 +12,7 @@
       "name": "ariaLabelChosenSingular",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "ariaLabelSelectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "getItemProps",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "highlightedIndex",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "isOpen",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "listItems",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "floatingStyles",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -119,7 +119,7 @@
       "name": "innerRef",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -153,7 +153,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -170,7 +170,7 @@
       "name": "noMatchesText",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -185,7 +185,7 @@
       "name": "selectAllCheckboxState",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -200,7 +200,7 @@
       "name": "selectAllItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -215,7 +215,7 @@
       "name": "selectedItems",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -230,7 +230,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -247,7 +247,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/DropdownList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/DropdownList.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/EditableCell.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/EditableCell.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/EditableCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/EditableCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/EditableCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/EditableCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "outlined",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/EditableCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/EditableCell.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/EditableCell.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
+          "fileName": "packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
+          "fileName": "packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
+          "fileName": "packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
+          "fileName": "packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "outlined",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/EditableCell.tsx",
+          "fileName": "packages/table/src/EditableCell.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/EmphasizedText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/EmphasizedText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/EmphasizedText.tsx",
+          "fileName": "packages/typography/src/EmphasizedText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/EmphasizedText.tsx",
+          "fileName": "packages/typography/src/EmphasizedText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/EmphasizedText.tsx",
+          "fileName": "packages/typography/src/EmphasizedText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/EmphasizedText.tsx",
+          "fileName": "packages/typography/src/EmphasizedText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/EmphasizedText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/EmphasizedText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/EmphasizedText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/EmphasizedText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/EmphasizedText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/EmphasizedText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/EmphasizedText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/EmphasizedText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/EmphasizedText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/EmphasizedText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandArrow.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandArrow.json
@@ -12,7 +12,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandArrow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandArrow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandArrow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandArrow.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandArrow.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandArrow.json
@@ -12,7 +12,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandArrow.tsx",
+          "fileName": "packages/expand/src/ExpandArrow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandArrow.tsx",
+          "fileName": "packages/expand/src/ExpandArrow.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandRowButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandRowButton.json
@@ -10,7 +10,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/ExpandRowButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandRowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/ExpandRowButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandRowButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandRowButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandRowButton.json
@@ -10,7 +10,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandRowButton.tsx",
+          "fileName": "packages/table/src/ExpandRowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandRowButton.tsx",
+          "fileName": "packages/table/src/ExpandRowButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandablePanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandablePanel.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "contentStyle",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandablePanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandablePanel.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "contentStyle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandablePanel.tsx",
+          "fileName": "packages/expand/src/ExpandablePanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableRow.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableRow.json
@@ -10,7 +10,7 @@
       "name": "colSpan",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandableRow.tsx",
+          "fileName": "packages/table/src/ExpandableRow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandableRow.tsx",
+          "fileName": "packages/table/src/ExpandableRow.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandableRow.tsx",
+          "fileName": "packages/table/src/ExpandableRow.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableRow.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableRow.json
@@ -10,7 +10,7 @@
       "name": "colSpan",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/ExpandableRow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandableRow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/ExpandableRow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandableRow.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/ExpandableRow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/ExpandableRow.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableText.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
+          "fileName": "packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
+          "fileName": "packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
+          "fileName": "packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
+          "fileName": "packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
+          "fileName": "packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "contentStyle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
+          "fileName": "packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "titleElement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
+          "fileName": "packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "disableAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
+          "fileName": "packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableText.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,11 +25,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "contentStyle",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "titleElement",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "disableAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableTextButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableTextButton.json
@@ -10,7 +10,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableTextButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableTextButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableTextButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableTextButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/ExpandableTextButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableTextButton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableTextButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ExpandableTextButton.json
@@ -10,7 +10,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableTextButton.tsx",
+          "fileName": "packages/expand/src/ExpandableTextButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableTextButton.tsx",
+          "fileName": "packages/expand/src/ExpandableTextButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/ExpandableTextButton.tsx",
+          "fileName": "packages/expand/src/ExpandableTextButton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FeedbackText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FeedbackText.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/FeedbackText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/FeedbackText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "hideIcon",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/FeedbackText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/FeedbackText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/FeedbackText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/FeedbackText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/FeedbackText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/FeedbackText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FeedbackText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FeedbackText.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/FeedbackText.tsx",
+          "fileName": "packages/form/src/FeedbackText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "hideIcon",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/FeedbackText.tsx",
+          "fileName": "packages/form/src/FeedbackText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/FeedbackText.tsx",
+          "fileName": "packages/form/src/FeedbackText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/FeedbackText.tsx",
+          "fileName": "packages/form/src/FeedbackText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FieldSegment.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FieldSegment.json
@@ -10,7 +10,7 @@
       "name": "segment",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/FieldSegment.tsx",
+          "fileName": "packages/datepicker/src/shared/FieldSegment.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "state",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/FieldSegment.tsx",
+          "fileName": "packages/datepicker/src/shared/FieldSegment.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "aria-describedby",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/FieldSegment.tsx",
+          "fileName": "packages/datepicker/src/shared/FieldSegment.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FieldSegment.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FieldSegment.json
@@ -10,7 +10,7 @@
       "name": "segment",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/shared/FieldSegment.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/FieldSegment.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "state",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/shared/FieldSegment.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/FieldSegment.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "aria-describedby",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/shared/FieldSegment.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/shared/FieldSegment.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Fieldset.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Fieldset.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Fieldset.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Fieldset.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Fieldset.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Fieldset.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Fieldset.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Fieldset.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Fieldset.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Fieldset.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Fieldset.tsx",
+          "fileName": "packages/form/src/Fieldset.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Fieldset.tsx",
+          "fileName": "packages/form/src/Fieldset.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Fieldset.tsx",
+          "fileName": "packages/form/src/Fieldset.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FileUpload.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FileUpload.json
@@ -12,11 +12,11 @@
       "name": "accept",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -31,11 +31,11 @@
       "name": "minSize",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -50,11 +50,11 @@
       "name": "maxSize",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -69,7 +69,7 @@
       "name": "maxFiles",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -84,7 +84,7 @@
       "name": "preventDropOnDocument",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -99,7 +99,7 @@
       "name": "noClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -114,7 +114,7 @@
       "name": "noKeyboard",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -129,7 +129,7 @@
       "name": "noDrag",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -144,7 +144,7 @@
       "name": "noDragEventsBubbling",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -159,7 +159,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -174,11 +174,11 @@
       "name": "onDrop",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -193,7 +193,7 @@
       "name": "onDropAccepted",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -208,7 +208,7 @@
       "name": "onDropRejected",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -223,7 +223,7 @@
       "name": "getFilesFromEvent",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -238,7 +238,7 @@
       "name": "onFileDialogCancel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -253,7 +253,7 @@
       "name": "onFileDialogOpen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -268,7 +268,7 @@
       "name": "validator",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -285,7 +285,7 @@
       "name": "successText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -302,7 +302,7 @@
       "name": "errorText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -319,7 +319,7 @@
       "name": "standbyText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -336,7 +336,7 @@
       "name": "errorUpload",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -353,7 +353,7 @@
       "name": "onDelete",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -370,7 +370,7 @@
       "name": "files",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -385,7 +385,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -402,7 +402,7 @@
       "name": "removeFileButtonDescription",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FileUpload.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FileUpload.json
@@ -12,11 +12,11 @@
       "name": "accept",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -31,11 +31,11 @@
       "name": "minSize",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -50,11 +50,11 @@
       "name": "maxSize",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -69,7 +69,7 @@
       "name": "maxFiles",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -84,7 +84,7 @@
       "name": "preventDropOnDocument",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -99,7 +99,7 @@
       "name": "noClick",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -114,7 +114,7 @@
       "name": "noKeyboard",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -129,7 +129,7 @@
       "name": "noDrag",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -144,7 +144,7 @@
       "name": "noDragEventsBubbling",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -159,7 +159,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -174,11 +174,11 @@
       "name": "onDrop",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -193,7 +193,7 @@
       "name": "onDropAccepted",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -208,7 +208,7 @@
       "name": "onDropRejected",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -223,7 +223,7 @@
       "name": "getFilesFromEvent",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -238,7 +238,7 @@
       "name": "onFileDialogCancel",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -253,7 +253,7 @@
       "name": "onFileDialogOpen",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -268,7 +268,7 @@
       "name": "validator",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/react-dropzone/typings/react-dropzone.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/react-dropzone/typings/react-dropzone.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -285,7 +285,7 @@
       "name": "successText",
       "declarations": [
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -302,7 +302,7 @@
       "name": "errorText",
       "declarations": [
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -319,7 +319,7 @@
       "name": "standbyText",
       "declarations": [
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -336,7 +336,7 @@
       "name": "errorUpload",
       "declarations": [
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -353,7 +353,7 @@
       "name": "onDelete",
       "declarations": [
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -370,7 +370,7 @@
       "name": "files",
       "declarations": [
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -385,7 +385,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -402,7 +402,7 @@
       "name": "removeFileButtonDescription",
       "declarations": [
         {
-          "fileName": "design-system/packages/fileupload/src/FileUpload.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/fileupload/src/FileUpload.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FilterChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FilterChip.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/FilterChip.tsx",
+          "fileName": "packages/chip/src/FilterChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/FilterChip.tsx",
+          "fileName": "packages/chip/src/FilterChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/FilterChip.tsx",
+          "fileName": "packages/chip/src/FilterChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -65,7 +65,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/FilterChip.tsx",
+          "fileName": "packages/chip/src/FilterChip.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FilterChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FilterChip.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/FilterChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/FilterChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/FilterChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/FilterChip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/FilterChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/FilterChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -65,7 +65,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/FilterChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/FilterChip.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Flex.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Flex.json
@@ -12,7 +12,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "wrap",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "align",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "justify",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "alignContent",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "gap",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "rowGap",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -119,7 +119,7 @@
       "name": "columnGap",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -134,7 +134,7 @@
       "name": "flex",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -149,7 +149,7 @@
       "name": "grow",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -164,7 +164,7 @@
       "name": "shrink",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -179,7 +179,7 @@
       "name": "basis",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -194,7 +194,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -209,7 +209,7 @@
       "name": "height",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -224,7 +224,7 @@
       "name": "minWidth",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -239,7 +239,7 @@
       "name": "minHeight",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -254,7 +254,7 @@
       "name": "maxWidth",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -269,7 +269,7 @@
       "name": "maxHeight",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -286,11 +286,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -305,7 +305,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -320,7 +320,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -335,7 +335,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Flex.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Flex.json
@@ -12,7 +12,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "wrap",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "align",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "justify",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "alignContent",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "gap",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "rowGap",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -119,7 +119,7 @@
       "name": "columnGap",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -134,7 +134,7 @@
       "name": "flex",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -149,7 +149,7 @@
       "name": "grow",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -164,7 +164,7 @@
       "name": "shrink",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -179,7 +179,7 @@
       "name": "basis",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -194,7 +194,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -209,7 +209,7 @@
       "name": "height",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -224,7 +224,7 @@
       "name": "minWidth",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -239,7 +239,7 @@
       "name": "minHeight",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -254,7 +254,7 @@
       "name": "maxWidth",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -269,7 +269,7 @@
       "name": "maxHeight",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -286,17 +286,17 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
       "required": false,
       "type": {
-        "name": "(string & ElementType<any, keyof IntrinsicElements>) | (ComponentClass<any, any> & ElementType<any, keyof IntrinsicElements>) | (FunctionComponent<...> & ElementType<...>) | undefined"
+        "name": "(string & ElementType<any>) | (ComponentClass<any, any> & ElementType<any>) | (FunctionComponent<any> & ElementType<...>) | undefined"
       }
     },
     "className": {
@@ -305,7 +305,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -320,7 +320,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -335,7 +335,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/Flex.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/Flex.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FlexSpacer.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FlexSpacer.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/FlexSpacer.tsx",
+          "fileName": "packages/layout/src/beta/Flex/FlexSpacer.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/FlexSpacer.tsx",
+          "fileName": "packages/layout/src/beta/Flex/FlexSpacer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/FlexSpacer.tsx",
+          "fileName": "packages/layout/src/beta/Flex/FlexSpacer.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FlexSpacer.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FlexSpacer.json
@@ -12,17 +12,17 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/FlexSpacer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/FlexSpacer.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
       "required": false,
       "type": {
-        "name": "(string & ElementType<any, keyof IntrinsicElements>) | (ComponentClass<any, any> & ElementType<any, keyof IntrinsicElements>) | (FunctionComponent<...> & ElementType<...>) | undefined"
+        "name": "(string & ElementType<any>) | (ComponentClass<any, any> & ElementType<any>) | (FunctionComponent<any> & ElementType<...>) | undefined"
       }
     },
     "className": {
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/FlexSpacer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/FlexSpacer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Flex/FlexSpacer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Flex/FlexSpacer.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FloatingButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FloatingButton.json
@@ -10,11 +10,11 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
+          "fileName": "packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "AriaAttributes"
         }
       ],
@@ -29,15 +29,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
+          "fileName": "packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -52,11 +52,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
+          "fileName": "packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -71,11 +71,11 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
+          "fileName": "packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -92,7 +92,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
+          "fileName": "packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FloatingButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FloatingButton.json
@@ -10,11 +10,11 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/FloatingButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "AriaAttributes"
         }
       ],
@@ -29,15 +29,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/FloatingButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -52,11 +52,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/FloatingButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -71,11 +71,11 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/FloatingButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -92,7 +92,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/FloatingButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/FloatingButton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Grid.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Grid.json
@@ -12,7 +12,7 @@
       "name": "templateColumns",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "gap",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "rowGap",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "columnGap",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "templateRows",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "autoFlow",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "align",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "justify",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "alignContent",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "height",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -168,11 +168,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -202,7 +202,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -217,7 +217,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Grid.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Grid.json
@@ -12,7 +12,7 @@
       "name": "templateColumns",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "gap",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "rowGap",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "columnGap",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "templateRows",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "autoFlow",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "align",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "justify",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "alignContent",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "height",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -168,17 +168,17 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
       "required": false,
       "type": {
-        "name": "(string & ElementType<any, keyof IntrinsicElements>) | (ComponentClass<any, any> & ElementType<any, keyof IntrinsicElements>) | (FunctionComponent<...> & ElementType<...>) | undefined"
+        "name": "(string & ElementType<any>) | (ComponentClass<any, any> & ElementType<any>) | (FunctionComponent<any> & ElementType<...>) | undefined"
       }
     },
     "className": {
@@ -187,7 +187,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -202,7 +202,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -217,7 +217,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/Grid.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/Grid.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/GridContainer.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/GridContainer.json
@@ -12,7 +12,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/GridContainer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "rowSpacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/GridContainer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,11 +44,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/GridContainer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/GridContainer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/grid/src/GridContainer.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/GridContainer.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/GridContainer.json
@@ -12,7 +12,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
+          "fileName": "packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "rowSpacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
+          "fileName": "packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,11 +44,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
+          "fileName": "packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
+          "fileName": "packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/grid/src/GridContainer.tsx",
+          "fileName": "packages/grid/src/GridContainer.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/GridItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/GridItem.json
@@ -10,7 +10,7 @@
       "name": "colSpan",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "rowSpan",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,11 +44,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/GridItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/GridItem.json
@@ -10,7 +10,7 @@
       "name": "colSpan",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "rowSpan",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,17 +44,17 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
       "required": false,
       "type": {
-        "name": "(string & ElementType<any, keyof IntrinsicElements>) | (ComponentClass<any, any> & ElementType<any, keyof IntrinsicElements>) | (FunctionComponent<...> & ElementType<...>) | undefined"
+        "name": "(string & ElementType<any>) | (ComponentClass<any, any> & ElementType<any>) | (FunctionComponent<any> & ElementType<...>) | undefined"
       }
     },
     "className": {
@@ -63,7 +63,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/Grid/GridItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/Grid/GridItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/HeaderCell.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/HeaderCell.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
+          "fileName": "packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
+          "fileName": "packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "name",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
+          "fileName": "packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -65,7 +65,7 @@
       "name": "sortable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
+          "fileName": "packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,7 +80,7 @@
       "name": "sortConfig",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
+          "fileName": "packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -97,7 +97,7 @@
       "name": "padding",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
+          "fileName": "packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -112,7 +112,7 @@
       "name": "sortableButtonProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
+          "fileName": "packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -129,7 +129,7 @@
       "name": "sortedAscendingAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
+          "fileName": "packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "sortedDescendingAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
+          "fileName": "packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/HeaderCell.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/HeaderCell.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/HeaderCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/HeaderCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "name",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/HeaderCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -65,7 +65,7 @@
       "name": "sortable",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/HeaderCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,7 +80,7 @@
       "name": "sortConfig",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/HeaderCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -97,7 +97,7 @@
       "name": "padding",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/HeaderCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -112,7 +112,7 @@
       "name": "sortableButtonProps",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/HeaderCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -129,7 +129,7 @@
       "name": "sortedAscendingAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/HeaderCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "sortedDescendingAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/HeaderCell.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/HeaderCell.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading.json
@@ -10,7 +10,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -100,7 +100,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading.json
@@ -10,7 +10,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Heading.tsx",
+          "fileName": "packages/typography/src/beta/components/Heading.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -100,7 +100,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading1.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading1.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading1.tsx",
+          "fileName": "packages/typography/src/Heading1.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading1.tsx",
+          "fileName": "packages/typography/src/Heading1.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading1.tsx",
+          "fileName": "packages/typography/src/Heading1.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading1.tsx",
+          "fileName": "packages/typography/src/Heading1.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading1.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading1.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading1.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading1.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading1.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading1.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading1.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading1.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading1.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading1.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading2.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading2.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading2.tsx",
+          "fileName": "packages/typography/src/Heading2.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading2.tsx",
+          "fileName": "packages/typography/src/Heading2.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading2.tsx",
+          "fileName": "packages/typography/src/Heading2.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading2.tsx",
+          "fileName": "packages/typography/src/Heading2.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading2.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading2.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading2.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading2.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading2.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading2.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading2.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading2.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading2.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading2.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading3.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading3.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading3.tsx",
+          "fileName": "packages/typography/src/Heading3.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading3.tsx",
+          "fileName": "packages/typography/src/Heading3.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading3.tsx",
+          "fileName": "packages/typography/src/Heading3.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading3.tsx",
+          "fileName": "packages/typography/src/Heading3.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading3.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading3.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading3.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading3.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading3.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading3.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading3.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading3.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading3.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading3.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading4.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading4.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading4.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading4.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading4.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading4.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading4.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading4.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading4.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading4.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading4.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading4.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading4.tsx",
+          "fileName": "packages/typography/src/Heading4.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading4.tsx",
+          "fileName": "packages/typography/src/Heading4.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading4.tsx",
+          "fileName": "packages/typography/src/Heading4.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading4.tsx",
+          "fileName": "packages/typography/src/Heading4.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading5.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading5.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading5.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading5.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading5.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading5.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading5.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading5.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading5.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading5.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading5.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading5.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading5.tsx",
+          "fileName": "packages/typography/src/Heading5.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading5.tsx",
+          "fileName": "packages/typography/src/Heading5.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading5.tsx",
+          "fileName": "packages/typography/src/Heading5.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading5.tsx",
+          "fileName": "packages/typography/src/Heading5.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading6.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading6.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading6.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading6.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading6.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading6.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading6.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading6.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Heading6.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading6.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Heading6.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Heading6.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading6.tsx",
+          "fileName": "packages/typography/src/Heading6.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading6.tsx",
+          "fileName": "packages/typography/src/Heading6.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading6.tsx",
+          "fileName": "packages/typography/src/Heading6.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Heading6.tsx",
+          "fileName": "packages/typography/src/Heading6.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/IconButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/IconButton.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/IconButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/IconButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/IconButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/IconButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,11 +74,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/IconButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/IconButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -112,7 +112,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/IconButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -127,7 +127,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/IconButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/IconButton.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
+          "fileName": "packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
+          "fileName": "packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
+          "fileName": "packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
+          "fileName": "packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,11 +74,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
+          "fileName": "packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
+          "fileName": "packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -112,7 +112,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/IconButton.tsx",
+          "fileName": "packages/button/src/IconButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -127,7 +127,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/InputGroupLabel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/InputGroupLabel.json
@@ -10,7 +10,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "isFilled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "staticAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/InputGroupLabel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/InputGroupLabel.json
@@ -10,7 +10,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "isFilled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "staticAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/InputGroupLabel.tsx",
+          "fileName": "packages/form/src/InputGroupLabel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/InputPanelBase.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/InputPanelBase.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,11 +42,11 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -63,11 +63,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,11 +84,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -105,11 +105,11 @@
       "name": "type",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -124,11 +124,11 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -143,11 +143,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -162,11 +162,11 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -181,11 +181,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -200,7 +200,7 @@
       "name": "secondaryLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -217,7 +217,7 @@
       "name": "hideSelectionIndicator",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/InputPanelBase.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/InputPanelBase.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,11 +42,11 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -63,11 +63,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,11 +84,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -105,11 +105,11 @@
       "name": "type",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -124,11 +124,11 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -143,11 +143,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -162,11 +162,11 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -181,11 +181,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -200,7 +200,7 @@
       "name": "secondaryLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -217,7 +217,7 @@
       "name": "hideSelectionIndicator",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/InputPanelBase.tsx",
+          "fileName": "packages/form/src/inputPanel/InputPanelBase.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Label.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Label.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Label.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Label.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Label.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Label.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Label.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Label.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Label.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Label.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Label.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Label.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Label.tsx",
+          "fileName": "packages/typography/src/Label.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Label.tsx",
+          "fileName": "packages/typography/src/Label.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Label.tsx",
+          "fileName": "packages/typography/src/Label.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Label.tsx",
+          "fileName": "packages/typography/src/Label.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LayoutProvider.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LayoutProvider.json
@@ -10,7 +10,7 @@
       "name": "breakpoints",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/LayoutProvider/LayoutProvider.tsx",
+          "fileName": "packages/layout/src/beta/LayoutProvider/LayoutProvider.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LayoutProvider.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LayoutProvider.json
@@ -10,7 +10,7 @@
       "name": "breakpoints",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/LayoutProvider/LayoutProvider.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/LayoutProvider/LayoutProvider.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LeadParagraph.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LeadParagraph.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/LeadParagraph.tsx",
+          "fileName": "packages/typography/src/LeadParagraph.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/LeadParagraph.tsx",
+          "fileName": "packages/typography/src/LeadParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/LeadParagraph.tsx",
+          "fileName": "packages/typography/src/LeadParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/LeadParagraph.tsx",
+          "fileName": "packages/typography/src/LeadParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LeadParagraph.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LeadParagraph.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/LeadParagraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/LeadParagraph.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/LeadParagraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/LeadParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/LeadParagraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/LeadParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/LeadParagraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/LeadParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LegBone.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LegBone.json
@@ -10,7 +10,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegBone.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "pattern",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegBone.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "color",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegBone.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "startColor",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegBone.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "endColor",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegBone.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "showStart",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegBone.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -112,7 +112,7 @@
       "name": "showLine",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegBone.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -129,7 +129,7 @@
       "name": "showStop",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegBone.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -144,11 +144,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegBone.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LegBone.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LegBone.json
@@ -10,7 +10,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
+          "fileName": "packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "pattern",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
+          "fileName": "packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "color",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
+          "fileName": "packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "startColor",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
+          "fileName": "packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "endColor",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
+          "fileName": "packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "showStart",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
+          "fileName": "packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -112,7 +112,7 @@
       "name": "showLine",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
+          "fileName": "packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -129,7 +129,7 @@
       "name": "showStop",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
+          "fileName": "packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -144,11 +144,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegBone.tsx",
+          "fileName": "packages/travel/src/LegBone.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LegLine.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LegLine.json
@@ -10,11 +10,11 @@
       "name": "color",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegLine.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegLine.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegLine.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegLine.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "pattern",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegLine.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegLine.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,11 +61,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/LegLine.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegLine.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LegLine.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LegLine.json
@@ -10,11 +10,11 @@
       "name": "color",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegLine.tsx",
+          "fileName": "packages/travel/src/LegLine.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegLine.tsx",
+          "fileName": "packages/travel/src/LegLine.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "pattern",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegLine.tsx",
+          "fileName": "packages/travel/src/LegLine.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,11 +61,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/LegLine.tsx",
+          "fileName": "packages/travel/src/LegLine.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Link.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Link.json
@@ -14,7 +14,7 @@
       "name": "external",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "ariaLabelExternalIcon",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Link.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Link.json
@@ -14,7 +14,7 @@
       "name": "external",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "ariaLabelExternalIcon",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Link.tsx",
+          "fileName": "packages/typography/src/beta/components/Link.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ListItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ListItem.json
@@ -12,7 +12,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/ListItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/ListItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/ListItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/ListItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/ListItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/ListItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/ListItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/ListItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ListItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ListItem.json
@@ -12,7 +12,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/ListItem.tsx",
+          "fileName": "packages/typography/src/beta/components/ListItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/ListItem.tsx",
+          "fileName": "packages/typography/src/beta/components/ListItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/ListItem.tsx",
+          "fileName": "packages/typography/src/beta/components/ListItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/ListItem.tsx",
+          "fileName": "packages/typography/src/beta/components/ListItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Loader.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Loader.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/Loader.tsx",
+          "fileName": "packages/loader/src/Loader.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/Loader.tsx",
+          "fileName": "packages/loader/src/Loader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "progress",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/Loader.tsx",
+          "fileName": "packages/loader/src/Loader.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Loader.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Loader.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/Loader.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/Loader.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/Loader.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/Loader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "progress",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/Loader.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/Loader.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LoadingDots.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LoadingDots.json
@@ -12,11 +12,11 @@
       "name": "color",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/LoadingDots.tsx",
+          "fileName": "packages/loader/src/LoadingDots.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -31,11 +31,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/LoadingDots.tsx",
+          "fileName": "packages/loader/src/LoadingDots.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/LoadingDots.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/LoadingDots.json
@@ -12,11 +12,11 @@
       "name": "color",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/LoadingDots.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/LoadingDots.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -31,11 +31,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/LoadingDots.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/LoadingDots.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/MediaCard.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/MediaCard.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "description",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "category",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "headingLevel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "hideArrow",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "orientation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -172,7 +172,7 @@
       "name": "wrapperProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "wholeCardAsElement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
+          "fileName": "packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/MediaCard.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/MediaCard.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "description",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "category",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "headingLevel",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "hideArrow",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "orientation",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -172,7 +172,7 @@
       "name": "wrapperProps",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "wholeCardAsElement",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/MediaCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/MediaCard.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Modal.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Modal.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
+          "fileName": "packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "closeLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
+          "fileName": "packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "initialFocusRef",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
+          "fileName": "packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
+          "fileName": "packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onDismiss",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
+          "fileName": "packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
+          "fileName": "packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "align",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
+          "fileName": "packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
+          "fileName": "packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "closeOnClickOutside",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
+          "fileName": "packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Modal.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Modal.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Modal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "closeLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Modal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "initialFocusRef",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Modal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Modal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onDismiss",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Modal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Modal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "align",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Modal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Modal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "closeOnClickOutside",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/Modal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/Modal.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ModalContent.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ModalContent.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalContent.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalContent.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalContent.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalContent.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "align",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalContent.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ModalContent.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ModalContent.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
+          "fileName": "packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
+          "fileName": "packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
+          "fileName": "packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
+          "fileName": "packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "align",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalContent.tsx",
+          "fileName": "packages/modal/src/ModalContent.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ModalOverlay.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ModalOverlay.json
@@ -10,7 +10,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onDismiss",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "initialFocusRef",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ModalOverlay.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ModalOverlay.json
@@ -10,7 +10,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onDismiss",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "initialFocusRef",
       "declarations": [
         {
-          "fileName": "design-system/packages/modal/src/ModalOverlay.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/modal/src/ModalOverlay.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/MultiSelect.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/MultiSelect.json
@@ -10,7 +10,7 @@
       "name": "items",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "placeholder",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "selectOnTab",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -155,7 +155,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -170,7 +170,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -204,7 +204,7 @@
       "name": "noMatchesText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -221,7 +221,7 @@
       "name": "labelClearSelectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -236,7 +236,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -253,7 +253,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -268,7 +268,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -283,7 +283,7 @@
       "name": "listStyle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -298,7 +298,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -315,7 +315,7 @@
       "name": "ariaLabelCloseList",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -332,7 +332,7 @@
       "name": "ariaLabelOpenList",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -349,7 +349,7 @@
       "name": "ariaLabelChosenSingular",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -366,7 +366,7 @@
       "name": "ariaLabelSelectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -383,7 +383,7 @@
       "name": "selectedItems",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -400,7 +400,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -417,7 +417,7 @@
       "name": "itemFilter",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -434,7 +434,7 @@
       "name": "hideSelectAll",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -451,7 +451,7 @@
       "name": "debounceTimeout",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -468,7 +468,7 @@
       "name": "maxChips",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -485,7 +485,7 @@
       "name": "clearInputOnSelect",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -502,7 +502,7 @@
       "name": "labelSelectAll",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -519,7 +519,7 @@
       "name": "labelAllItemsSelected",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -536,7 +536,7 @@
       "name": "labelClearAllItems",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -553,7 +553,7 @@
       "name": "ariaLabelRemoveSelected",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -570,7 +570,7 @@
       "name": "ariaLabelChosenPlural",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -587,7 +587,7 @@
       "name": "ariaLabelJumpToInput",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -602,7 +602,7 @@
       "name": "onBlur",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -617,7 +617,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -632,7 +632,7 @@
       "name": "onKeyDown",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -647,7 +647,7 @@
       "name": "onFocus",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/MultiSelect.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/MultiSelect.json
@@ -10,7 +10,7 @@
       "name": "items",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "placeholder",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "selectOnTab",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -155,7 +155,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -170,7 +170,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -204,7 +204,7 @@
       "name": "noMatchesText",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -221,7 +221,7 @@
       "name": "labelClearSelectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -236,7 +236,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -253,7 +253,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -268,7 +268,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -283,7 +283,7 @@
       "name": "listStyle",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -298,7 +298,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -315,7 +315,7 @@
       "name": "ariaLabelCloseList",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -332,7 +332,7 @@
       "name": "ariaLabelOpenList",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -349,7 +349,7 @@
       "name": "ariaLabelChosenSingular",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -366,7 +366,7 @@
       "name": "ariaLabelSelectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -383,7 +383,7 @@
       "name": "selectedItems",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -400,7 +400,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -417,7 +417,7 @@
       "name": "itemFilter",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -434,7 +434,7 @@
       "name": "hideSelectAll",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -451,7 +451,7 @@
       "name": "debounceTimeout",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -468,7 +468,7 @@
       "name": "maxChips",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -485,7 +485,7 @@
       "name": "clearInputOnSelect",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -502,7 +502,7 @@
       "name": "labelSelectAll",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -519,7 +519,7 @@
       "name": "labelAllItemsSelected",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -536,7 +536,7 @@
       "name": "labelClearAllItems",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -553,7 +553,7 @@
       "name": "ariaLabelRemoveSelected",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -570,7 +570,7 @@
       "name": "ariaLabelChosenPlural",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -587,7 +587,7 @@
       "name": "ariaLabelJumpToInput",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -602,7 +602,7 @@
       "name": "onBlur",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -617,7 +617,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -632,7 +632,7 @@
       "name": "onKeyDown",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -647,7 +647,7 @@
       "name": "onFocus",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/MultiSelect.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/MultiSelect.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NativeDatePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NativeDatePicker.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NativeDatePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NativeDatePicker.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
+          "fileName": "packages/datepicker/src/DatePicker/NativeDatePicker.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NativeTimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NativeTimePicker.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NativeTimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NativeTimePicker.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/NativeTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NavigationCard.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NavigationCard.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
+          "fileName": "packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
+          "fileName": "packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "titleIcon",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
+          "fileName": "packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
+          "fileName": "packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "compact",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
+          "fileName": "packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
+          "fileName": "packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "externalLink",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
+          "fileName": "packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NavigationCard.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NavigationCard.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/NavigationCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/NavigationCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "titleIcon",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/NavigationCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/NavigationCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "compact",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/NavigationCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/NavigationCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "externalLink",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/NavigationCard.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/NavigationCard.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NegativeButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NegativeButton.json
@@ -12,7 +12,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
+          "fileName": "packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
+          "fileName": "packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
+          "fileName": "packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
+          "fileName": "packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
+          "fileName": "packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
+          "fileName": "packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NegativeButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NegativeButton.json
@@ -12,7 +12,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/NegativeButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/NegativeButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/NegativeButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/NegativeButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/NegativeButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/NegativeButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/NegativeButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NotificationBadge.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NotificationBadge.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "showZero",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "max",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "hide",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NotificationBadge.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NotificationBadge.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "showZero",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "max",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "hide",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/NotificationBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/NotificationBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NumberedList.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NumberedList.json
@@ -12,7 +12,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/NumberedList.tsx",
+          "fileName": "packages/typography/src/beta/components/NumberedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/NumberedList.tsx",
+          "fileName": "packages/typography/src/beta/components/NumberedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "type",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/NumberedList.tsx",
+          "fileName": "packages/typography/src/beta/components/NumberedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/NumberedList.tsx",
+          "fileName": "packages/typography/src/beta/components/NumberedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NumberedList.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NumberedList.json
@@ -12,7 +12,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/NumberedList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/NumberedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/NumberedList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/NumberedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "type",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/NumberedList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/NumberedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/NumberedList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/NumberedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenu.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenu.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "buttonIcon",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "button",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "placement",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "position",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenu.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenu.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "buttonIcon",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "button",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "placement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "position",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenuItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenuItem.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onSelect",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "href",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenuItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenuItem.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onSelect",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "href",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenuLink.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenuLink.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,11 +42,11 @@
       "name": "onSelect",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "href",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenuLink.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/OverflowMenuLink.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,11 +42,11 @@
       "name": "onSelect",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "href",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/OverflowMenu.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/OverflowMenu.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Pagination.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Pagination.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "currentPage",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "onPageChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "pageCount",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "previousPageLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "nextPageLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "pageLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "currentPageLabelForScreenreader",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "showInput",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "inputLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -172,7 +172,7 @@
       "name": "numberOfResults",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "resultsPerPage",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -204,7 +204,7 @@
       "name": "resultsPerPageOptions",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -219,7 +219,7 @@
       "name": "onResultsPerPageChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -236,7 +236,7 @@
       "name": "hideNextButton",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -253,7 +253,7 @@
       "name": "hidePrevButton",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -270,7 +270,7 @@
       "name": "showingResultsLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -287,7 +287,7 @@
       "name": "showNumberOfResultsLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
+          "fileName": "packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Pagination.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Pagination.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "currentPage",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "onPageChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "pageCount",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "previousPageLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "nextPageLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "pageLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "currentPageLabelForScreenreader",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "showInput",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "inputLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -172,7 +172,7 @@
       "name": "numberOfResults",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "resultsPerPage",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -204,7 +204,7 @@
       "name": "resultsPerPageOptions",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -219,7 +219,7 @@
       "name": "onResultsPerPageChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -236,7 +236,7 @@
       "name": "hideNextButton",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -253,7 +253,7 @@
       "name": "hidePrevButton",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -270,7 +270,7 @@
       "name": "showingResultsLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -287,7 +287,7 @@
       "name": "showNumberOfResultsLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Pagination.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Pagination.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PaginationInput.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PaginationInput.json
@@ -10,7 +10,7 @@
       "name": "currentPage",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationInput.tsx",
+          "fileName": "packages/menu/src/PaginationInput.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationInput.tsx",
+          "fileName": "packages/menu/src/PaginationInput.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onPageChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationInput.tsx",
+          "fileName": "packages/menu/src/PaginationInput.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "pageCount",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationInput.tsx",
+          "fileName": "packages/menu/src/PaginationInput.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PaginationInput.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PaginationInput.json
@@ -10,7 +10,7 @@
       "name": "currentPage",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationInput.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationInput.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationInput.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationInput.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onPageChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationInput.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationInput.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "pageCount",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationInput.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationInput.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PaginationPage.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PaginationPage.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
+          "fileName": "packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
+          "fileName": "packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "selected",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
+          "fileName": "packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
+          "fileName": "packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
+          "fileName": "packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
+          "fileName": "packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "aria-describedby",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
+          "fileName": "packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PaginationPage.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PaginationPage.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationPage.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationPage.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "selected",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationPage.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationPage.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationPage.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationPage.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "aria-describedby",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/PaginationPage.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/PaginationPage.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Paragraph.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Paragraph.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Paragraph.tsx",
+          "fileName": "packages/typography/src/Paragraph.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Paragraph.tsx",
+          "fileName": "packages/typography/src/Paragraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Paragraph.tsx",
+          "fileName": "packages/typography/src/Paragraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Paragraph.tsx",
+          "fileName": "packages/typography/src/Paragraph.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Paragraph.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Paragraph.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Paragraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Paragraph.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Paragraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Paragraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Paragraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Paragraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/Paragraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/Paragraph.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Popover.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Popover.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Popover.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "placement",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Popover.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "showPopover",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Popover.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "setShowPopover",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Popover.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Popover.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Popover.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
+          "fileName": "packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "placement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
+          "fileName": "packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "showPopover",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
+          "fileName": "packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "setShowPopover",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
+          "fileName": "packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PopoverCloseButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PopoverCloseButton.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Popover.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PopoverCloseButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PopoverCloseButton.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
+          "fileName": "packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PopoverContent.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PopoverContent.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
+          "fileName": "packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
+          "fileName": "packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
+          "fileName": "packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PopoverContent.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PopoverContent.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Popover.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Popover.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Popover.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PopoverTrigger.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PopoverTrigger.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Popover.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PopoverTrigger.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PopoverTrigger.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Popover.tsx",
+          "fileName": "packages/tooltip/src/Popover.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PreformattedText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PreformattedText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/PreformattedText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/PreformattedText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/PreformattedText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/PreformattedText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/PreformattedText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/PreformattedText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PreformattedText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PreformattedText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/PreformattedText.tsx",
+          "fileName": "packages/typography/src/PreformattedText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/PreformattedText.tsx",
+          "fileName": "packages/typography/src/PreformattedText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/PreformattedText.tsx",
+          "fileName": "packages/typography/src/PreformattedText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PrimaryButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PrimaryButton.json
@@ -12,7 +12,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
+          "fileName": "packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
+          "fileName": "packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
+          "fileName": "packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
+          "fileName": "packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
+          "fileName": "packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
+          "fileName": "packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/PrimaryButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/PrimaryButton.json
@@ -12,7 +12,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/PrimaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/PrimaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/PrimaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/PrimaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/PrimaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/PrimaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/PrimaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Radio.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Radio.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Radio.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Radio.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -48,11 +48,11 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Radio.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -69,11 +69,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Radio.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -88,7 +88,7 @@
       "name": "readOnlyLabelDescription",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Radio.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Radio.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Radio.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
+          "fileName": "packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
+          "fileName": "packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -48,11 +48,11 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
+          "fileName": "packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -69,11 +69,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
+          "fileName": "packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -88,7 +88,7 @@
       "name": "readOnlyLabelDescription",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Radio.tsx",
+          "fileName": "packages/form/src/Radio.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/RadioGroup.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/RadioGroup.json
@@ -10,7 +10,7 @@
       "name": "name",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/RadioGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/RadioGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/RadioGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,11 +55,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/RadioGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/RadioGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/RadioGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/RadioGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/RadioGroup.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/RadioGroup.json
@@ -10,7 +10,7 @@
       "name": "name",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
+          "fileName": "packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
+          "fileName": "packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
+          "fileName": "packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,11 +55,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
+          "fileName": "packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
+          "fileName": "packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
+          "fileName": "packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/RadioGroup.tsx",
+          "fileName": "packages/form/src/RadioGroup.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/RadioPanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/RadioPanel.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,11 +44,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -65,11 +65,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,11 +84,11 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -103,11 +103,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -122,11 +122,11 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -141,11 +141,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -160,7 +160,7 @@
       "name": "secondaryLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -177,7 +177,7 @@
       "name": "hideRadioButton",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/RadioPanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/RadioPanel.json
@@ -10,7 +10,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,11 +44,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -65,11 +65,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,11 +84,11 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -103,11 +103,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -122,11 +122,11 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -141,11 +141,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -160,7 +160,7 @@
       "name": "secondaryLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -177,7 +177,7 @@
       "name": "hideRadioButton",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/inputPanel/RadioPanel.tsx",
+          "fileName": "packages/form/src/inputPanel/RadioPanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SearchableDropdown.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SearchableDropdown.json
@@ -10,7 +10,7 @@
       "name": "items",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "selectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "placeholder",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "selectOnTab",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -172,7 +172,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -202,7 +202,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -219,7 +219,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -236,11 +236,11 @@
       "name": "noMatchesText",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -257,7 +257,7 @@
       "name": "labelClearSelectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -272,7 +272,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -289,7 +289,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -304,7 +304,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -319,7 +319,7 @@
       "name": "listStyle",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -334,7 +334,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -351,7 +351,7 @@
       "name": "ariaLabelCloseList",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -368,7 +368,7 @@
       "name": "ariaLabelOpenList",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -385,7 +385,7 @@
       "name": "ariaLabelChosenSingular",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -402,7 +402,7 @@
       "name": "ariaLabelSelectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -419,7 +419,7 @@
       "name": "itemFilter",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -434,7 +434,7 @@
       "name": "debounceTimeout",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -449,7 +449,7 @@
       "name": "onBlur",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -464,7 +464,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -479,7 +479,7 @@
       "name": "onKeyDown",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -494,7 +494,7 @@
       "name": "onFocus",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SearchableDropdown.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SearchableDropdown.json
@@ -10,7 +10,7 @@
       "name": "items",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "selectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "placeholder",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "selectOnTab",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -172,7 +172,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -202,7 +202,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -219,7 +219,7 @@
       "name": "loadingText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -236,11 +236,11 @@
       "name": "noMatchesText",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -257,7 +257,7 @@
       "name": "labelClearSelectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -272,7 +272,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -289,7 +289,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -304,7 +304,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -319,7 +319,7 @@
       "name": "listStyle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -334,7 +334,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -351,7 +351,7 @@
       "name": "ariaLabelCloseList",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -368,7 +368,7 @@
       "name": "ariaLabelOpenList",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -385,7 +385,7 @@
       "name": "ariaLabelChosenSingular",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -402,7 +402,7 @@
       "name": "ariaLabelSelectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/Dropdown.tsx",
+          "fileName": "packages/dropdown/src/Dropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -419,7 +419,7 @@
       "name": "itemFilter",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -434,7 +434,7 @@
       "name": "debounceTimeout",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -449,7 +449,7 @@
       "name": "onBlur",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -464,7 +464,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -479,7 +479,7 @@
       "name": "onKeyDown",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -494,7 +494,7 @@
       "name": "onFocus",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/SearchableDropdown.tsx",
+          "fileName": "packages/dropdown/src/SearchableDropdown.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SecondaryButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SecondaryButton.json
@@ -12,7 +12,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SecondaryButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SecondaryButton.json
@@ -12,7 +12,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
+          "fileName": "packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
+          "fileName": "packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
+          "fileName": "packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
+          "fileName": "packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
+          "fileName": "packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondaryButton.tsx",
+          "fileName": "packages/button/src/SecondaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SecondarySquareButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SecondarySquareButton.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SecondarySquareButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SecondarySquareButton.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SecondarySquareButton.tsx",
+          "fileName": "packages/button/src/SecondarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SegmentedChoice.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SegmentedChoice.json
@@ -10,7 +10,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedChoice.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedChoice.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedChoice.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedChoice.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedChoice.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedChoice.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedChoice.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedChoice.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SegmentedChoice.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SegmentedChoice.json
@@ -10,7 +10,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedChoice.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedChoice.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedChoice.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedChoice.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedChoice.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedChoice.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedChoice.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedChoice.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SegmentedControl.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SegmentedControl.json
@@ -10,7 +10,7 @@
       "name": "name",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "defaultValue",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -102,7 +102,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -117,7 +117,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -132,7 +132,7 @@
       "name": "selectedValue",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SegmentedControl.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SegmentedControl.json
@@ -10,7 +10,7 @@
       "name": "name",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "value",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "defaultValue",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -102,7 +102,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -117,7 +117,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -132,7 +132,7 @@
       "name": "selectedValue",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/segmentedControl/SegmentedControl.tsx",
+          "fileName": "packages/form/src/segmentedControl/SegmentedControl.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SelectedItemTag.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SelectedItemTag.json
@@ -10,7 +10,7 @@
       "name": "ariaLabelRemoveSelected",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "ariaLabelChosen",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "getSelectedItemProps",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "index",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -102,7 +102,7 @@
       "name": "removeSelectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -117,7 +117,7 @@
       "name": "selectedItem",
       "declarations": [
         {
-          "fileName": "design-system/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SelectedItemTag.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SelectedItemTag.json
@@ -10,7 +10,7 @@
       "name": "ariaLabelRemoveSelected",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "ariaLabelChosen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "getSelectedItemProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "index",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -87,7 +87,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -102,7 +102,7 @@
       "name": "removeSelectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -117,7 +117,7 @@
       "name": "selectedItem",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/dropdown/src/components/FieldComponents.tsx",
+          "fileName": "packages/dropdown/src/components/FieldComponents.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigation.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigation.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigation.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigation.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigation.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigation.tsx",
+          "fileName": "packages/menu/src/SideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigation.tsx",
+          "fileName": "packages/menu/src/SideNavigation.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationGroup.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationGroup.json
@@ -12,7 +12,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,11 +72,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "icon",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationGroup.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationGroup.json
@@ -12,7 +12,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "open",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onToggle",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,11 +72,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "icon",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationGroup.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationGroup.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationItem.json
@@ -12,7 +12,7 @@
       "name": "active",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,11 +27,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "forceExpandSubMenus",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "icon",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationItem.json
@@ -12,7 +12,7 @@
       "name": "active",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,11 +27,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "forceExpandSubMenus",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "icon",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/SideNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/SideNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SimpleTimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SimpleTimePicker.json
@@ -10,7 +10,7 @@
       "name": "selectedTime",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "showSeconds",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "showClockIcon",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "padding",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -166,7 +166,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -181,7 +181,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -196,7 +196,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -211,7 +211,7 @@
       "name": "inputRef",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -226,7 +226,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -241,7 +241,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -256,7 +256,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -271,7 +271,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -286,7 +286,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -301,7 +301,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -316,7 +316,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -331,7 +331,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -346,7 +346,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -361,7 +361,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -376,7 +376,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -391,7 +391,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SimpleTimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SimpleTimePicker.json
@@ -10,7 +10,7 @@
       "name": "selectedTime",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "showSeconds",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "showClockIcon",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "padding",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -166,7 +166,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -181,7 +181,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -196,7 +196,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -211,7 +211,7 @@
       "name": "inputRef",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -226,7 +226,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -241,7 +241,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -256,7 +256,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -271,7 +271,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -286,7 +286,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -301,7 +301,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -316,7 +316,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -331,7 +331,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -346,7 +346,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -361,7 +361,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -376,7 +376,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -391,7 +391,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonCircle.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonCircle.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonCircle.tsx",
+          "fileName": "packages/loader/src/SkeletonCircle.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonCircle.tsx",
+          "fileName": "packages/loader/src/SkeletonCircle.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonCircle.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonCircle.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/SkeletonCircle.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonCircle.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/SkeletonCircle.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonCircle.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonRectangle.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonRectangle.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonRectangle.tsx",
+          "fileName": "packages/loader/src/SkeletonRectangle.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonRectangle.tsx",
+          "fileName": "packages/loader/src/SkeletonRectangle.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "height",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonRectangle.tsx",
+          "fileName": "packages/loader/src/SkeletonRectangle.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonRectangle.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonRectangle.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/SkeletonRectangle.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonRectangle.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/SkeletonRectangle.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonRectangle.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "height",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/SkeletonRectangle.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonRectangle.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonWrapper.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonWrapper.json
@@ -12,7 +12,7 @@
       "name": "loadingAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonWrapper.tsx",
+          "fileName": "packages/loader/src/SkeletonWrapper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonWrapper.tsx",
+          "fileName": "packages/loader/src/SkeletonWrapper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,11 +42,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonWrapper.tsx",
+          "fileName": "packages/loader/src/SkeletonWrapper.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonWrapper.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SkeletonWrapper.json
@@ -12,7 +12,7 @@
       "name": "loadingAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/SkeletonWrapper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonWrapper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/SkeletonWrapper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonWrapper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,11 +42,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/SkeletonWrapper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/SkeletonWrapper.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SkipToContent.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SkipToContent.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/a11y/src/SkipToContent.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/a11y/src/SkipToContent.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "mainId",
       "declarations": [
         {
-          "fileName": "design-system/packages/a11y/src/SkipToContent.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/a11y/src/SkipToContent.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SkipToContent.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SkipToContent.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/a11y/src/SkipToContent.tsx",
+          "fileName": "packages/a11y/src/SkipToContent.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "mainId",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/a11y/src/SkipToContent.tsx",
+          "fileName": "packages/a11y/src/SkipToContent.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SmallAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SmallAlertBox.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SmallAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SmallAlertBox.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SmallExpandableAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SmallExpandableAlertBox.json
@@ -10,11 +10,11 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -48,15 +48,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -71,11 +71,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -92,7 +92,7 @@
       "name": "openLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -109,7 +109,7 @@
       "name": "closeLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -124,7 +124,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -141,7 +141,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -156,7 +156,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -171,7 +171,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SmallExpandableAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SmallExpandableAlertBox.json
@@ -10,11 +10,11 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -48,15 +48,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -71,11 +71,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -92,7 +92,7 @@
       "name": "openLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -109,7 +109,7 @@
       "name": "closeLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ExpandableAlertBox.tsx",
+          "fileName": "packages/alert/src/ExpandableAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -124,7 +124,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -141,7 +141,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -156,7 +156,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -171,7 +171,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/SmallAlertBox.tsx",
+          "fileName": "packages/alert/src/SmallAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SmallText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SmallText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SmallText.tsx",
+          "fileName": "packages/typography/src/SmallText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SmallText.tsx",
+          "fileName": "packages/typography/src/SmallText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SmallText.tsx",
+          "fileName": "packages/typography/src/SmallText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SmallText.tsx",
+          "fileName": "packages/typography/src/SmallText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SmallText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SmallText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SmallText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SmallText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SmallText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SmallText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SmallText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SmallText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SmallText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SmallText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Spinner.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Spinner.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/Spinner.tsx",
+          "fileName": "packages/loader/src/Spinner.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Spinner.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Spinner.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/loader/src/Spinner.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/loader/src/Spinner.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SquareButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SquareButton.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
+          "fileName": "packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
+          "fileName": "packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
+          "fileName": "packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
+          "fileName": "packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
+          "fileName": "packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
+          "fileName": "packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,11 +108,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
+          "fileName": "packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -127,7 +127,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SquareButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SquareButton.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,11 +108,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SquareButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -127,7 +127,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/StatusBadge.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/StatusBadge.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "hide",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/StatusBadge.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/StatusBadge.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "hide",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Badge/StatusBadge.tsx",
+          "fileName": "packages/layout/src/Badge/StatusBadge.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Stepper.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Stepper.json
@@ -10,7 +10,7 @@
       "name": "steps",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "activeIndex",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "interactive",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "onStepClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "showStepperIndex",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "ariaLabelStep",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ariaLabelOf",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "ariaLabelCompleted",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "ariaLabelSummary",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/Stepper.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Stepper.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Stepper.json
@@ -10,7 +10,7 @@
       "name": "steps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "activeIndex",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "interactive",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "onStepClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "showStepperIndex",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "ariaLabelStep",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ariaLabelOf",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -140,7 +140,7 @@
       "name": "ariaLabelCompleted",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "ariaLabelSummary",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/Stepper.tsx",
+          "fileName": "packages/menu/src/Stepper.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/StrongText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/StrongText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/StrongText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/StrongText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/StrongText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/StrongText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/StrongText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/StrongText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/StrongText.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/StrongText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/StrongText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/StrongText.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/StrongText.tsx",
+          "fileName": "packages/typography/src/StrongText.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/StrongText.tsx",
+          "fileName": "packages/typography/src/StrongText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/StrongText.tsx",
+          "fileName": "packages/typography/src/StrongText.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/StrongText.tsx",
+          "fileName": "packages/typography/src/StrongText.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SubLabel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SubLabel.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubLabel.tsx",
+          "fileName": "packages/typography/src/SubLabel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubLabel.tsx",
+          "fileName": "packages/typography/src/SubLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubLabel.tsx",
+          "fileName": "packages/typography/src/SubLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubLabel.tsx",
+          "fileName": "packages/typography/src/SubLabel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SubLabel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SubLabel.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SubLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubLabel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SubLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SubLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubLabel.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SubLabel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubLabel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SubParagraph.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SubParagraph.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubParagraph.tsx",
+          "fileName": "packages/typography/src/SubParagraph.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubParagraph.tsx",
+          "fileName": "packages/typography/src/SubParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubParagraph.tsx",
+          "fileName": "packages/typography/src/SubParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubParagraph.tsx",
+          "fileName": "packages/typography/src/SubParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SubParagraph.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SubParagraph.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SubParagraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubParagraph.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SubParagraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SubParagraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "margin",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/SubParagraph.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/SubParagraph.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SuccessButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SuccessButton.json
@@ -12,7 +12,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SuccessButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SuccessButton.json
@@ -12,7 +12,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
+          "fileName": "packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
+          "fileName": "packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
+          "fileName": "packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
+          "fileName": "packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -78,7 +78,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
+          "fileName": "packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -93,7 +93,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessButton.tsx",
+          "fileName": "packages/button/src/SuccessButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -123,7 +123,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SuccessSquareButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SuccessSquareButton.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SuccessSquareButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SuccessSquareButton.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/SuccessSquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/SuccessSquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Switch.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Switch.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -50,7 +50,7 @@
       "name": "labelPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -65,11 +65,11 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,7 +84,7 @@
       "name": "icon",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -101,7 +101,7 @@
       "name": "hideIcon",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -118,11 +118,11 @@
       "name": "color",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -139,7 +139,7 @@
       "name": "contrastColor",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -156,7 +156,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -171,11 +171,11 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
+          "fileName": "packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Switch.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Switch.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],
@@ -50,7 +50,7 @@
       "name": "labelPlacement",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -65,11 +65,11 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -84,7 +84,7 @@
       "name": "icon",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -101,7 +101,7 @@
       "name": "hideIcon",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -118,11 +118,11 @@
       "name": "color",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -139,7 +139,7 @@
       "name": "contrastColor",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -156,7 +156,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -171,11 +171,11 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/Switch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/Switch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Tab.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Tab.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/Tab.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tab.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/Tab.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tab.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/Tab.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tab.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "removeActiveLine",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/Tab.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tab.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Tab.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Tab.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tab.tsx",
+          "fileName": "packages/tab/src/Tab.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tab.tsx",
+          "fileName": "packages/tab/src/Tab.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tab.tsx",
+          "fileName": "packages/tab/src/Tab.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "removeActiveLine",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tab.tsx",
+          "fileName": "packages/tab/src/Tab.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TabList.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TabList.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/TabList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabList.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/TabList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/TabList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabList.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TabList.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TabList.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabList.tsx",
+          "fileName": "packages/tab/src/TabList.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabList.tsx",
+          "fileName": "packages/tab/src/TabList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabList.tsx",
+          "fileName": "packages/tab/src/TabList.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TabPanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TabPanel.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabPanel.tsx",
+          "fileName": "packages/tab/src/TabPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabPanel.tsx",
+          "fileName": "packages/tab/src/TabPanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TabPanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TabPanel.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/TabPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabPanel.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/TabPanel.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabPanel.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TabPanels.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TabPanels.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabPanels.tsx",
+          "fileName": "packages/tab/src/TabPanels.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabPanels.tsx",
+          "fileName": "packages/tab/src/TabPanels.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TabPanels.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TabPanels.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/TabPanels.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabPanels.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/TabPanels.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/TabPanels.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TableBody.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TableBody.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableBody.tsx",
+          "fileName": "packages/table/src/TableBody.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableBody.tsx",
+          "fileName": "packages/table/src/TableBody.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TableBody.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TableBody.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableBody.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableBody.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableBody.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableBody.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TableFooter.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TableFooter.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableFooter.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableFooter.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TableFooter.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TableFooter.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableFooter.tsx",
+          "fileName": "packages/table/src/TableFooter.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TableHead.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TableHead.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableHead.tsx",
+          "fileName": "packages/table/src/TableHead.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableHead.tsx",
+          "fileName": "packages/table/src/TableHead.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TableHead.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TableHead.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableHead.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableHead.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableHead.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableHead.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TableRow.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TableRow.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableRow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "hover",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableRow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "active",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableRow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -65,7 +65,7 @@
       "name": "error",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableRow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,11 +80,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/table/src/TableRow.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TableRow.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TableRow.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
+          "fileName": "packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "hover",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
+          "fileName": "packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "active",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
+          "fileName": "packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -65,7 +65,7 @@
       "name": "error",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
+          "fileName": "packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,11 +80,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/table/src/TableRow.tsx",
+          "fileName": "packages/table/src/TableRow.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Tabs.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Tabs.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
+          "fileName": "packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
+          "fileName": "packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "defaultIndex",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
+          "fileName": "packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "index",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
+          "fileName": "packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
+          "fileName": "packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Tabs.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Tabs.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/Tabs.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/Tabs.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "defaultIndex",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/Tabs.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "index",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/Tabs.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/tab/src/Tabs.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tab/src/Tabs.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Tag.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Tag.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Tag.tsx",
+          "fileName": "packages/layout/src/Tag.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Tag.tsx",
+          "fileName": "packages/layout/src/Tag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "compact",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Tag.tsx",
+          "fileName": "packages/layout/src/Tag.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Tag.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Tag.json
@@ -12,11 +12,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Tag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Tag.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Tag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Tag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -48,7 +48,7 @@
       "name": "compact",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/Tag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/Tag.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TagChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TagChip.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "closeButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/chip/src/TagChip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TagChip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TagChip.json
@@ -10,7 +10,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
+          "fileName": "packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
+          "fileName": "packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
+          "fileName": "packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "closeButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
+          "fileName": "packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -72,7 +72,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/chip/src/TagChip.tsx",
+          "fileName": "packages/chip/src/TagChip.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.Sidebar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.Sidebar.json
@@ -12,7 +12,7 @@
       "name": "contrast",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "collapsed",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onCollapseToggle",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "openSidebarAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "closeSidebarAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,13 +136,13 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
       "required": false,
       "type": {
-        "name": "ElementType<any, keyof IntrinsicElements> | undefined"
+        "name": "ElementType<any> | undefined"
       }
     },
     "ref": {
@@ -151,7 +151,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.Sidebar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.Sidebar.json
@@ -12,7 +12,7 @@
       "name": "contrast",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "collapsed",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "onCollapseToggle",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "openSidebarAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "closeSidebarAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -106,7 +106,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -121,7 +121,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -136,7 +136,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -151,7 +151,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/Sidebar.tsx",
+          "fileName": "packages/layout/src/beta/templates/Sidebar.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/portal/Portal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/portal/Portal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/portal/Portal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,13 +55,13 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
       "required": false,
       "type": {
-        "name": "ElementType<any, keyof IntrinsicElements> | undefined"
+        "name": "ElementType<any> | undefined"
       }
     },
     "ref": {
@@ -70,7 +70,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/portal/Portal.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Template.Portal.json
@@ -10,7 +10,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "fileName": "packages/layout/src/beta/templates/portal/Portal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "fileName": "packages/layout/src/beta/templates/portal/Portal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "fileName": "packages/layout/src/beta/templates/portal/Portal.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/layout/src/beta/templates/portal/Portal.tsx",
+          "fileName": "packages/layout/src/beta/templates/portal/Portal.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TertiaryButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TertiaryButton.json
@@ -14,7 +14,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,7 +80,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiaryButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TertiaryButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TertiaryButton.json
@@ -14,7 +14,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
+          "fileName": "packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -31,7 +31,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
+          "fileName": "packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,7 +46,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
+          "fileName": "packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
+          "fileName": "packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -80,7 +80,7 @@
       "name": "width",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
+          "fileName": "packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiaryButton.tsx",
+          "fileName": "packages/button/src/TertiaryButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -110,7 +110,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TertiarySquareButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TertiarySquareButton.json
@@ -12,7 +12,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,11 +76,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TertiarySquareButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TertiarySquareButton.json
@@ -12,7 +12,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -61,7 +61,7 @@
       "name": "loading",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,11 +76,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/button/src/TertiarySquareButton.tsx",
+          "fileName": "packages/button/src/TertiarySquareButton.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -95,7 +95,7 @@
       "name": "ref",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Text.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Text.json
@@ -10,7 +10,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "weight",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -100,7 +100,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Text.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Text.json
@@ -10,7 +10,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "weight",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/Text.tsx",
+          "fileName": "packages/typography/src/beta/components/Text.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -100,7 +100,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TextArea.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TextArea.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,11 +46,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TextareaHTMLAttributes"
         }
       ],
@@ -67,11 +67,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TextareaHTMLAttributes"
         }
       ],
@@ -86,7 +86,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -101,7 +101,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -116,7 +116,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -131,7 +131,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -163,7 +163,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -180,7 +180,7 @@
       "name": "resize",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextArea.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TextArea.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TextArea.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -46,11 +46,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TextareaHTMLAttributes"
         }
       ],
@@ -67,11 +67,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TextareaHTMLAttributes"
         }
       ],
@@ -86,7 +86,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -101,7 +101,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -116,7 +116,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -131,7 +131,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -146,7 +146,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -163,7 +163,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -180,7 +180,7 @@
       "name": "resize",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/TextArea.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
@@ -10,7 +10,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -119,7 +119,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -134,7 +134,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,11 +151,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -172,11 +172,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -193,7 +193,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -210,7 +210,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -225,7 +225,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -242,7 +242,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -257,7 +257,7 @@
       "name": "onClear",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -274,7 +274,7 @@
       "name": "clearButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -291,7 +291,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/TextField.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
@@ -10,7 +10,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -119,7 +119,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -134,7 +134,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -151,11 +151,11 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -172,11 +172,11 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -193,7 +193,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -210,7 +210,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -225,7 +225,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -242,7 +242,7 @@
       "name": "clearable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -257,7 +257,7 @@
       "name": "onClear",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -274,7 +274,7 @@
       "name": "clearButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -291,7 +291,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/TextField.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
@@ -10,7 +10,7 @@
       "name": "selectedTime",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "minuteIncrementForArrowButtons",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "locale",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "showTimeZone",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "showSeconds",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "leftArrowButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -142,7 +142,7 @@
       "name": "rightArrowButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -172,7 +172,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -202,7 +202,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -217,7 +217,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -232,7 +232,7 @@
       "name": "inputRef",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -249,7 +249,7 @@
       "name": "forcedReturnType",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -264,7 +264,7 @@
       "name": "forcedTimeZone",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -279,7 +279,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -294,7 +294,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -309,7 +309,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -324,7 +324,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -339,7 +339,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -354,7 +354,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -369,7 +369,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -384,7 +384,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -399,7 +399,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -414,7 +414,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -429,7 +429,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -444,7 +444,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -459,7 +459,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -474,7 +474,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
@@ -10,7 +10,7 @@
       "name": "selectedTime",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "minuteIncrementForArrowButtons",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "locale",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "showTimeZone",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "showSeconds",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "leftArrowButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -142,7 +142,7 @@
       "name": "rightArrowButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -157,7 +157,7 @@
       "name": "feedback",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -172,7 +172,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -187,7 +187,7 @@
       "name": "labelTooltip",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -202,7 +202,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -217,7 +217,7 @@
       "name": "readOnly",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -232,7 +232,7 @@
       "name": "inputRef",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -249,7 +249,7 @@
       "name": "forcedReturnType",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -264,7 +264,7 @@
       "name": "forcedTimeZone",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -279,7 +279,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -294,7 +294,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePicker.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePicker.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -309,7 +309,7 @@
       "name": "prepend",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -324,7 +324,7 @@
       "name": "append",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -339,7 +339,7 @@
       "name": "labelTooltipButtonAriaLabel",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -354,7 +354,7 @@
       "name": "labelTooltipPlacement",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -369,7 +369,7 @@
       "name": "required",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -384,7 +384,7 @@
       "name": "labelId",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -399,7 +399,7 @@
       "name": "labelProps",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -414,7 +414,7 @@
       "name": "disableLabelAnimation",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -429,7 +429,7 @@
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -444,7 +444,7 @@
       "name": "after",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -459,7 +459,7 @@
       "name": "before",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -474,7 +474,7 @@
       "name": "ariaLabelOnReadOnly",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/form/dist/BaseFormControl.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TimePickerArrowButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TimePickerArrowButton.json
@@ -10,7 +10,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "readonly",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "onFocus",
       "declarations": [
         {
-          "fileName": "design-system/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TimePickerArrowButton.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TimePickerArrowButton.json
@@ -10,7 +10,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "disabled",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,7 +40,7 @@
       "name": "readonly",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -55,7 +55,7 @@
       "name": "aria-label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -70,7 +70,7 @@
       "name": "onClick",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -85,7 +85,7 @@
       "name": "onFocus",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
+          "fileName": "packages/datepicker/src/TimePicker/TimePickerArrowButton.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ToastAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ToastAlertBox.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ToastAlertBox.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ToastAlertBox.json
@@ -10,11 +10,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "closeButtonLabel",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "closable",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "title",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -104,7 +104,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastAlertBox.tsx",
+          "fileName": "packages/alert/src/ToastAlertBox.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ToastProvider.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ToastProvider.json
@@ -12,7 +12,7 @@
       "name": "delay",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastProvider.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "position",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastProvider.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastProvider.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastProvider.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,11 +74,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/alert/src/ToastProvider.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/ToastProvider.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/ToastProvider.json
@@ -12,7 +12,7 @@
       "name": "delay",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
+          "fileName": "packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "position",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
+          "fileName": "packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
+          "fileName": "packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "style",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
+          "fileName": "packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,11 +74,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/alert/src/ToastProvider.tsx",
+          "fileName": "packages/alert/src/ToastProvider.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Tooltip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Tooltip.json
@@ -10,7 +10,7 @@
       "name": "placement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "content",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "isOpen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onClickCloseButton",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "disableHoverListener",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "disableFocusListener",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -142,7 +142,7 @@
       "name": "disableKeyboardListener",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -159,7 +159,7 @@
       "name": "disableClickListener",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -176,7 +176,7 @@
       "name": "showCloseButton",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -191,7 +191,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -208,7 +208,7 @@
       "name": "hoverDelay",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -223,7 +223,7 @@
       "name": "popperModifiers",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Tooltip.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Tooltip.json
@@ -10,7 +10,7 @@
       "name": "placement",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "content",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -40,11 +40,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "isOpen",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -76,7 +76,7 @@
       "name": "onClickCloseButton",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -91,7 +91,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -108,7 +108,7 @@
       "name": "disableHoverListener",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -125,7 +125,7 @@
       "name": "disableFocusListener",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -142,7 +142,7 @@
       "name": "disableKeyboardListener",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -159,7 +159,7 @@
       "name": "disableClickListener",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -176,7 +176,7 @@
       "name": "showCloseButton",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -191,7 +191,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -208,7 +208,7 @@
       "name": "hoverDelay",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -223,7 +223,7 @@
       "name": "popperModifiers",
       "declarations": [
         {
-          "fileName": "design-system/packages/tooltip/src/Tooltip.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/tooltip/src/Tooltip.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TopNavigationItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TopNavigationItem.json
@@ -12,7 +12,7 @@
       "name": "active",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/TopNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/TopNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/TopNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/TopNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,11 +44,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/TopNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/TopNavigationItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/menu/src/TopNavigationItem.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/TopNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TopNavigationItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TopNavigationItem.json
@@ -12,7 +12,7 @@
       "name": "active",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/TopNavigationItem.tsx",
+          "fileName": "packages/menu/src/TopNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/TopNavigationItem.tsx",
+          "fileName": "packages/menu/src/TopNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,11 +44,11 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/TopNavigationItem.tsx",
+          "fileName": "packages/menu/src/TopNavigationItem.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -63,7 +63,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/menu/src/TopNavigationItem.tsx",
+          "fileName": "packages/menu/src/TopNavigationItem.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TravelHeader.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TravelHeader.json
@@ -12,7 +12,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelHeader.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "from",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelHeader.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "to",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelHeader.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelHeader.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "noWrap",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelHeader.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelHeader.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TravelHeader.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TravelHeader.json
@@ -12,7 +12,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
+          "fileName": "packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "from",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
+          "fileName": "packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "to",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
+          "fileName": "packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -59,7 +59,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
+          "fileName": "packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -74,7 +74,7 @@
       "name": "noWrap",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
+          "fileName": "packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -89,7 +89,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelHeader.tsx",
+          "fileName": "packages/travel/src/TravelHeader.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TravelLeg.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TravelLeg.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelLeg.tsx",
+          "fileName": "packages/travel/src/TravelLeg.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "transport",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelLeg.tsx",
+          "fileName": "packages/travel/src/TravelLeg.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelLeg.tsx",
+          "fileName": "packages/travel/src/TravelLeg.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TravelLeg.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TravelLeg.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelLeg.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelLeg.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,7 +29,7 @@
       "name": "transport",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelLeg.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelLeg.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -44,7 +44,7 @@
       "name": "direction",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelLeg.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelLeg.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TravelSwitch.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TravelSwitch.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -48,15 +48,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -73,7 +73,7 @@
       "name": "labelPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -88,7 +88,7 @@
       "name": "transport",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -103,11 +103,11 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -124,7 +124,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TravelSwitch.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TravelSwitch.json
@@ -10,11 +10,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -29,11 +29,11 @@
       "name": "checked",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -48,15 +48,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -73,7 +73,7 @@
       "name": "labelPlacement",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -88,7 +88,7 @@
       "name": "transport",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -103,11 +103,11 @@
       "name": "onChange",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "InputHTMLAttributes"
         }
       ],
@@ -124,7 +124,7 @@
       "name": "size",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelSwitch.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelSwitch.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TravelTag.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TravelTag.json
@@ -12,7 +12,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelTag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,15 +27,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelTag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -50,11 +50,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelTag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -71,13 +71,30 @@
       "name": "alert",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelTag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
       "required": false,
       "type": {
         "name": "\"none\" | \"error\" | \"warning\" | \"info\" | undefined"
+      }
+    },
+    "type": {
+      "defaultValue": {
+        "value": "publicCode"
+      },
+      "description": "Duration brukes når man viser tid dette \"transportmiddelet\" bruker, anbefales hovedsaklig til gange og delingsmobilitet. publicCode brukes for å vise ID-en til linjen.",
+      "name": "type",
+      "declarations": [
+        {
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "\"publicCode\" | \"duration\" | undefined"
       }
     },
     "transport": {
@@ -88,7 +105,7 @@
       "name": "transport",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelTag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -103,7 +120,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelTag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -120,7 +137,7 @@
       "name": "labelPlacement",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelTag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -135,7 +152,7 @@
       "name": "details",
       "declarations": [
         {
-          "fileName": "design-system/packages/travel/src/TravelTag.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TravelTag.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TravelTag.json
@@ -12,7 +12,7 @@
       "name": "onClose",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "fileName": "packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,15 +27,15 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "fileName": "packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "DOMAttributes"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],
@@ -50,11 +50,11 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "fileName": "packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "HTMLAttributes"
         }
       ],
@@ -71,7 +71,7 @@
       "name": "alert",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "fileName": "packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -88,7 +88,7 @@
       "name": "type",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "fileName": "packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -105,7 +105,7 @@
       "name": "transport",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "fileName": "packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -120,7 +120,7 @@
       "name": "label",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "fileName": "packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -137,7 +137,7 @@
       "name": "labelPlacement",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "fileName": "packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -152,7 +152,7 @@
       "name": "details",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/travel/src/TravelTag.tsx",
+          "fileName": "packages/travel/src/TravelTag.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/UnorderedList.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/UnorderedList.json
@@ -12,7 +12,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/UnorderedList.tsx",
+          "fileName": "packages/typography/src/beta/components/UnorderedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/UnorderedList.tsx",
+          "fileName": "packages/typography/src/beta/components/UnorderedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/UnorderedList.tsx",
+          "fileName": "packages/typography/src/beta/components/UnorderedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/UnorderedList.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/UnorderedList.json
@@ -12,7 +12,7 @@
       "name": "className",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/UnorderedList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/UnorderedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,7 +27,7 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/UnorderedList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/UnorderedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -42,7 +42,7 @@
       "name": "spacing",
       "declarations": [
         {
-          "fileName": "design-system/packages/typography/src/beta/components/UnorderedList.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/typography/src/beta/components/UnorderedList.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -57,7 +57,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/VariantProvider.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/VariantProvider.json
@@ -12,7 +12,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "design-system/packages/form/src/VariantProvider.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/VariantProvider.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/VariantProvider.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/VariantProvider.json
@@ -12,7 +12,7 @@
       "name": "variant",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/form/src/VariantProvider.tsx",
+          "fileName": "packages/form/src/VariantProvider.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/VisuallyHidden.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/VisuallyHidden.json
@@ -12,7 +12,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "design-system/packages/a11y/src/VisuallyHidden.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/a11y/src/VisuallyHidden.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,11 +27,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "design-system/packages/a11y/src/VisuallyHidden.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/a11y/src/VisuallyHidden.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "design-system/node_modules/@types/react/index.d.ts",
+          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/VisuallyHidden.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/VisuallyHidden.json
@@ -12,7 +12,7 @@
       "name": "as",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/a11y/src/VisuallyHidden.tsx",
+          "fileName": "packages/a11y/src/VisuallyHidden.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -27,11 +27,11 @@
       "name": "children",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/a11y/src/VisuallyHidden.tsx",
+          "fileName": "packages/a11y/src/VisuallyHidden.tsx",
           "name": "TypeLiteral"
         },
         {
-          "fileName": "apps/documentation/fix-cache-corruption/node_modules/@types/react/index.d.ts",
+          "fileName": "node_modules/@types/react/index.d.ts",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
@@ -11,9 +11,17 @@
     "hash": "568200ef48798123d661fbe5e939a7d1",
     "outputs": ["BannerAlertBox.json"]
   },
+  "alert/src/BaseAlertBox.tsx": {
+    "hash": "450f532f63a7765c1b9efbcc435dee50",
+    "outputs": ["BaseAlertBox.json"]
+  },
   "alert/src/CopyableText.tsx": {
     "hash": "340e0f61e1daa7e658483a15025adba4",
     "outputs": ["CopyableText.json"]
+  },
+  "alert/src/ExpandableAlertBox.tsx": {
+    "hash": "c6d0b416ca7307e8919ab05e38590e34",
+    "outputs": ["SmallExpandableAlertBox.json", "BannerExpandableAlertBox.json"]
   },
   "alert/src/SmallAlertBox.tsx": {
     "hash": "1f07d25a294fab18bc6520da413e584b",
@@ -55,9 +63,21 @@
     "hash": "3ab5b2ddea795af3c547b0af0897ba2b",
     "outputs": ["SecondaryButton.json"]
   },
+  "button/src/SecondarySquareButton.tsx": {
+    "hash": "e5ccbef87d80b21f93823808cbfb8bdd",
+    "outputs": ["SecondarySquareButton.json"]
+  },
+  "button/src/SquareButton.tsx": {
+    "hash": "2ddc8792cb1d6ea4ee8a86d8aca66940",
+    "outputs": ["SquareButton.json"]
+  },
   "button/src/SuccessButton.tsx": {
     "hash": "9f1d8c8a06a4d1716300cec68a9453c3",
     "outputs": ["SuccessButton.json"]
+  },
+  "button/src/SuccessSquareButton.tsx": {
+    "hash": "9b22d12b4ff4ce0640cd7536b91a7332",
+    "outputs": ["SuccessSquareButton.json"]
   },
   "button/src/TertiaryButton.tsx": {
     "hash": "fae7ce69572a03ec8c0e3210089b3f91",
@@ -67,6 +87,14 @@
     "hash": "fd48e0e8f256ba0b9946bbde05e401ab",
     "outputs": ["TertiarySquareButton.json"]
   },
+  "chip/src/ActionChip.tsx": {
+    "hash": "93455a4d3eab80dfded653dd1f982106",
+    "outputs": ["ActionChip.json"]
+  },
+  "chip/src/ChoiceChip.tsx": {
+    "hash": "206205314648c624331d8518bb06e53f",
+    "outputs": ["ChoiceChip.json"]
+  },
   "chip/src/ChoiceChipGroup.tsx": {
     "hash": "af901a8b474db060c03d9e9ef74402f6",
     "outputs": ["ChoiceChipGroup.json"]
@@ -75,9 +103,89 @@
     "hash": "0aa0fe499beea46704fb4a8c500646d4",
     "outputs": ["ChoiceChipGroupContextProvider.json"]
   },
+  "chip/src/FilterChip.tsx": {
+    "hash": "b3c9c001a11c167a405fe21402255739",
+    "outputs": ["FilterChip.json"]
+  },
+  "chip/src/TagChip.tsx": {
+    "hash": "f264870b6b27587f8063bb4bc2374640",
+    "outputs": ["TagChip.json"]
+  },
+  "datepicker/src/DatePicker/Calendar.tsx": {
+    "hash": "67dbb6c3afb0ef6325ef55484b96b917",
+    "outputs": ["Calendar.json"]
+  },
+  "datepicker/src/DatePicker/CalendarCell.tsx": {
+    "hash": "507404d4061fba31dd6d6c5e253c63ea",
+    "outputs": ["CalendarCell.json"]
+  },
+  "datepicker/src/DatePicker/CalendarGrid.tsx": {
+    "hash": "a819ae2f8329740ede2c2e09b51f623b",
+    "outputs": ["CalendarGrid.json"]
+  },
+  "datepicker/src/DatePicker/DateField.tsx": {
+    "hash": "51599ea5fff3e6268dd444469eb865e6",
+    "outputs": ["DateField.json"]
+  },
+  "datepicker/src/DatePicker/DatePicker.tsx": {
+    "hash": "6c2dec68f8edc170674b1d376b54c0c9",
+    "outputs": ["DatePicker.json"]
+  },
+  "datepicker/src/DatePicker/NativeDatePicker.tsx": {
+    "hash": "d0785acd4e051d7681983f6a951f7999",
+    "outputs": ["NativeDatePicker.json"]
+  },
+  "datepicker/src/TimePicker/NativeTimePicker.tsx": {
+    "hash": "f803448062012b0d4bee790d06abaff3",
+    "outputs": ["NativeTimePicker.json"]
+  },
+  "datepicker/src/TimePicker/SimpleTimePicker.tsx": {
+    "hash": "0edee77520d8663af9102beeb2aa3cd3",
+    "outputs": ["SimpleTimePicker.json"]
+  },
+  "datepicker/src/TimePicker/TimePicker.tsx": {
+    "hash": "f646e51c08497012f34196594ad1bb36",
+    "outputs": ["TimePicker.json"]
+  },
+  "datepicker/src/TimePicker/TimePickerArrowButton.tsx": {
+    "hash": "274b000c22e7771df05ea213c2da88f7",
+    "outputs": ["TimePickerArrowButton.json"]
+  },
   "datepicker/src/shared/CalendarButton.tsx": {
     "hash": "44d79e9276733e20b73cc5bd7a58e01f",
     "outputs": ["CalendarButton.json"]
+  },
+  "datepicker/src/shared/FieldSegment.tsx": {
+    "hash": "2aa8065fbfdd56135a0a84c0b07b2e93",
+    "outputs": ["FieldSegment.json"]
+  },
+  "dropdown/src/Dropdown.tsx": {
+    "hash": "2385c97e21037664a9efa973cf74a5a7",
+    "outputs": ["Dropdown.json"]
+  },
+  "dropdown/src/MultiSelect.tsx": {
+    "hash": "2b5dc57f4a3948ed0413927aaebb868c",
+    "outputs": ["MultiSelect.json"]
+  },
+  "dropdown/src/NativeDropdown.tsx": {
+    "hash": "681fb30500efad9bd513ca66ea284038",
+    "outputs": ["NativeDropdown.json"]
+  },
+  "dropdown/src/SearchableDropdown.tsx": {
+    "hash": "56128d532a96a014e9bededbb0d45d69",
+    "outputs": ["SearchableDropdown.json"]
+  },
+  "dropdown/src/components/DropdownList.tsx": {
+    "hash": "dd365c2f20ab387844116a185704f9d0",
+    "outputs": ["DropdownList.json"]
+  },
+  "dropdown/src/components/FieldComponents.tsx": {
+    "hash": "cfc28bec9370ead02a31f77fd37100e0",
+    "outputs": [
+      "SelectedItemTag.json",
+      "DropdownFieldAppendix.json",
+      "ClearableButton.json"
+    ]
   },
   "expand/src/Accordion.tsx": {
     "hash": "158e62e55eeefe964462deae0abdad7e",
@@ -86,6 +194,10 @@
   "expand/src/AccordionItem.tsx": {
     "hash": "e576d14de4678d01c7de61f8b2e8e594",
     "outputs": ["AccordionItem.json"]
+  },
+  "expand/src/BaseExpand.tsx": {
+    "hash": "558da91dec198221e27daa306aa7783c",
+    "outputs": ["BaseExpand.json"]
   },
   "expand/src/BaseExpandablePanel.tsx": {
     "hash": "33d642da7d90681abed4ce9d53504b38",
@@ -107,17 +219,81 @@
     "hash": "b12b8fcddc89d66ffb6f0f3e40998d28",
     "outputs": ["ExpandableTextButton.json"]
   },
+  "fileupload/src/FileUpload.tsx": {
+    "hash": "8653ec4a3a8bb0a59fae41dbce8d4ea2",
+    "outputs": ["FileUpload.json"]
+  },
+  "form/src/BaseFormControl.tsx": {
+    "hash": "0f951ac0829ab91bfe452d5a80b4eec0",
+    "outputs": ["BaseFormControl.json"]
+  },
+  "form/src/Checkbox.tsx": {
+    "hash": "ed6ed2b525764d271148dd3f2cea5fce",
+    "outputs": ["Checkbox.json"]
+  },
+  "form/src/FeedbackText.tsx": {
+    "hash": "fc7e3c2f3a0edd6e5a2e7ab6cb62b92a",
+    "outputs": ["FeedbackText.json"]
+  },
   "form/src/Fieldset.tsx": {
     "hash": "acb7fb78477efec86f150ba6549f92ba",
     "outputs": ["Fieldset.json"]
+  },
+  "form/src/InputGroupContext.tsx": {
+    "hash": "e65c8f7b00c1b6042a1d0a694a3675c0",
+    "outputs": ["InputGroupContextProvider.json"]
+  },
+  "form/src/InputGroupLabel.tsx": {
+    "hash": "987d16fcc06f49a5f09ef9058fe5b52a",
+    "outputs": ["InputGroupLabel.json"]
+  },
+  "form/src/Radio.tsx": {
+    "hash": "c51389fe61d6207532cd244effab8a13",
+    "outputs": ["Radio.json"]
+  },
+  "form/src/RadioGroup.tsx": {
+    "hash": "b62326c6a07cf4c97a75acb298fe79ec",
+    "outputs": ["RadioGroup.json"]
+  },
+  "form/src/RadioGroupContext.tsx": {
+    "hash": "93329379d41aa9905be27dca131c4bd3",
+    "outputs": ["RadioGroupContextProvider.json"]
   },
   "form/src/Switch.tsx": {
     "hash": "716d0864ffda4d33121d22ec5cb209f0",
     "outputs": ["Switch.json"]
   },
+  "form/src/TextArea.tsx": {
+    "hash": "226f4e5cf93059fcdf96bf3e39cb3796",
+    "outputs": ["TextArea.json"]
+  },
+  "form/src/TextField.tsx": {
+    "hash": "dc0131d97dc9df4aab23610f1d3cc3e4",
+    "outputs": ["TextField.json"]
+  },
   "form/src/VariantProvider.tsx": {
     "hash": "a2bd1ce018b31f8f368f0f6d51afaa7c",
     "outputs": ["VariantProvider.json"]
+  },
+  "form/src/inputPanel/CheckboxPanel.tsx": {
+    "hash": "dddaddecae7c0c790cbf3abfa798d2ca",
+    "outputs": ["CheckboxPanel.json"]
+  },
+  "form/src/inputPanel/InputPanelBase.tsx": {
+    "hash": "4be67febbbed714cac03fa4d06b4b676",
+    "outputs": ["InputPanelBase.json"]
+  },
+  "form/src/inputPanel/RadioPanel.tsx": {
+    "hash": "3b75107e00686ec084f7af3b3ab101fb",
+    "outputs": ["RadioPanel.json"]
+  },
+  "form/src/segmentedControl/SegmentedChoice.tsx": {
+    "hash": "73020f5c733d65db4d72156884b67eef",
+    "outputs": ["SegmentedChoice.json"]
+  },
+  "form/src/segmentedControl/SegmentedControl.tsx": {
+    "hash": "08b40d83ac972c0f3476a3c3bd8d9b68",
+    "outputs": ["SegmentedControl.json"]
   },
   "grid/src/BaseGrid.tsx": {
     "hash": "f3956095517b644e2c75d8addee06964",
@@ -155,13 +331,45 @@
     "hash": "8bed9c5452e0f2337275ba1c042becb2",
     "outputs": ["Contrast.json"]
   },
+  "layout/src/MediaCard.tsx": {
+    "hash": "9d8ef8b8d9a5bba061eae3e873e82184",
+    "outputs": ["MediaCard.json"]
+  },
+  "layout/src/NavigationCard.tsx": {
+    "hash": "0e466e41037e7a2a93ed48d40ee97940",
+    "outputs": ["NavigationCard.json"]
+  },
   "layout/src/Tag.tsx": {
     "hash": "f7c5889d8c07e4d67efee217a298c58d",
     "outputs": ["Tag.json"]
   },
+  "layout/src/beta/Flex/Flex.tsx": {
+    "hash": "bdfb861644430c32909cfaaa584448e9",
+    "outputs": ["Flex.json"]
+  },
+  "layout/src/beta/Flex/FlexSpacer.tsx": {
+    "hash": "77102cdf186ed6260e916519d52b97c3",
+    "outputs": ["FlexSpacer.json"]
+  },
+  "layout/src/beta/Grid/Grid.tsx": {
+    "hash": "15cd3fd6b6899c9fe663cbae18ad6bbb",
+    "outputs": ["Grid.json"]
+  },
   "layout/src/beta/Grid/GridItem.tsx": {
     "hash": "7c591c0f95ea02133ac01ba4aa694d7e",
     "outputs": ["GridItem.json"]
+  },
+  "layout/src/beta/LayoutProvider/LayoutProvider.tsx": {
+    "hash": "693792318fe331399c1e6c0ee284e49d",
+    "outputs": ["LayoutProvider.json"]
+  },
+  "layout/src/beta/templates/Sidebar.tsx": {
+    "hash": "a48618c6f67b1f34ecb7a761cb4b73f8",
+    "outputs": ["Template.Portal.Sidebar.json"]
+  },
+  "layout/src/beta/templates/portal/Portal.tsx": {
+    "hash": "0766d160ad5ffe749292ed4d8aa543e2",
+    "outputs": ["Template.Portal.json"]
   },
   "loader/src/BaseSkeleton.tsx": {
     "hash": "3c6155f55ea168bf381cd28d3883cc39",
@@ -191,6 +399,30 @@
     "hash": "bf25cdf72fb2425de91922feba13655c",
     "outputs": ["Spinner.json"]
   },
+  "menu/src/BreadcrumbItem.tsx": {
+    "hash": "a0ab55ce274859eb95c42671bc25075a",
+    "outputs": ["BreadcrumbItem.json"]
+  },
+  "menu/src/BreadcrumbNavigation.tsx": {
+    "hash": "270d4769f111e693310795886a14e441",
+    "outputs": ["BreadcrumbNavigation.json"]
+  },
+  "menu/src/CollapsibleSideNavigation.tsx": {
+    "hash": "a0310bbe283135e6438fbfdc44d672c8",
+    "outputs": ["CollapsibleSideNavigation.json"]
+  },
+  "menu/src/OverflowMenu.tsx": {
+    "hash": "72489aa68523320adcee54227e27b98a",
+    "outputs": [
+      "OverflowMenu.json",
+      "OverflowMenuItem.json",
+      "OverflowMenuLink.json"
+    ]
+  },
+  "menu/src/Pagination.tsx": {
+    "hash": "664da875354c5b61b2384bc72510770c",
+    "outputs": ["Pagination.json"]
+  },
   "menu/src/PaginationInput.tsx": {
     "hash": "ca8cc10f77c340f8a402d403187d799e",
     "outputs": ["PaginationInput.json"]
@@ -202,6 +434,10 @@
   "menu/src/SideNavigation.tsx": {
     "hash": "26189eb1c9a8e733dff85356266bf4fb",
     "outputs": ["SideNavigation.json", "SideNavigation.___IS_ENTUR_MENU__.json"]
+  },
+  "menu/src/SideNavigationGroup.tsx": {
+    "hash": "40f516f53183dea636985b20486e7faf",
+    "outputs": ["SideNavigationGroup.json"]
   },
   "menu/src/SideNavigationItem.tsx": {
     "hash": "280526cfea86790ec7a2b83e32131ac3",
@@ -215,9 +451,17 @@
     "hash": "cc015eb43fe5aea084269f1a68e5af50",
     "outputs": ["TopNavigationItem.json"]
   },
+  "modal/src/Drawer.tsx": {
+    "hash": "2079d01bd9e2f1597b802e622fe9db6e",
+    "outputs": ["Drawer.json"]
+  },
   "modal/src/Modal.tsx": {
     "hash": "57c754b46c5f9a12d607255f797cbf1c",
     "outputs": ["Modal.json"]
+  },
+  "modal/src/ModalContent.tsx": {
+    "hash": "34819de8932762d65acfd41dc1424d46",
+    "outputs": ["ModalContent.json"]
   },
   "modal/src/ModalOverlay.tsx": {
     "hash": "0f4f3270bce7d8f1583843f8123d3277",
@@ -259,6 +503,14 @@
     "hash": "2b13b6e3da7132f1cf19da979bfb7eee",
     "outputs": ["ExpandableRow.json"]
   },
+  "table/src/HeaderCell.tsx": {
+    "hash": "06547391e7b5f80f5132c2057b6e2802",
+    "outputs": ["HeaderCell.json"]
+  },
+  "table/src/Table.tsx": {
+    "hash": "59ea7b9c3ce8724580d238e23f8e9ea0",
+    "outputs": ["Table.json"]
+  },
   "table/src/TableBody.tsx": {
     "hash": "309156719ff36f596dbb500221bea9f2",
     "outputs": ["TableBody.json"]
@@ -274,6 +526,19 @@
   "table/src/TableRow.tsx": {
     "hash": "6c4beb0c5287f16d8406ca9fbe4e5b47",
     "outputs": ["TableRow.json"]
+  },
+  "tooltip/src/Popover.tsx": {
+    "hash": "7c52fab353ef2bb78efc9316fdfb2ef8",
+    "outputs": [
+      "Popover.json",
+      "PopoverTrigger.json",
+      "PopoverCloseButton.json",
+      "PopoverContent.json"
+    ]
+  },
+  "tooltip/src/Tooltip.tsx": {
+    "hash": "26844b3d1439cd8016a242020aaf69f5",
+    "outputs": ["Tooltip.json"]
   },
   "travel/src/LegBone.tsx": {
     "hash": "8188f6f2aa80eb9d73a4061dc190da29",
@@ -294,6 +559,10 @@
   "travel/src/TravelSwitch.tsx": {
     "hash": "0f249315a35dd58d8b3fdf7c69446e3f",
     "outputs": ["TravelSwitch.json"]
+  },
+  "travel/src/TravelTag.tsx": {
+    "hash": "0c92b460e68f4715ae195f3728d00fdf",
+    "outputs": ["TravelTag.json"]
   },
   "typography/src/BaseHeading.tsx": {
     "hash": "d5eeb474d1ecc1b3877f75abf1922779",
@@ -387,6 +656,10 @@
     "hash": "66d2bc869d35ca6da0886b0734a070f7",
     "outputs": ["Blockquote.json", "BlockquoteFooter.json"]
   },
+  "typography/src/beta/components/Heading.tsx": {
+    "hash": "06b826fa8f28422ef2fb09b8ff95321f",
+    "outputs": ["Heading.json"]
+  },
   "typography/src/beta/components/Link.tsx": {
     "hash": "1ab60ad3b54b9dd613482373359d2aee",
     "outputs": ["Link.json"]
@@ -399,6 +672,10 @@
     "hash": "5638999c64e29c19345adcf626f93d1f",
     "outputs": ["NumberedList.json"]
   },
+  "typography/src/beta/components/Text.tsx": {
+    "hash": "11e1fd38c76eb4a44bb79bf37fe74a13",
+    "outputs": ["Text.json"]
+  },
   "typography/src/beta/components/UnorderedList.tsx": {
     "hash": "4a969c3d22190d08d5c4ce8024024c48",
     "outputs": ["UnorderedList.json"]
@@ -407,289 +684,8 @@
     "hash": "48091c1589dfed5003c679099b1ac91d",
     "outputs": ["ConditionalWrapper.json"]
   },
-  "alert/src/BaseAlertBox.tsx": {
-    "hash": "450f532f63a7765c1b9efbcc435dee50",
-    "outputs": ["BaseAlertBox.json"]
-  },
-  "alert/src/ExpandableAlertBox.tsx": {
-    "hash": "c6d0b416ca7307e8919ab05e38590e34",
-    "outputs": ["SmallExpandableAlertBox.json", "BannerExpandableAlertBox.json"]
-  },
-  "button/src/SecondarySquareButton.tsx": {
-    "hash": "e5ccbef87d80b21f93823808cbfb8bdd",
-    "outputs": ["SecondarySquareButton.json"]
-  },
-  "button/src/SquareButton.tsx": {
-    "hash": "2ddc8792cb1d6ea4ee8a86d8aca66940",
-    "outputs": ["SquareButton.json"]
-  },
-  "button/src/SuccessSquareButton.tsx": {
-    "hash": "9b22d12b4ff4ce0640cd7536b91a7332",
-    "outputs": ["SuccessSquareButton.json"]
-  },
-  "chip/src/ActionChip.tsx": {
-    "hash": "93455a4d3eab80dfded653dd1f982106",
-    "outputs": ["ActionChip.json"]
-  },
-  "chip/src/ChoiceChip.tsx": {
-    "hash": "206205314648c624331d8518bb06e53f",
-    "outputs": ["ChoiceChip.json"]
-  },
-  "chip/src/FilterChip.tsx": {
-    "hash": "b3c9c001a11c167a405fe21402255739",
-    "outputs": ["FilterChip.json"]
-  },
-  "chip/src/TagChip.tsx": {
-    "hash": "f264870b6b27587f8063bb4bc2374640",
-    "outputs": ["TagChip.json"]
-  },
-  "datepicker/src/DatePicker/Calendar.tsx": {
-    "hash": "67dbb6c3afb0ef6325ef55484b96b917",
-    "outputs": ["Calendar.json"]
-  },
-  "datepicker/src/DatePicker/CalendarCell.tsx": {
-    "hash": "507404d4061fba31dd6d6c5e253c63ea",
-    "outputs": ["CalendarCell.json"]
-  },
-  "datepicker/src/DatePicker/CalendarGrid.tsx": {
-    "hash": "a819ae2f8329740ede2c2e09b51f623b",
-    "outputs": ["CalendarGrid.json"]
-  },
-  "datepicker/src/DatePicker/DateField.tsx": {
-    "hash": "51599ea5fff3e6268dd444469eb865e6",
-    "outputs": ["DateField.json"]
-  },
-  "datepicker/src/DatePicker/DatePicker.tsx": {
-    "hash": "6c2dec68f8edc170674b1d376b54c0c9",
-    "outputs": ["DatePicker.json"]
-  },
-  "datepicker/src/DatePicker/NativeDatePicker.tsx": {
-    "hash": "d0785acd4e051d7681983f6a951f7999",
-    "outputs": ["NativeDatePicker.json"]
-  },
-  "datepicker/src/TimePicker/NativeTimePicker.tsx": {
-    "hash": "f803448062012b0d4bee790d06abaff3",
-    "outputs": ["NativeTimePicker.json"]
-  },
-  "datepicker/src/TimePicker/SimpleTimePicker.tsx": {
-    "hash": "0edee77520d8663af9102beeb2aa3cd3",
-    "outputs": ["SimpleTimePicker.json"]
-  },
-  "datepicker/src/TimePicker/TimePicker.tsx": {
-    "hash": "f646e51c08497012f34196594ad1bb36",
-    "outputs": ["TimePicker.json"]
-  },
-  "datepicker/src/TimePicker/TimePickerArrowButton.tsx": {
-    "hash": "274b000c22e7771df05ea213c2da88f7",
-    "outputs": ["TimePickerArrowButton.json"]
-  },
-  "datepicker/src/shared/FieldSegment.tsx": {
-    "hash": "2aa8065fbfdd56135a0a84c0b07b2e93",
-    "outputs": ["FieldSegment.json"]
-  },
-  "dropdown/src/Dropdown.tsx": {
-    "hash": "2385c97e21037664a9efa973cf74a5a7",
-    "outputs": ["Dropdown.json"]
-  },
-  "dropdown/src/MultiSelect.tsx": {
-    "hash": "2b5dc57f4a3948ed0413927aaebb868c",
-    "outputs": ["MultiSelect.json"]
-  },
-  "dropdown/src/NativeDropdown.tsx": {
-    "hash": "681fb30500efad9bd513ca66ea284038",
-    "outputs": ["NativeDropdown.json"]
-  },
-  "dropdown/src/SearchableDropdown.tsx": {
-    "hash": "56128d532a96a014e9bededbb0d45d69",
-    "outputs": ["SearchableDropdown.json"]
-  },
-  "dropdown/src/components/DropdownList.tsx": {
-    "hash": "dd365c2f20ab387844116a185704f9d0",
-    "outputs": ["DropdownList.json"]
-  },
-  "dropdown/src/components/FieldComponents.tsx": {
-    "hash": "cfc28bec9370ead02a31f77fd37100e0",
-    "outputs": [
-      "SelectedItemTag.json",
-      "DropdownFieldAppendix.json",
-      "ClearableButton.json"
-    ]
-  },
-  "expand/src/BaseExpand.tsx": {
-    "hash": "558da91dec198221e27daa306aa7783c",
-    "outputs": ["BaseExpand.json"]
-  },
-  "fileupload/src/FileUpload.tsx": {
-    "hash": "8653ec4a3a8bb0a59fae41dbce8d4ea2",
-    "outputs": ["FileUpload.json"]
-  },
-  "form/src/BaseFormControl.tsx": {
-    "hash": "0f951ac0829ab91bfe452d5a80b4eec0",
-    "outputs": ["BaseFormControl.json"]
-  },
-  "form/src/Checkbox.tsx": {
-    "hash": "ed6ed2b525764d271148dd3f2cea5fce",
-    "outputs": ["Checkbox.json"]
-  },
-  "form/src/FeedbackText.tsx": {
-    "hash": "fc7e3c2f3a0edd6e5a2e7ab6cb62b92a",
-    "outputs": ["FeedbackText.json"]
-  },
-  "form/src/InputGroupContext.tsx": {
-    "hash": "e65c8f7b00c1b6042a1d0a694a3675c0",
-    "outputs": ["InputGroupContextProvider.json"]
-  },
-  "form/src/InputGroupLabel.tsx": {
-    "hash": "987d16fcc06f49a5f09ef9058fe5b52a",
-    "outputs": ["InputGroupLabel.json"]
-  },
-  "form/src/Radio.tsx": {
-    "hash": "c51389fe61d6207532cd244effab8a13",
-    "outputs": ["Radio.json"]
-  },
-  "form/src/RadioGroup.tsx": {
-    "hash": "b62326c6a07cf4c97a75acb298fe79ec",
-    "outputs": ["RadioGroup.json"]
-  },
-  "form/src/RadioGroupContext.tsx": {
-    "hash": "93329379d41aa9905be27dca131c4bd3",
-    "outputs": ["RadioGroupContextProvider.json"]
-  },
-  "form/src/TextArea.tsx": {
-    "hash": "226f4e5cf93059fcdf96bf3e39cb3796",
-    "outputs": ["TextArea.json"]
-  },
-  "form/src/TextField.tsx": {
-    "hash": "dc0131d97dc9df4aab23610f1d3cc3e4",
-    "outputs": ["TextField.json"]
-  },
-  "form/src/inputPanel/CheckboxPanel.tsx": {
-    "hash": "dddaddecae7c0c790cbf3abfa798d2ca",
-    "outputs": ["CheckboxPanel.json"]
-  },
-  "form/src/inputPanel/InputPanelBase.tsx": {
-    "hash": "4be67febbbed714cac03fa4d06b4b676",
-    "outputs": ["InputPanelBase.json"]
-  },
-  "form/src/inputPanel/RadioPanel.tsx": {
-    "hash": "3b75107e00686ec084f7af3b3ab101fb",
-    "outputs": ["RadioPanel.json"]
-  },
-  "form/src/segmentedControl/SegmentedChoice.tsx": {
-    "hash": "73020f5c733d65db4d72156884b67eef",
-    "outputs": ["SegmentedChoice.json"]
-  },
-  "form/src/segmentedControl/SegmentedControl.tsx": {
-    "hash": "08b40d83ac972c0f3476a3c3bd8d9b68",
-    "outputs": ["SegmentedControl.json"]
-  },
-  "layout/src/MediaCard.tsx": {
-    "hash": "9d8ef8b8d9a5bba061eae3e873e82184",
-    "outputs": ["MediaCard.json"]
-  },
-  "layout/src/NavigationCard.tsx": {
-    "hash": "0e466e41037e7a2a93ed48d40ee97940",
-    "outputs": ["NavigationCard.json"]
-  },
-  "layout/src/beta/Flex/Flex.tsx": {
-    "hash": "bdfb861644430c32909cfaaa584448e9",
-    "outputs": ["Flex.json"]
-  },
-  "layout/src/beta/Flex/FlexSpacer.tsx": {
-    "hash": "77102cdf186ed6260e916519d52b97c3",
-    "outputs": ["FlexSpacer.json"]
-  },
-  "layout/src/beta/Grid/Grid.tsx": {
-    "hash": "15cd3fd6b6899c9fe663cbae18ad6bbb",
-    "outputs": ["Grid.json"]
-  },
-  "layout/src/beta/LayoutWrapper/LayoutWrapper.tsx": {
-    "hash": "404b73b85daf88e23b138e198b276e07",
-    "outputs": ["LayoutWrapper.json"]
-  },
-  "layout/src/beta/templates/Sidebar.tsx": {
-    "hash": "a48618c6f67b1f34ecb7a761cb4b73f8",
-    "outputs": ["Template.Portal.Sidebar.json"]
-  },
-  "layout/src/beta/templates/portal/Portal.tsx": {
-    "hash": "0766d160ad5ffe749292ed4d8aa543e2",
-    "outputs": ["Template.Portal.json"]
-  },
-  "menu/src/BreadcrumbItem.tsx": {
-    "hash": "a0ab55ce274859eb95c42671bc25075a",
-    "outputs": ["BreadcrumbItem.json"]
-  },
-  "menu/src/BreadcrumbNavigation.tsx": {
-    "hash": "270d4769f111e693310795886a14e441",
-    "outputs": ["BreadcrumbNavigation.json"]
-  },
-  "menu/src/CollapsibleSideNavigation.tsx": {
-    "hash": "a0310bbe283135e6438fbfdc44d672c8",
-    "outputs": ["CollapsibleSideNavigation.json"]
-  },
-  "menu/src/OverflowMenu.tsx": {
-    "hash": "72489aa68523320adcee54227e27b98a",
-    "outputs": [
-      "OverflowMenu.json",
-      "OverflowMenuItem.json",
-      "OverflowMenuLink.json"
-    ]
-  },
-  "menu/src/Pagination.tsx": {
-    "hash": "664da875354c5b61b2384bc72510770c",
-    "outputs": ["Pagination.json"]
-  },
-  "menu/src/SideNavigationGroup.tsx": {
-    "hash": "40f516f53183dea636985b20486e7faf",
-    "outputs": ["SideNavigationGroup.json"]
-  },
-  "modal/src/Drawer.tsx": {
-    "hash": "2079d01bd9e2f1597b802e622fe9db6e",
-    "outputs": ["Drawer.json"]
-  },
-  "modal/src/ModalContent.tsx": {
-    "hash": "34819de8932762d65acfd41dc1424d46",
-    "outputs": ["ModalContent.json"]
-  },
-  "table/src/HeaderCell.tsx": {
-    "hash": "06547391e7b5f80f5132c2057b6e2802",
-    "outputs": ["HeaderCell.json"]
-  },
-  "table/src/Table.tsx": {
-    "hash": "59ea7b9c3ce8724580d238e23f8e9ea0",
-    "outputs": ["Table.json"]
-  },
-  "tooltip/src/Popover.tsx": {
-    "hash": "7c52fab353ef2bb78efc9316fdfb2ef8",
-    "outputs": [
-      "Popover.json",
-      "PopoverTrigger.json",
-      "PopoverCloseButton.json",
-      "PopoverContent.json"
-    ]
-  },
-  "tooltip/src/Tooltip.tsx": {
-    "hash": "26844b3d1439cd8016a242020aaf69f5",
-    "outputs": ["Tooltip.json"]
-  },
-  "travel/src/TravelTag.tsx": {
-    "hash": "04092c9d634fee91928cbf32f812676a",
-    "outputs": ["TravelTag.json"]
-  },
-  "typography/src/beta/components/Heading.tsx": {
-    "hash": "06b826fa8f28422ef2fb09b8ff95321f",
-    "outputs": ["Heading.json"]
-  },
-  "typography/src/beta/components/Text.tsx": {
-    "hash": "11e1fd38c76eb4a44bb79bf37fe74a13",
-    "outputs": ["Text.json"]
-  },
   "utils/src/PolymorphicComponent.tsx": {
     "hash": "c98a4c8755ceb1b523f93006e5d8039f",
     "outputs": []
-  },
-  "layout/src/beta/LayoutProvider/LayoutProvider.tsx": {
-    "hash": "693792318fe331399c1e6c0ee284e49d",
-    "outputs": ["LayoutProvider.json"]
   }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/useAccordion.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/useAccordion.json
@@ -10,7 +10,7 @@
       "name": "id",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/Accordion.tsx",
+          "fileName": "packages/expand/src/Accordion.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/Accordion.tsx",
+          "fileName": "packages/expand/src/Accordion.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/eds-component-props/useAccordion.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/useAccordion.json
@@ -10,7 +10,7 @@
       "name": "id",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/Accordion.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/Accordion.tsx",
           "name": "TypeLiteral"
         }
       ],
@@ -25,7 +25,7 @@
       "name": "defaultOpen",
       "declarations": [
         {
-          "fileName": "design-system/packages/expand/src/Accordion.tsx",
+          "fileName": "apps/documentation/fix-cache-corruption/packages/expand/src/Accordion.tsx",
           "name": "TypeLiteral"
         }
       ],

--- a/apps/documentation/src/utils/componentProps/generate-props.ts
+++ b/apps/documentation/src/utils/componentProps/generate-props.ts
@@ -2,6 +2,7 @@ import { ComponentDoc, withCustomConfig } from 'react-docgen-typescript';
 import fs from 'fs-extra';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
 import crypto from 'crypto';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -21,7 +22,9 @@ const parser = withCustomConfig(tsConfigPath, {
   },
 });
 
-const repoRoot = path.resolve(__dirname, '../../../../..');
+const repoRoot = execSync('git rev-parse --show-toplevel', {
+  encoding: 'utf8',
+}).trim();
 const componentsRootDir = path.join(repoRoot, 'packages');
 
 const outputDir = path.join(__dirname, 'eds-component-props');
@@ -156,16 +159,22 @@ function generatePropFileForComponent(componentFile: string): {
   }
 }
 
+function normalizeFileName(fileName: string): string {
+  const normalized = fileName.replace(/\\/g, '/');
+  for (const prefix of ['packages/', 'node_modules/']) {
+    const idx = normalized.indexOf(prefix);
+    if (idx !== -1) return normalized.slice(idx);
+  }
+  return normalized;
+}
+
 function normalizeFileNames(componentProps: Partial<ComponentDoc>): void {
   if (!componentProps.props) return;
   for (const prop of Object.values(componentProps.props)) {
     if (!prop.declarations) continue;
     for (const decl of prop.declarations) {
       if (!decl.fileName) continue;
-      const abs = path.isAbsolute(decl.fileName)
-        ? decl.fileName
-        : path.resolve(decl.fileName);
-      decl.fileName = path.relative(repoRoot, abs);
+      decl.fileName = normalizeFileName(decl.fileName);
     }
   }
 }

--- a/apps/documentation/src/utils/componentProps/generate-props.ts
+++ b/apps/documentation/src/utils/componentProps/generate-props.ts
@@ -21,7 +21,8 @@ const parser = withCustomConfig(tsConfigPath, {
   },
 });
 
-const componentsRootDir = path.join(__dirname, '../../../../../packages');
+const repoRoot = path.resolve(__dirname, '../../../../..');
+const componentsRootDir = path.join(repoRoot, 'packages');
 
 const outputDir = path.join(__dirname, 'eds-component-props');
 
@@ -122,6 +123,7 @@ function generatePropFileForComponent(componentFile: string): {
 
     parsedProps.forEach((componentProps: Partial<ComponentDoc>) => {
       delete componentProps.filePath;
+      normalizeFileNames(componentProps);
 
       const componentDisplayName = componentProps.displayName;
       const outputFilePath = path.join(
@@ -151,6 +153,20 @@ function generatePropFileForComponent(componentFile: string): {
   } catch (error) {
     console.error(`Failed to extract props for ${componentFile}:`, error);
     return { parsed: false, outputs: [] };
+  }
+}
+
+function normalizeFileNames(componentProps: Partial<ComponentDoc>): void {
+  if (!componentProps.props) return;
+  for (const prop of Object.values(componentProps.props)) {
+    if (!prop.declarations) continue;
+    for (const decl of prop.declarations) {
+      if (!decl.fileName) continue;
+      const abs = path.isAbsolute(decl.fileName)
+        ? decl.fileName
+        : path.resolve(decl.fileName);
+      decl.fileName = path.relative(repoRoot, abs);
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:package": "lerna run build --scope \"@entur/$*\" | cat",
     "build:packages": "lerna run build --no-private",
     "build:documentation": "lerna run --scope @entur/documentation build",
-    "build:documentation:skip-packages-dependency": "lerna run --scope @entur/documentation build:skip-props-generator",
+    "build:documentation:skip-packages-dependency": "yarn workspace @entur/documentation build",
     "build:code-playground": "lerna run --scope @entur/code-playground build",
     "build:studio-linje": "lerna run --scope @entur/studio-linje build",
     "clean": "lerna clean",


### PR DESCRIPTION
## 💡 Hvorfor?

Dokumentasjonssiden har hatt gjentakende problemer med korrupt Gatsby-cache i CI som fører til at JavaScript ikke lastes riktig. I tillegg forsvinner sidenavigasjonen helt når JS feiler fordi den kun rendres på klient-siden. Code-playground og prop-generatoren fungerte heller ikke i git worktrees pga. hardkodede stier.

## 🔧 Hvordan?

**Gatsby-cache fjernet fra prod-bygg:**
- `actions/cache` for `.cache`-mappen fjernet fra `build-and-deploy-prod.yml`
- Cachen var umulig å holde konsistent på tvers av ulike commits/pakker

**Sidebar rendres nå i SSR:**
- CSS media queries erstatter `useWindowDimensions` for responsiv visning
- Både desktop- og mobilvariant rendres, CSS styrer synlighet
- `<nav aria-label="Sidemeny">` landmark rundt navigasjonen
- Drawer brukes uten overlay (ikke-modal) for mobilnavigasjon
- `aria-expanded` på menyknappen
- Drawer-tittel satt til "Navigasjonsmeny" med sr-only styling

**Worktree-kompatibilitet:**
- Playroom webpack-config bruker `path.resolve` i stedet for hardkodede regex-stier
- Prop-generator normaliserer filstier relativt til repo-root

## 🧩 Type endring

- [x] 🐞 Feilretting
- [x] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

- Preview-workflowen beholder Gatsby-cache (dag+branch-scopet) — der er risikoen lavere
- Prop-filene har en engangsdiff der `design-system/` i stier erstattes med repo-relative stier
- ~90 sekunder ekstra byggetid på prod uten Gatsby-cache, men eliminerer korrupsjonsrisiko

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden