### PR TITLE
feat(datepicker/range calendar): add RangeCalendar component

### DIFF
--- a/apps/documentation/src/pages/komponenter/skjemaelementer/datepicker.mdx
+++ b/apps/documentation/src/pages/komponenter/skjemaelementer/datepicker.mdx
@@ -14,6 +14,7 @@ import {
   DatePicker,
   DateField,
   Calendar,
+  RangeCalendar,
   TimePicker,
   NativeDatePicker,
   nativeDateToDateValue,
@@ -385,6 +386,39 @@ code={`() => {
   }`}
 scope={{now}} />
 
+### Periodekalender
+
+Hvis du ønsker å la brukeren velge en periode (fra- og til-dato) kan du benytte `<RangeCalendar />`-komponenten. Den fungerer med samme type datoobjekter som `<Calendar />` og støtter de fleste av de samme props-ene, men tar inn og returnerer et objekt med `start` og `end` i stedet for én enkelt dato. Props som er spesifikke for enkeltdatovelgeren (`onSelectedCellClick`, `onCellClick` og `forcedReturnType`) er ikke tilgjengelige, mens `visibleDuration` er en prop som kun finnes på `<RangeCalendar />`.
+
+<Playground hideContrastOption code={`() => {
+    const [range, setRange] = React.useState(null);
+    return (
+      <RangeCalendar
+        value={range}
+        onChange={setRange}
+        locale="nb-NO"
+      />
+    );
+  }`}
+  scope={{RangeCalendar}} />
+
+#### Vise flere måneder samtidig
+
+Bruk `visibleDuration`-prop-en for å vise flere måneder samtidig i periodekalenderen.
+
+<Playground hideContrastOption code={`() => {
+    const [range, setRange] = React.useState(null);
+    return (
+      <RangeCalendar
+        value={range}
+        onChange={setRange}
+        locale="nb-NO"
+        visibleDuration={{ months: 2 }}
+      />
+    );
+  }`}
+  scope={{RangeCalendar}} />
+
 ### Kun inputfelt
 
 Hvis du ønsker å kun vise et inputfelt uten mulighet for en kalender-popover kan du benytte `<DateField />`-komponenten. Denne fungerer med samme type datoobjekter som `<DatePicker />` og støtter mange av de samme props-ene.
@@ -444,6 +478,11 @@ Hvis du endrer `locale` (dvs. språk) til noe annet enn norsk og engelsk må du 
 
 <ImportStatement imports="Calendar" packageName={props.pageContext.frontmatter.npmPackage} />
 <Props componentName="Calendar" />
+
+### RangeCalendar
+
+<ImportStatement imports="RangeCalendar" packageName={props.pageContext.frontmatter.npmPackage} />
+<Props componentName="RangeCalendar" />
 
 ### NativeDatePicker
 

--- a/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendar.json
@@ -1,0 +1,275 @@
+{
+  "tags": {},
+  "description": "",
+  "displayName": "RangeCalendar",
+  "methods": [],
+  "props": {
+    "value": {
+      "defaultValue": null,
+      "description": "Det valgte datoperioden. Null hvis ingen periode er valgt.",
+      "name": "value",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "RangeValue<MappedDateValue<DateType>> | null"
+      }
+    },
+    "onChange": {
+      "defaultValue": null,
+      "description": "Callback som kalles når valgt periode endres.",
+      "name": "onChange",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((value: RangeValue<MappedDateValue<DateType>> | null) => void) | undefined"
+      }
+    },
+    "navigationDescription": {
+      "defaultValue": null,
+      "description": "",
+      "name": "navigationDescription",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "style": {
+      "defaultValue": null,
+      "description": "",
+      "name": "style",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "CSSProperties | undefined"
+      }
+    },
+    "className": {
+      "defaultValue": null,
+      "description": "Ekstra klassenavn",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "minDate": {
+      "defaultValue": null,
+      "description": "Tidligste gyldige datovalg.\nEks: today(getLocalTimeZone()) == i dag i lokal tidssone.",
+      "name": "minDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "DateValue | undefined"
+      }
+    },
+    "maxDate": {
+      "defaultValue": null,
+      "description": "Seneste gyldige datovalg.\nEks: today(getLocalTimeZone()).add({days: 1}) == i morgen i lokal tidssone",
+      "name": "maxDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "DateValue | undefined"
+      }
+    },
+    "showWeekNumbers": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Slå på visning av ukenummere i kalenderen. Overskriften for ukenummer-kolonnen\nkan endres med prop-en 'weekNumberHeader'",
+      "name": "showWeekNumbers",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "weekNumberHeader": {
+      "defaultValue": {
+        "value": "uke"
+      },
+      "description": "Overskrift som vises for ukenummer-kolonnen. Vises kun hvis 'showWeekNumbers' er true.",
+      "name": "weekNumberHeader",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "showOutsideMonth": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Vis datoer som ligger utenfor den viste måneden.",
+      "name": "showOutsideMonth",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "classNameForDate": {
+      "defaultValue": {
+        "value": "undefined"
+      },
+      "description": "Brukes for å legge til klassenavn på spesifikke datoer i kalenderen.\nTar inn en dato og skal returnere klassenavnet som skal legges til den datoen.\n@example (date) => isWeekend(date, 'no-NO') ? 'weekend' : ''\n\nOBS: hvis stylingen er meningsbærende bør du bruke ariaLabelForDate i tillegg for å beskrive\nmeningen til skjermlesere o.l.",
+      "name": "classNameForDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((date: CalendarDate) => string) | undefined"
+      }
+    },
+    "ariaLabelForDate": {
+      "defaultValue": {
+        "value": "undefined"
+      },
+      "description": "Legger til teksten som returneres på datoen i kalenderen sin aria-label.\nBør brukes sammen med classNameForDate hvis styling-endringene gjort der er meningsbærende.\n@example (date) => isWeekend(date, 'no-NO') ? 'helgedag' : ''",
+      "name": "ariaLabelForDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((date: CalendarDate) => string) | undefined"
+      }
+    },
+    "onValidate": {
+      "defaultValue": null,
+      "description": "Callback-funksjon for når valideringen til datovelgeren endrer seg",
+      "name": "onValidate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((isValid?: boolean | undefined) => void) | undefined"
+      }
+    },
+    "disabled": {
+      "defaultValue": null,
+      "description": "",
+      "name": "disabled",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "locale": {
+      "defaultValue": null,
+      "description": "",
+      "name": "locale",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "calendarRef": {
+      "defaultValue": null,
+      "description": "",
+      "name": "calendarRef",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "MutableRefObject<HTMLDivElement | null> | undefined"
+      }
+    },
+    "visibleDuration": {
+      "defaultValue": {
+        "value": "{months: 1}"
+      },
+      "description": "Vis flere måneder samtidig i kalenderen.\n@example {months: 2}",
+      "name": "visibleDuration",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendar.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "Pick<DateDuration, \"months\"> | undefined"
+      }
+    }
+  }
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendar.json
@@ -81,7 +81,7 @@
     },
     "minDate": {
       "defaultValue": null,
-      "description": "Tidligste gyldige datovalg.\nEks: today(getLocalTimeZone()) == i dag i lokal tidssone.",
+      "description": "Tidligste gyldige datovalg.\nEks: today(getLocalTimeZone()) == i dag i lokal tidssone.\n\nOBS: Hvis du bruker dato med tid vil tidspunktet også tas hensyn til.\nGyldig fra og med den tiden som legges inn som minDate.\nDato uten tid vil være gyldig hele minDate-dagen",
       "name": "minDate",
       "declarations": [
         {
@@ -96,7 +96,7 @@
     },
     "maxDate": {
       "defaultValue": null,
-      "description": "Seneste gyldige datovalg.\nEks: today(getLocalTimeZone()).add({days: 1}) == i morgen i lokal tidssone",
+      "description": "Seneste gyldige datovalg.\nEks: today(getLocalTimeZone()).add({days: 1}) == i morgen i lokal tidssone\n\nOBS: Hvis du bruker dato med tid vil tidspunktet også tas hensyn til.\nGyldig til og med den tiden som legges inn som maxDate.\nDato uten tid vil være gyldig hele maxDate-dagen",
       "name": "maxDate",
       "declarations": [
         {
@@ -147,7 +147,7 @@
       "defaultValue": {
         "value": false
       },
-      "description": "Vis datoer som ligger utenfor den viste måneden.",
+      "description": "Vis datoer som ligger utenfor den viste måneden.\n@example Hvis uken starter på onsdag vises de to siste datoene i forrige måned i ruten til mandagen og tirsdagen før.",
       "name": "showOutsideMonth",
       "declarations": [
         {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendarCell.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendarCell.json
@@ -1,0 +1,100 @@
+{
+  "tags": {},
+  "description": "",
+  "displayName": "RangeCalendarCell",
+  "methods": [],
+  "props": {
+    "state": {
+      "defaultValue": null,
+      "description": "",
+      "name": "state",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarCell.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "RangeCalendarState<DateValue>"
+      }
+    },
+    "date": {
+      "defaultValue": null,
+      "description": "",
+      "name": "date",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarCell.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "CalendarDate"
+      }
+    },
+    "weekNumberString": {
+      "defaultValue": null,
+      "description": "",
+      "name": "weekNumberString",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarCell.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "string"
+      }
+    },
+    "showOutsideMonth": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "",
+      "name": "showOutsideMonth",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarCell.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "classNameForDate": {
+      "defaultValue": null,
+      "description": "",
+      "name": "classNameForDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarCell.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((date: CalendarDate) => string) | undefined"
+      }
+    },
+    "ariaLabelForDate": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ariaLabelForDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarCell.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((date: CalendarDate) => string) | undefined"
+      }
+    }
+  }
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendarGrid.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendarGrid.json
@@ -1,0 +1,130 @@
+{
+  "tags": {},
+  "description": "",
+  "displayName": "RangeCalendarGrid",
+  "methods": [],
+  "props": {
+    "state": {
+      "defaultValue": null,
+      "description": "",
+      "name": "state",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "RangeCalendarState<DateValue>"
+      }
+    },
+    "startDate": {
+      "defaultValue": null,
+      "description": "",
+      "name": "startDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "CalendarDate | undefined"
+      }
+    },
+    "navigationDescription": {
+      "defaultValue": null,
+      "description": "",
+      "name": "navigationDescription",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "showWeekNumbers": {
+      "defaultValue": null,
+      "description": "",
+      "name": "showWeekNumbers",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "boolean"
+      }
+    },
+    "weekNumberHeader": {
+      "defaultValue": null,
+      "description": "",
+      "name": "weekNumberHeader",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "string"
+      }
+    },
+    "showOutsideMonth": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "",
+      "name": "showOutsideMonth",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "classNameForDate": {
+      "defaultValue": null,
+      "description": "",
+      "name": "classNameForDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((date: CalendarDate) => string) | undefined"
+      }
+    },
+    "ariaLabelForDate": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ariaLabelForDate",
+      "declarations": [
+        {
+          "fileName": "design-system/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((date: CalendarDate) => string) | undefined"
+      }
+    }
+  }
+}

--- a/packages/datepicker/src/DatePicker/Calendar.scss
+++ b/packages/datepicker/src/DatePicker/Calendar.scss
@@ -17,6 +17,8 @@
     color: var(--components-datepicker-calendar-text-accent);
 
     h2 {
+      flex: 1;
+      text-align: center;
       font-size: t.$font-sizes-large;
       font-weight: t.$font-weights-heading;
     }
@@ -40,6 +42,16 @@
         visibility: hidden;
       }
     }
+  }
+
+  &__grids {
+    display: flex;
+    gap: t.$space-large;
+  }
+
+  &__month {
+    display: flex;
+    flex-direction: column;
   }
 
   &__grid {
@@ -77,6 +89,33 @@
           border-style: dashed;
         }
 
+        &:has(.eds-datepicker__calendar__grid__cell--in-range) {
+          background-color: var(--components-datepicker-calendar-datefill-range);
+          border-left-color: var(--components-datepicker-calendar-datefill-range);
+          border-right-color: var(--components-datepicker-calendar-datefill-range);
+          border-top-color: var(--components-datepicker-calendar-dateborder);
+          border-bottom-color: var(--components-datepicker-calendar-dateborder);
+        }
+
+        &:has(.eds-datepicker__calendar__grid__cell--selection-start:not(.eds-datepicker__calendar__grid__cell--selection-end)) {
+          background: linear-gradient(to right, transparent 50%, var(--components-datepicker-calendar-datefill-range) 50%);
+          border-right-color: var(--components-datepicker-calendar-datefill-range);
+          border-top-color: var(--components-datepicker-calendar-dateborder);
+          border-bottom-color: var(--components-datepicker-calendar-dateborder);
+        }
+
+        &:has(.eds-datepicker__calendar__grid__cell--selection-end:not(.eds-datepicker__calendar__grid__cell--selection-start)) {
+          background: linear-gradient(to left, transparent 50%, var(--components-datepicker-calendar-datefill-range) 50%);
+          border-left-color: var(--components-datepicker-calendar-datefill-range);
+          border-top-color: var(--components-datepicker-calendar-dateborder);
+          border-bottom-color: var(--components-datepicker-calendar-dateborder);
+        }
+
+        &:has(.eds-datepicker__calendar__grid__cell--selection-start.eds-datepicker__calendar__grid__cell--selection-end) {
+          background: transparent;
+          border-color: transparent;
+        }
+
         &:focus-within {
           z-index: 2;
         }
@@ -89,7 +128,12 @@
 
       &:active {
         background-color: var(--components-datepicker-calendar-datefill-selected);
-        color: var(--components-datepicker-calendar-text-accent);
+        color: var(--components-datepicker-calendar-text-range-endpoint);
+      }
+
+      &--between-months {
+        opacity: 0.5;
+        pointer-events: none;
       }
       &:focus-visible {
         outline: t.$outlines-focus;
@@ -98,18 +142,53 @@
       }
 
       &--selected {
-        background-color: var(--components-datepicker-calendar-datefill-selected);
-        color: var(--components-datepicker-calendar-text-accent);
+        background-color: var(--components-datepicker-calendar-datefill-range-endpoint);
+        color: var(--components-datepicker-calendar-text-range-endpoint);
+        border-radius: 4px;
 
         &:hover {
-          background-color: var(--components-datepicker-calendar-datefill-hover);
-          color: var(--components-datepicker-calendar-text-accent);
+          background-color: var(--components-datepicker-calendar-datefill-range-endpoint-hover);
+          color: var(--components-datepicker-calendar-text-range-endpoint);
         }
 
         &:active {
-          background-color: var(--components-datepicker-calendar-datefill-selected);
+          background-color: var(--components-datepicker-calendar-datefill-range-endpoint);
+          color: var(--components-datepicker-calendar-text-range-endpoint);
+        }
+      }
+
+      &--in-range {
+        background-color: var(--components-datepicker-calendar-datefill-range);
+        color: var(--components-datepicker-calendar-text-accent);
+        border-radius: 0;
+
+        &:hover {
+          background-color: var(--components-datepicker-calendar-datefill-range-hover);
           color: var(--components-datepicker-calendar-text-accent);
         }
+      }
+
+      &--selection-start,
+      &--selection-end {
+        background-color: var(--components-datepicker-calendar-datefill-range-endpoint);
+        color: var(--components-datepicker-calendar-text-range-endpoint);
+
+        &:hover {
+          background-color: var(--components-datepicker-calendar-datefill-range-endpoint-hover);
+          color: var(--components-datepicker-calendar-text-range-endpoint);
+        }
+      }
+
+      &--selection-start:not(.eds-datepicker__calendar__grid__cell--selection-end) {
+        border-radius: 4px 0 0 4px;
+      }
+
+      &--selection-end:not(.eds-datepicker__calendar__grid__cell--selection-start) {
+        border-radius: 0 4px 4px 0;
+      }
+
+      &--selection-start.eds-datepicker__calendar__grid__cell--selection-end {
+        border-radius: 4px;
       }
 
       &--disabled {

--- a/packages/datepicker/src/DatePicker/RangeCalendar.tsx
+++ b/packages/datepicker/src/DatePicker/RangeCalendar.tsx
@@ -1,0 +1,214 @@
+import React, { useEffect, useRef } from 'react';
+
+import classNames from 'classnames';
+import './Calendar.scss';
+import { I18nProvider, useLocale } from '@react-aria/i18n';
+import { AriaRangeCalendarProps, useRangeCalendar } from '@react-aria/calendar';
+import {
+  RangeCalendarStateOptions,
+  useRangeCalendarState,
+} from '@react-stately/calendar';
+import { CalendarDate, DateDuration, DateValue } from '@internationalized/date';
+import { RangeValue } from '@react-types/shared';
+import { MappedDateValue } from '@react-types/datepicker';
+
+import { LeftArrowIcon, RightArrowIcon } from '@entur/icons';
+
+import {
+  ariaLabelIfNorwegian,
+  createCalendar,
+  getAdjustedMaxDate,
+} from '../shared/utils';
+import { CalendarButton } from '../shared/CalendarButton';
+import { RangeCalendarGrid } from './RangeCalendarGrid';
+
+type BaseRangeCalendarProps<DateType extends DateValue> = {
+  /** Det valgte datoperioden. Null hvis ingen periode er valgt. */
+  value: RangeValue<MappedDateValue<DateType>> | null;
+  /** Callback som kalles når valgt periode endres. */
+  onChange?: (value: RangeValue<MappedDateValue<DateType>> | null) => void;
+  navigationDescription?: string;
+  style?: React.CSSProperties;
+  /** Ekstra klassenavn */
+  className?: string;
+  /** Tidligste gyldige datovalg.
+   * Eks: today(getLocalTimeZone()) == i dag i lokal tidssone. */
+  minDate?: DateValue;
+  /** Seneste gyldige datovalg.
+   * Eks: today(getLocalTimeZone()).add({days: 1}) == i morgen i lokal tidssone */
+  maxDate?: DateValue;
+  /** Slå på visning av ukenummere i kalenderen. Overskriften for ukenummer-kolonnen
+   * kan endres med prop-en 'weekNumberHeader'
+   * @default false */
+  showWeekNumbers?: boolean;
+  /** Overskrift som vises for ukenummer-kolonnen. Vises kun hvis 'showWeekNumbers' er true.
+   * @default 'uke' */
+  weekNumberHeader?: string;
+  /** Vis datoer som ligger utenfor den viste måneden.
+   * @default false */
+  showOutsideMonth?: boolean;
+  /** Brukes for å legge til klassenavn på spesifikke datoer i kalenderen.
+   *  Tar inn en dato og skal returnere klassenavnet som skal legges til den datoen.
+   *  @default undefined
+   *  @example (date) => isWeekend(date, 'no-NO') ? 'weekend' : ''
+   *
+   *  OBS: hvis stylingen er meningsbærende bør du bruke ariaLabelForDate i tillegg for å beskrive
+   *  meningen til skjermlesere o.l.
+   */
+  classNameForDate?: (date: CalendarDate) => string;
+  /** Legger til teksten som returneres på datoen i kalenderen sin aria-label.
+   *  Bør brukes sammen med classNameForDate hvis styling-endringene gjort der er meningsbærende.
+   *  @default undefined
+   *  @example (date) => isWeekend(date, 'no-NO') ? 'helgedag' : ''
+   */
+  ariaLabelForDate?: (date: CalendarDate) => string;
+  /** Callback-funksjon for når valideringen til datovelgeren endrer seg */
+  onValidate?: (isValid?: boolean) => void;
+  disabled?: boolean;
+  locale?: string;
+  calendarRef?: React.MutableRefObject<HTMLDivElement | null>;
+  /** Vis flere måneder samtidig i kalenderen.
+   * @default {months: 1}
+   * @example {months: 2}
+   */
+  visibleDuration?: Pick<DateDuration, 'months'>;
+};
+
+type ExtendedRangeCalendarProps<DateType extends DateValue> = Omit<
+  AriaRangeCalendarProps<DateType>,
+  | keyof BaseRangeCalendarProps<DateType>
+  | 'value'
+  | 'label'
+  | 'hideTimeZone'
+  | 'placeholder'
+  | 'placeholderValue'
+  | 'defaultValue'
+  | 'minValue'
+  | 'maxValue'
+>;
+
+export type RangeCalendarProps<DateType extends DateValue> =
+  BaseRangeCalendarProps<DateType> & ExtendedRangeCalendarProps<DateType>;
+
+export const RangeCalendar = <DateType extends DateValue>({
+  locale: localeOverride,
+  ...rest
+}: RangeCalendarProps<DateType>) => {
+  const props = { isDisabled: rest.disabled, ...rest };
+  const { locale } = useLocale();
+  return (
+    <I18nProvider locale={localeOverride ?? locale}>
+      <RangeCalendarBase {...props} />
+    </I18nProvider>
+  );
+};
+
+const RangeCalendarBase = <DateType extends DateValue>({
+  value,
+  onChange,
+  minDate,
+  maxDate,
+  showWeekNumbers = false,
+  weekNumberHeader = 'uke',
+  showOutsideMonth = false,
+  visibleDuration,
+  style,
+  className,
+  navigationDescription,
+  classNameForDate,
+  ariaLabelForDate,
+  calendarRef,
+  ...rest
+}: RangeCalendarProps<DateType>) => {
+  const { locale } = useLocale();
+  const internalRef = useRef<HTMLDivElement | null>(null);
+  const ref = calendarRef ?? internalRef;
+
+  const _props: RangeCalendarStateOptions<DateType> = {
+    ...rest,
+    value,
+    onChange,
+    locale,
+    createCalendar,
+    minValue: minDate,
+    maxValue: getAdjustedMaxDate(maxDate),
+    visibleDuration,
+  };
+
+  const state = useRangeCalendarState(_props);
+  const { calendarProps, prevButtonProps, nextButtonProps, title } =
+    useRangeCalendar(_props, state, ref);
+
+  useEffect(
+    () => rest.onValidate?.(!state.isValueInvalid),
+    [state.isValueInvalid],
+  );
+
+  const monthCount =
+    state.visibleRange.end.month -
+    state.visibleRange.start.month +
+    1 +
+    (state.visibleRange.end.year - state.visibleRange.start.year) * 12;
+
+  const getMonthTitle = (startDate: CalendarDate) =>
+    new Intl.DateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(
+      new Date(startDate.year, startDate.month - 1),
+    );
+
+  return (
+    <div
+      {...calendarProps}
+      ref={ref}
+      className={classNames('eds-datepicker__calendar', className)}
+      style={style}
+    >
+      <div className="eds-datepicker__calendar__grids">
+        {Array.from({ length: monthCount }, (_, i) => {
+          const startDate = state.visibleRange.start.add({ months: i });
+          return (
+            <div key={i} className="eds-datepicker__calendar__month">
+              <div className="eds-datepicker__calendar__header">
+                {i === 0 && (
+                  <CalendarButton
+                    {...prevButtonProps}
+                    aria-label={ariaLabelIfNorwegian(
+                      'Forrige måned',
+                      locale,
+                      prevButtonProps,
+                    )}
+                  >
+                    <LeftArrowIcon size={20} />
+                  </CalendarButton>
+                )}
+                <h2>{monthCount > 1 ? getMonthTitle(startDate) : title}</h2>
+                {i === monthCount - 1 && (
+                  <CalendarButton
+                    {...nextButtonProps}
+                    aria-label={ariaLabelIfNorwegian(
+                      'Neste måned',
+                      locale,
+                      nextButtonProps,
+                    )}
+                  >
+                    <RightArrowIcon size={20} />
+                  </CalendarButton>
+                )}
+              </div>
+              <RangeCalendarGrid
+                {...rest}
+                state={state}
+                startDate={startDate}
+                navigationDescription={navigationDescription}
+                classNameForDate={classNameForDate}
+                ariaLabelForDate={ariaLabelForDate}
+                showWeekNumbers={showWeekNumbers}
+                weekNumberHeader={weekNumberHeader}
+                showOutsideMonth={showOutsideMonth}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/datepicker/src/DatePicker/RangeCalendar.tsx
+++ b/packages/datepicker/src/DatePicker/RangeCalendar.tsx
@@ -32,10 +32,18 @@ type BaseRangeCalendarProps<DateType extends DateValue> = {
   /** Ekstra klassenavn */
   className?: string;
   /** Tidligste gyldige datovalg.
-   * Eks: today(getLocalTimeZone()) == i dag i lokal tidssone. */
+   * Eks: today(getLocalTimeZone()) == i dag i lokal tidssone.
+   *
+   * OBS: Hvis du bruker dato med tid vil tidspunktet også tas hensyn til.
+   * Gyldig fra og med den tiden som legges inn som minDate.
+   * Dato uten tid vil være gyldig hele minDate-dagen */
   minDate?: DateValue;
   /** Seneste gyldige datovalg.
-   * Eks: today(getLocalTimeZone()).add({days: 1}) == i morgen i lokal tidssone */
+   * Eks: today(getLocalTimeZone()).add({days: 1}) == i morgen i lokal tidssone
+   *
+   * OBS: Hvis du bruker dato med tid vil tidspunktet også tas hensyn til.
+   * Gyldig til og med den tiden som legges inn som maxDate.
+   * Dato uten tid vil være gyldig hele maxDate-dagen */
   maxDate?: DateValue;
   /** Slå på visning av ukenummere i kalenderen. Overskriften for ukenummer-kolonnen
    * kan endres med prop-en 'weekNumberHeader'
@@ -45,6 +53,7 @@ type BaseRangeCalendarProps<DateType extends DateValue> = {
    * @default 'uke' */
   weekNumberHeader?: string;
   /** Vis datoer som ligger utenfor den viste måneden.
+   * @example Hvis uken starter på onsdag vises de to siste datoene i forrige måned i ruten til mandagen og tirsdagen før.
    * @default false */
   showOutsideMonth?: boolean;
   /** Brukes for å legge til klassenavn på spesifikke datoer i kalenderen.
@@ -91,13 +100,13 @@ export type RangeCalendarProps<DateType extends DateValue> =
   BaseRangeCalendarProps<DateType> & ExtendedRangeCalendarProps<DateType>;
 
 export const RangeCalendar = <DateType extends DateValue>({
-  locale: localeOverride,
+  locale: localOverride,
   ...rest
 }: RangeCalendarProps<DateType>) => {
   const props = { isDisabled: rest.disabled, ...rest };
   const { locale } = useLocale();
   return (
-    <I18nProvider locale={localeOverride ?? locale}>
+    <I18nProvider locale={localOverride ?? locale}>
       <RangeCalendarBase {...props} />
     </I18nProvider>
   );

--- a/packages/datepicker/src/DatePicker/RangeCalendarCell.tsx
+++ b/packages/datepicker/src/DatePicker/RangeCalendarCell.tsx
@@ -1,0 +1,124 @@
+import React, { useRef } from 'react';
+
+import { useCalendarCell } from '@react-aria/calendar';
+import { RangeCalendarState } from '@react-stately/calendar';
+import {
+  CalendarDate,
+  getLocalTimeZone,
+  isEqualDay,
+  isSameDay,
+  now,
+} from '@internationalized/date';
+import classNames from 'classnames';
+
+type RangeCalendarCellProps = {
+  state: RangeCalendarState;
+  date: CalendarDate;
+  currentMonth: CalendarDate;
+  weekNumberString: string;
+  showOutsideMonth?: boolean;
+  classNameForDate?: (date: CalendarDate) => string;
+  ariaLabelForDate?: (date: CalendarDate) => string;
+};
+
+export const RangeCalendarCell = ({
+  state,
+  date,
+  currentMonth,
+  showOutsideMonth = false,
+  weekNumberString,
+  classNameForDate,
+  ariaLabelForDate,
+  ...rest
+}: RangeCalendarCellProps) => {
+  const cellRef = useRef(null);
+
+  const {
+    cellProps,
+    buttonProps,
+    isSelected,
+    isOutsideVisibleRange,
+    isDisabled,
+    isUnavailable,
+    formattedDate,
+  } = useCalendarCell({ date }, state, cellRef);
+
+  const ariaLabel = `${buttonProps['aria-label']}${weekNumberString} ${
+    ariaLabelForDate?.(date) ?? ''
+  }`;
+
+  const highlightedRange = state.highlightedRange;
+  const isSelectionStart =
+    isSelected && highlightedRange
+      ? isSameDay(date, highlightedRange.start)
+      : isSelected;
+  const isSelectionEnd =
+    isSelected && highlightedRange
+      ? isSameDay(date, highlightedRange.end)
+      : isSelected;
+  const isInRange = isSelected && !isSelectionStart && !isSelectionEnd;
+
+  const isOverflowDate =
+    date.month !== currentMonth.month || date.year !== currentMonth.year;
+  const isBetweenVisibleMonths = isOverflowDate && !isOutsideVisibleRange;
+
+  const shouldHideDate = !showOutsideMonth && isOutsideVisibleRange;
+
+  const extendedButtonProps = {
+    ...buttonProps,
+    ...(showOutsideMonth &&
+      isOutsideVisibleRange && {
+        onClick: () => state.selectDate(date),
+        onKeyUp: (e: React.KeyboardEvent) => {
+          if (e.key === 'Enter') state.selectDate(date);
+        },
+      }),
+    ...(isBetweenVisibleMonths && {
+      tabIndex: -1,
+      role: 'presentation' as const,
+      onClick: undefined,
+      onKeyDown: undefined,
+      onKeyUp: undefined,
+      onPointerDown: undefined,
+      onFocus: undefined,
+    }),
+  };
+
+  return (
+    <td {...cellProps} className="eds-datepicker__calendar__grid__cell__td">
+      <div
+        {...extendedButtonProps}
+        aria-label={isBetweenVisibleMonths ? undefined : ariaLabel}
+        aria-hidden={shouldHideDate || isBetweenVisibleMonths}
+        ref={cellRef}
+        hidden={shouldHideDate}
+        className={classNames('eds-datepicker__calendar__grid__cell', {
+          [classNameForDate?.(date) ?? '']: !shouldHideDate,
+          'eds-datepicker__calendar__grid__cell--selected':
+            isSelected && !isOverflowDate,
+          'eds-datepicker__calendar__grid__cell--selection-start':
+            isSelectionStart && !isOverflowDate,
+          'eds-datepicker__calendar__grid__cell--selection-end':
+            isSelectionEnd && !isOverflowDate,
+          'eds-datepicker__calendar__grid__cell--in-range':
+            isInRange && !isOverflowDate,
+          'eds-datepicker__calendar__grid__cell--disabled':
+            isDisabled || isUnavailable,
+          'eds-datepicker__calendar__grid__cell--outside-month':
+            isOutsideVisibleRange && !showOutsideMonth,
+          'eds-datepicker__calendar__grid__cell--between-months':
+            isBetweenVisibleMonths,
+          'eds-datepicker__calendar__grid__cell--outside-month--visible':
+            isOutsideVisibleRange && showOutsideMonth,
+          'eds-datepicker__calendar__grid__cell--today': isEqualDay(
+            date,
+            now(state.timeZone ?? getLocalTimeZone()),
+          ),
+        })}
+        {...rest}
+      >
+        {formattedDate}
+      </div>
+    </td>
+  );
+};

--- a/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx
+++ b/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+
+import { useLocale } from '@react-aria/i18n';
+import { useCalendarGrid } from '@react-aria/calendar';
+import { RangeCalendarState } from '@react-stately/calendar';
+import { CalendarDate, getWeeksInMonth } from '@internationalized/date';
+
+import { useRandomId } from '@entur/utils';
+import { VisuallyHidden } from '@entur/a11y';
+
+import { getWeekNumberForDate } from '../shared/utils';
+import { RangeCalendarCell } from './RangeCalendarCell';
+
+type RangeCalendarGridProps = {
+  state: RangeCalendarState;
+  startDate?: CalendarDate;
+  navigationDescription?: string;
+  showWeekNumbers: boolean;
+  weekNumberHeader: string;
+  showOutsideMonth?: boolean;
+  classNameForDate?: (date: CalendarDate) => string;
+  ariaLabelForDate?: (date: CalendarDate) => string;
+};
+
+export const RangeCalendarGrid = ({
+  state,
+  startDate,
+  navigationDescription,
+  showWeekNumbers,
+  weekNumberHeader,
+  showOutsideMonth = false,
+  classNameForDate,
+  ariaLabelForDate,
+  ...rest
+}: RangeCalendarGridProps) => {
+  const calendarGridId = useRandomId('eds-calendar');
+  const { locale } = useLocale();
+
+  const gridStartDate = startDate ?? state.visibleRange.start;
+  const { gridProps, headerProps, weekDays } = useCalendarGrid(
+    { ...rest, startDate: gridStartDate },
+    state,
+  );
+
+  const weeksInMonth = getWeeksInMonth(gridStartDate, locale);
+  const weeksArray = Array.from(Array(weeksInMonth).keys());
+
+  const weekDaysMapped = () => {
+    if (locale.toLowerCase().includes('no'))
+      return ['ma', 'ti', 'on', 'to', 'fr', 'lø', 'sø'];
+    if (locale.toLowerCase().includes('en')) {
+      if (weekDays[0] === 'M')
+        return ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+      if (weekDays[0] === 'S')
+        return ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+    }
+    return weekDays.map(day => day.toLowerCase());
+  };
+
+  const getNavigationDescription = () => {
+    if (navigationDescription) return navigationDescription;
+    if (locale.toLowerCase().includes('en'))
+      return 'Use the arrow keys to navigate between dates';
+    return 'Bruk piltastene til å navigere mellom datoer';
+  };
+
+  return (
+    <>
+      <table
+        {...gridProps}
+        cellSpacing="0"
+        className="eds-datepicker__calendar__grid"
+      >
+        <thead {...headerProps}>
+          <tr>
+            {showWeekNumbers && (
+              <th className="eds-datepicker__calendar__grid__weeknumber-header">
+                {weekNumberHeader}
+              </th>
+            )}
+            {weekDaysMapped().map(day => (
+              <th key={day}>{day}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {weeksArray.map(weekIndex => {
+            const weekNumber = getWeekNumberForDate(
+              state.getDatesInWeek(weekIndex, gridStartDate)[0],
+            );
+            return (
+              <tr key={weekIndex}>
+                {showWeekNumbers && (
+                  <th
+                    aria-label={`${weekNumberHeader} ${weekNumber}`}
+                    className="eds-datepicker__calendar__grid__weeknumber"
+                  >
+                    {weekNumber}
+                  </th>
+                )}
+                {state
+                  .getDatesInWeek(weekIndex, gridStartDate)
+                  .map((date, i) =>
+                    date ? (
+                      <RangeCalendarCell
+                        key={`${date.month}.${date.day}`}
+                        state={state}
+                        date={date}
+                        currentMonth={gridStartDate}
+                        aria-describedby={calendarGridId + 'description'}
+                        weekNumberString={
+                          showWeekNumbers
+                            ? `, ${weekNumberHeader} ${weekNumber},`
+                            : ''
+                        }
+                        classNameForDate={classNameForDate}
+                        ariaLabelForDate={ariaLabelForDate}
+                        showOutsideMonth={showOutsideMonth}
+                      />
+                    ) : (
+                      <td key={i} />
+                    ),
+                  )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <VisuallyHidden id={calendarGridId + 'description'}>
+        {getNavigationDescription()}
+      </VisuallyHidden>
+    </>
+  );
+};

--- a/packages/datepicker/src/DatePicker/index.ts
+++ b/packages/datepicker/src/DatePicker/index.ts
@@ -1,4 +1,5 @@
 export * from './DateField';
 export * from './Calendar';
+export * from './RangeCalendar';
 export * from './DatePicker';
 export * from './NativeDatePicker';

--- a/packages/datepicker/src/componentVariables.scss
+++ b/packages/datepicker/src/componentVariables.scss
@@ -10,11 +10,16 @@
   --components-datepicker-calendar-border: #{$stroke-neutral};
   --components-datepicker-calendar-dateborder: #{$stroke-neutral};
   --components-datepicker-calendar-datefill-hover: #{$fill-secondary-hover-light};
-  --components-datepicker-calendar-datefill-selected: #{$fill-secondary-active-light};
+  --components-datepicker-calendar-datefill-range: #{$fill-selected-default-tint};
+  --components-datepicker-calendar-datefill-range-endpoint: #{$fill-primary-default-light};
+  --components-datepicker-calendar-datefill-range-endpoint-hover: #{$fill-background-contrast-lightalt-2};
+  --components-datepicker-calendar-datefill-range-hover: #{$fill-selected-hover-tint};
+  --components-datepicker-calendar-datefill-selected: #{$fill-primary-default-light};
   --components-datepicker-calendar-icon: #{$shape-accent};
   --components-datepicker-calendar-stroke-today: #{$stroke-highlight};
   --components-datepicker-calendar-text-accent: #{$text-accent};
   --components-datepicker-calendar-text-disabled: #{$text-neutralalt};
+  --components-datepicker-calendar-text-range-endpoint: #{$text-light};
   --components-datepicker-calendar-text-subdued: #{$text-subdued};
 }
 
@@ -24,10 +29,15 @@
   --components-datepicker-calendar-border: #{$stroke-colorless};
   --components-datepicker-calendar-dateborder: #{$stroke-darkalt};
   --components-datepicker-calendar-datefill-hover: #{$fill-selected-hover-dark};
-  --components-datepicker-calendar-datefill-selected: #{$fill-background-overlay-transparent};
+  --components-datepicker-calendar-datefill-range: #{$fill-selected-default-tintdark};
+  --components-datepicker-calendar-datefill-range-endpoint: #{$fill-primary-default-contrast};
+  --components-datepicker-calendar-datefill-range-endpoint-hover: #{$fill-primary-hover-contrast};
+  --components-datepicker-calendar-datefill-range-hover: #{$fill-selected-hover-tintdark};
+  --components-datepicker-calendar-datefill-selected: #{$fill-primary-default-contrast};
   --components-datepicker-calendar-icon: #{$shape-lightalt};
   --components-datepicker-calendar-stroke-today: #{$stroke-highlight};
   --components-datepicker-calendar-text-accent: #{$text-lightalt};
   --components-datepicker-calendar-text-disabled: #{$text-neutral};
+  --components-datepicker-calendar-text-range-endpoint: #{$text-dark};
   --components-datepicker-calendar-text-subdued: #{$text-darkalt};
 }

--- a/packages/datepicker/src/tests/RangeCalendar.test.tsx
+++ b/packages/datepicker/src/tests/RangeCalendar.test.tsx
@@ -1,0 +1,301 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CalendarDate } from '@internationalized/date';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+import { RangeCalendar } from '../DatePicker/RangeCalendar';
+
+expect.extend(toHaveNoViolations);
+
+// Locale is added on all tests to ensure a static testing basis
+// Time zone is set globally for Jest as UTC in ~/global-setup.js
+
+describe('RangeCalendar', () => {
+  const defaultProps = {
+    value: {
+      start: new CalendarDate(2023, 9, 10),
+      end: new CalendarDate(2023, 9, 20),
+    },
+    onChange: jest.fn(),
+    locale: 'en-GB',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders calendar with correct month and year', () => {
+    render(<RangeCalendar {...defaultProps} />);
+
+    expect(screen.getByRole('grid')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'September 2023' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders with null value', () => {
+    render(<RangeCalendar {...defaultProps} value={null} />);
+
+    expect(screen.getByRole('grid')).toBeInTheDocument();
+    expect(screen.getByRole('heading')).toBeInTheDocument();
+  });
+
+  test('marks selection start and end dates', () => {
+    const { container } = render(<RangeCalendar {...defaultProps} />);
+
+    const startCell = container.querySelector(
+      '.eds-datepicker__calendar__grid__cell--selection-start',
+    );
+    const endCell = container.querySelector(
+      '.eds-datepicker__calendar__grid__cell--selection-end',
+    );
+
+    expect(startCell).toBeInTheDocument();
+    expect(endCell).toBeInTheDocument();
+  });
+
+  test('marks dates within range with in-range class', () => {
+    const { container } = render(<RangeCalendar {...defaultProps} />);
+
+    const inRangeCells = container.querySelectorAll(
+      '.eds-datepicker__calendar__grid__cell--in-range',
+    );
+    expect(inRangeCells.length).toBeGreaterThan(0);
+  });
+
+  test('calls onChange when a range is selected', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(<RangeCalendar {...defaultProps} onChange={onChange} />);
+
+    // Range selection requires two clicks: start date then end date
+    const startCell = screen.getByRole('button', {
+      name: /^Wednesday, 6 September 2023/,
+    });
+    await user.click(startCell);
+
+    const endCell = screen.getByRole('button', {
+      name: /^Friday, 8 September 2023/,
+    });
+    await user.click(endCell);
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  test('navigates to previous month when left arrow is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<RangeCalendar {...defaultProps} />);
+
+    const leftArrow = screen.getByLabelText('Previous');
+    await user.click(leftArrow);
+
+    expect(
+      screen.getByRole('heading', { name: 'August 2023' }),
+    ).toBeInTheDocument();
+  });
+
+  test('navigates to next month when right arrow is clicked', async () => {
+    const user = userEvent.setup();
+
+    render(<RangeCalendar {...defaultProps} />);
+
+    const rightArrow = screen.getByLabelText('Next');
+    await user.click(rightArrow);
+
+    expect(
+      screen.getByRole('heading', { name: 'October 2023' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders two month headers when visibleDuration is 2 months', () => {
+    render(<RangeCalendar {...defaultProps} visibleDuration={{ months: 2 }} />);
+
+    const headings = screen.getAllByRole('heading');
+    expect(headings.length).toBe(2);
+    expect(headings[0]).toHaveTextContent('September 2023');
+    expect(headings[1]).toHaveTextContent('October 2023');
+  });
+
+  test('renders two grids when visibleDuration is 2 months', () => {
+    render(<RangeCalendar {...defaultProps} visibleDuration={{ months: 2 }} />);
+
+    const grids = screen.getAllByRole('grid');
+    expect(grids.length).toBe(2);
+  });
+
+  test('renders week numbers when showWeekNumbers is true', () => {
+    render(<RangeCalendar {...defaultProps} showWeekNumbers />);
+
+    expect(screen.getByText('uke')).toBeInTheDocument();
+    expect(screen.getByText('36')).toBeInTheDocument(); // Week 36 contains September 10, 2023
+  });
+
+  test('renders custom week number header', () => {
+    render(
+      <RangeCalendar
+        {...defaultProps}
+        showWeekNumbers
+        weekNumberHeader="Week"
+      />,
+    );
+
+    expect(screen.getByText('Week')).toBeInTheDocument();
+  });
+
+  test('disables dates before minDate', () => {
+    const minDate = new CalendarDate(2023, 9, 15);
+
+    render(<RangeCalendar {...defaultProps} minDate={minDate} />);
+
+    // Cells before minDate get aria-disabled="true" on the gridcell td
+    const disabledGridCell = screen.getByRole('gridcell', { name: '10' });
+    expect(disabledGridCell).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  test('disables dates after maxDate', () => {
+    const maxDate = new CalendarDate(2023, 9, 15);
+
+    render(<RangeCalendar {...defaultProps} maxDate={maxDate} />);
+
+    const disabledGridCell = screen.getByRole('gridcell', { name: '20' });
+    expect(disabledGridCell).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  test('applies custom classNameForDate function', () => {
+    const classNameForDate = jest.fn((date: CalendarDate) =>
+      date.day === 15 ? 'special-day' : '',
+    );
+
+    const { container } = render(
+      <RangeCalendar {...defaultProps} classNameForDate={classNameForDate} />,
+    );
+
+    expect(classNameForDate).toHaveBeenCalled();
+    expect(container.querySelector('.special-day')).toBeInTheDocument();
+  });
+
+  test('applies custom ariaLabelForDate function', () => {
+    const ariaLabelForDate = jest.fn((date: CalendarDate) =>
+      date.day === 15 ? 'special day' : '',
+    );
+
+    render(
+      <RangeCalendar {...defaultProps} ariaLabelForDate={ariaLabelForDate} />,
+    );
+
+    expect(ariaLabelForDate).toHaveBeenCalled();
+  });
+
+  test('calls onValidate on render', () => {
+    const onValidate = jest.fn();
+
+    render(<RangeCalendar {...defaultProps} onValidate={onValidate} />);
+
+    expect(onValidate).toHaveBeenCalled();
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(
+      <RangeCalendar {...defaultProps} className="custom-class" />,
+    );
+
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  test('applies custom style', () => {
+    const { container } = render(
+      <RangeCalendar {...defaultProps} style={{ backgroundColor: 'red' }} />,
+    );
+
+    expect(container.firstChild).toHaveStyle({ backgroundColor: 'red' });
+  });
+
+  test('renders with Norwegian locale', () => {
+    render(<RangeCalendar {...defaultProps} locale="no-NO" />);
+
+    expect(screen.getByRole('grid')).toBeInTheDocument();
+    expect(screen.getByText('ma')).toBeInTheDocument();
+    expect(screen.getByText('ti')).toBeInTheDocument();
+  });
+
+  test('renders with US locale', () => {
+    render(<RangeCalendar {...defaultProps} locale="en-US" />);
+
+    expect(screen.getByRole('grid')).toBeInTheDocument();
+    expect(screen.getByText('Su')).toBeInTheDocument();
+    expect(screen.getByText('Mo')).toBeInTheDocument();
+  });
+
+  test('applies custom navigation description', () => {
+    const navigationDescription = 'Custom navigation description';
+
+    render(
+      <RangeCalendar
+        {...defaultProps}
+        navigationDescription={navigationDescription}
+      />,
+    );
+
+    const hiddenDescription = screen.getByText(navigationDescription);
+    expect(hiddenDescription).toBeInTheDocument();
+  });
+
+  test('shows outside month dates when showOutsideMonth is true', () => {
+    const { container } = render(
+      <RangeCalendar {...defaultProps} showOutsideMonth />,
+    );
+
+    const outsideMonthCells = container.querySelectorAll(
+      '.eds-datepicker__calendar__grid__cell--outside-month--visible',
+    );
+    expect(outsideMonthCells.length).toBeGreaterThan(0);
+  });
+
+  test('hides outside month dates when showOutsideMonth is false', () => {
+    const { container } = render(
+      <RangeCalendar {...defaultProps} showOutsideMonth={false} />,
+    );
+
+    const outsideMonthVisibleCells = container.querySelectorAll(
+      '.eds-datepicker__calendar__grid__cell--outside-month--visible',
+    );
+    expect(outsideMonthVisibleCells.length).toBe(0);
+
+    const outsideMonthHiddenCells = container.querySelectorAll(
+      '.eds-datepicker__calendar__grid__cell--outside-month',
+    );
+    expect(outsideMonthHiddenCells.length).toBeGreaterThan(0);
+  });
+
+  test('allows selecting outside month dates when showOutsideMonth is true', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    const { container } = render(
+      <RangeCalendar {...defaultProps} showOutsideMonth onChange={onChange} />,
+    );
+
+    const outsideMonthCells = container.querySelectorAll(
+      '.eds-datepicker__calendar__grid__cell--outside-month--visible',
+    );
+    expect(outsideMonthCells.length).toBeGreaterThan(0);
+
+    // Range selection requires two clicks: click an outside-month cell as start, then another date as end
+    await user.click(outsideMonthCells[0]);
+    const endCell = screen.getByRole('button', {
+      name: /^Friday, 8 September 2023/,
+    });
+    await user.click(endCell);
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  test('has no accessibility violations', async () => {
+    const { container } = render(<RangeCalendar {...defaultProps} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/tokens/src/component.json
+++ b/packages/tokens/src/component.json
@@ -1713,10 +1713,34 @@
             "rootAlias": "Lavender/20"
           },
           {
+            "name": "Components/datepicker/Calendar/DateFill-Range",
+            "value": "#eaeaf1",
+            "var": "Fill/Selected/Default/Tint",
+            "rootAlias": "Blue/20"
+          },
+          {
+            "name": "Components/datepicker/Calendar/DateFill-Range-Endpoint",
+            "value": "#181c56",
+            "var": "Fill/Primary/Default/Light",
+            "rootAlias": "Lavender/90"
+          },
+          {
+            "name": "Components/datepicker/Calendar/DateFill-Range-Endpoint-Hover",
+            "value": "#292b6a",
+            "var": "Fill/Background/Contrast/LightAlt-2",
+            "rootAlias": "Blue/100"
+          },
+          {
+            "name": "Components/datepicker/Calendar/DateFill-Range-Hover",
+            "value": "#d9dae8",
+            "var": "Fill/Selected/Hover/Tint",
+            "rootAlias": "Blue/30"
+          },
+          {
             "name": "Components/datepicker/Calendar/DateFill-Selected",
-            "value": "#aeb7e2",
-            "var": "Fill/Secondary/Active/Light",
-            "rootAlias": "Lavender/40"
+            "value": "#181c56",
+            "var": "Fill/Primary/Default/Light",
+            "rootAlias": "Lavender/90"
           },
           {
             "name": "Components/datepicker/Calendar/Icon",
@@ -1741,6 +1765,12 @@
             "value": "#b6b8ba",
             "var": "Text/NeutralAlt",
             "rootAlias": "Grey/50"
+          },
+          {
+            "name": "Components/datepicker/Calendar/Text-Range-Endpoint",
+            "value": "#ffffff",
+            "var": "Text/Light",
+            "rootAlias": "White/Alpha-100"
           },
           {
             "name": "Components/datepicker/Calendar/Text-Subdued",
@@ -8005,10 +8035,34 @@
             "rootAlias": "Transparent/Ebony-Alpha35"
           },
           {
+            "name": "Components/datepicker/Calendar/DateFill-Range",
+            "value": "#525360",
+            "var": "Fill/Selected/Default/TintDark",
+            "rootAlias": "Ebony/70"
+          },
+          {
+            "name": "Components/datepicker/Calendar/DateFill-Range-Endpoint",
+            "value": "#aeb7e2",
+            "var": "Fill/Primary/Default/Contrast",
+            "rootAlias": "Lavender/40"
+          },
+          {
+            "name": "Components/datepicker/Calendar/DateFill-Range-Endpoint-Hover",
+            "value": "#c7cdeb",
+            "var": "Fill/Primary/Hover/Contrast",
+            "rootAlias": "Lavender/30"
+          },
+          {
+            "name": "Components/datepicker/Calendar/DateFill-Range-Hover",
+            "value": "#5e5f6c",
+            "var": "Fill/Selected/Hover/TintDark",
+            "rootAlias": "Ebony/65"
+          },
+          {
             "name": "Components/datepicker/Calendar/DateFill-Selected",
-            "value": "#e5e5e926",
-            "var": "Fill/Background/Overlay/Transparent",
-            "rootAlias": "Transparent/Ebony-Alpha15"
+            "value": "#aeb7e2",
+            "var": "Fill/Primary/Default/Contrast",
+            "rootAlias": "Lavender/40"
           },
           {
             "name": "Components/datepicker/Calendar/Icon",
@@ -8033,6 +8087,12 @@
             "value": "#6e6f73",
             "var": "Text/Neutral",
             "rootAlias": "Grey/70"
+          },
+          {
+            "name": "Components/datepicker/Calendar/Text-Range-Endpoint",
+            "value": "#08091c",
+            "var": "Text/Dark",
+            "rootAlias": "Ebony/100"
           },
           {
             "name": "Components/datepicker/Calendar/Text-Subdued",

--- a/packages/tokens/src/semantic.json
+++ b/packages/tokens/src/semantic.json
@@ -339,6 +339,18 @@
             "rootAlias": "Grey/30"
           },
           {
+            "name": "Fill/Selected/Default/Tint",
+            "value": "#eaeaf1",
+            "var": "Blue/20",
+            "rootAlias": "Blue/20"
+          },
+          {
+            "name": "Fill/Selected/Default/TintDark",
+            "value": "#525360",
+            "var": "Ebony/70",
+            "rootAlias": "Ebony/70"
+          },
+          {
             "name": "Fill/Selected/Hover/Contrast",
             "value": "#54568c",
             "var": "Blue/80",
@@ -361,6 +373,18 @@
             "value": "#edf0f2",
             "var": "Grey/20",
             "rootAlias": "Grey/20"
+          },
+          {
+            "name": "Fill/Selected/Hover/Tint",
+            "value": "#d9dae8",
+            "var": "Blue/30",
+            "rootAlias": "Blue/30"
+          },
+          {
+            "name": "Fill/Selected/Hover/TintDark",
+            "value": "#5e5f6c",
+            "var": "Ebony/65",
+            "rootAlias": "Ebony/65"
           },
           {
             "name": "Fill/Success/Accent",


### PR DESCRIPTION
## 💡 Hvorfor?
`Calendar`-komponenten manglet støtte for å velge datoperioder (fra- og til-dato), noe som er et behov i reiseplanlegging.

## 🔧 Hvordan?
- Lagt til ny `RangeCalendar`-komponent bygget på React Aria sin `useRangeCalendar` og `useRangeCalendarState`
- Implementert `RangeCalendarGrid` og `RangeCalendarCell` som håndterer range-state med `highlightedRange` fra React Aria
- Lagt til `visibleDuration`-prop for å vise flere måneder samtidig
- Lagt til CSS-variabler for range-styling (endepunkter, in-range, hover) med tilhørende fargetokens
- Lagt til semantiske fargetokens (`Fill/Selected/Default/Tint`, `TintDark`, `Fill/Selected/Hover/Tint`, `TintDark`) og komponent-tokens (`DateFill-Range`, `DateFill-Range-Endpoint`, `DateFill-Range-Endpoint-Hover`, `DateFill-Range-Hover`, `Text-Range-Endpoint`) i Figma og `@entur/tokens`
- Oppdatert `DateFill-Selected` til å bruke `Fill/Primary/Default` i stedet for `Fill/Secondary/Active`
- Overflow-datoer mellom synlige måneder i flervisning er visuelt dempet og ikke-interaktive, med seleksjonsklasser undertrykt slik at hver månedsvisning kun markerer sine egne datoer
- Eksportert `RangeCalendar` fra `@entur/datepicker`
- Lagt til komponentdokumentasjon og eksempler i docs-siden
- Lagt til enhetstester for `RangeCalendar`

## 🧩 Type endring

<!-- Kryss av det som passer -->

- [x] 🚀 Ny funksjonalitet
- [x] 📝 Dokumentasjonsoppdatering

## 🖼️ Skjermbilder
<img width="389" height="343" alt="Screenshot 2026-06-18 at 17 09 02" src="https://github.com/user-attachments/assets/7e7fb0e7-6a7e-48b0-8930-fb2f13b45ef6" />

<img width="699" height="341" alt="Screenshot 2026-06-18 at 17 09 10" src="https://github.com/user-attachments/assets/c15cb210-c501-4949-a669-8fa64c6fdf72" />

<img width="403" height="341" alt="image" src="https://github.com/user-attachments/assets/bd033171-bb4b-4faa-b7d1-d23237b14ef9" />

<!-- Legg ved hvis det hjelper å forstå endringen -->

## ✅ Sjekkliste

<!-- Kryss av når punktene er oppfylt -->

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

<!-- Hvordan er endringen testet og verifisert? -->

- [x] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden