### PR TITLE
fix(website): navigation, layout and footer updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ coverage
 /.claude/commands/*
 !/.claude/commands/commit.md
 !/.claude/commands/update-pr.md
+.playwright-mcp
 
 # GitHub
 # We might want to include skills later on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,11 @@ tsconfig.json
 package.json
 ```
 
+## HTML & Markup Principles
+
+- **Minimize wrappers:** Avoid unnecessary wrapper elements. Prefer composing via the `as` prop (e.g. `<GridItem as={Footer}>`) over adding wrapping `<div>`s.
+- **Semantic HTML5:** Use the correct element for the job — `<header>`, `<footer>`, `<nav>`, `<main>`, `<section>`, `<aside>`, etc. — rather than generic `<div>`s wherever semantics apply.
+
 ## Architecture & Patterns
 
 - **Polymorphic components:** Many components accept an `as` prop for element composition (e.g. Button can render as `<a>`)

--- a/apps/documentation/gatsby-browser.tsx
+++ b/apps/documentation/gatsby-browser.tsx
@@ -43,12 +43,7 @@ export const wrapPageElement: GatsbyBrowser['wrapPageElement'] = ({
   ];
   const normalizedPath = props.location.pathname.replace(/\/$/, '') || '/';
   if (CUSTOM_LAYOUT_PAGES.includes(normalizedPath)) return <>{children}</>;
-  const disableToc = Boolean(props.pageContext?.isComponentDoc);
-  return (
-    <DocLayout {...props} disableToc={disableToc}>
-      {children}
-    </DocLayout>
-  );
+  return <DocLayout {...props}>{children}</DocLayout>;
 };
 
 // Since Gatsby does automatic scroll restoration on navigation,

--- a/apps/documentation/gatsby-ssr.tsx
+++ b/apps/documentation/gatsby-ssr.tsx
@@ -45,12 +45,7 @@ export const wrapPageElement: GatsbySSR['wrapPageElement'] = ({
   const normalizedPath = props.location.pathname.replace(/\/$/, '') || '/';
   if (CUSTOM_LAYOUT_PAGES.includes(normalizedPath)) return <>{children}</>;
 
-  const disableToc = Boolean(props.pageContext?.isComponentDoc);
-  return (
-    <DocLayout {...props} disableToc={disableToc}>
-      {children}
-    </DocLayout>
-  );
+  return <DocLayout {...props}>{children}</DocLayout>;
 };
 
 export const onRenderBody: GatsbySSR['onRenderBody'] = ({

--- a/apps/documentation/src/components/Footer/Footer.scss
+++ b/apps/documentation/src/components/Footer/Footer.scss
@@ -1,52 +1,59 @@
+@use '@entur/tokens/dist/styles.scss' as eds;
 @use '@entur/utils/dist/breakpoints.scss' as breakpoint;
 
 .footer {
   position: relative;
-  background-color: var(--basecolors-frame-contrast);
-
-  &--light {
-    background-color: var(--basecolors-background-default);
-  }
-
-  &__mobile-item {
-    @include breakpoint.for-desktop {
-      display: none;
-    }
-  }
-  &__lead {
-    margin: 0 !important;
-    @include breakpoint.for-desktop {
-      width: 69%;
-    }
-  }
+  border-top: eds.$border-widths-default solid var(--designentur-header-default-divider);
 
   &__grid-container {
-    max-width: 1280px;
-    margin: 0 auto;
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-    padding-top: 2rem;
-    padding-bottom: 2rem;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+    padding: 2rem 1.5rem;
+
     @include breakpoint.for-desktop {
-      padding-top: 4.5rem;
-      padding-bottom: 2.5rem;
-    }
-    .eds-grid__container {
-      gap: 2rem;
-      @include breakpoint.for-desktop;
+      grid-template-columns: repeat(3, 1fr);
+      padding: 4rem 3rem 3rem;
     }
   }
+
+  &__social {
+    display: flex;
+    margin-top: 1rem;
+
+    .eds-icon-button {
+      width: unset;
+      height: unset;
+    }
+  }
+
   &__link {
     display: block;
     width: fit-content;
     margin-bottom: 1rem;
   }
+
+  &__description {
+    margin-top: 1rem;
+    margin-bottom: 0;
+  }
+
   &__entur-banner {
     display: flex;
-    justify-content: space-between;
-    max-width: 1328px;
-    margin: 0 auto;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
     border-top: 1px solid var(--designentur-footer-default-divider);
     padding: 1rem 1.5rem;
+
+    @include breakpoint.for-desktop {
+      padding-left: 3rem;
+      padding-right: 3rem;
+    }
+
+    &__item {
+      border-right: 1px solid var(--designentur-footer-default-divider);
+      padding-right: 0.5rem;
+    }
   }
 }

--- a/apps/documentation/src/components/Footer/Footer.scss
+++ b/apps/documentation/src/components/Footer/Footer.scss
@@ -4,6 +4,10 @@
   position: relative;
   background-color: var(--basecolors-frame-contrast);
 
+  &--light {
+    background-color: var(--basecolors-background-default);
+  }
+
   &__mobile-item {
     @include breakpoint.for-desktop {
       display: none;

--- a/apps/documentation/src/components/Footer/Footer.scss
+++ b/apps/documentation/src/components/Footer/Footer.scss
@@ -5,6 +5,10 @@
   position: relative;
   border-top: eds.$border-widths-default solid var(--designentur-header-default-divider);
 
+  &.eds-contrast {
+    border-top-color: var(--designentur-header-contrast-divider);
+  }
+
   &__grid-container {
     display: grid;
     grid-template-columns: 1fr;
@@ -41,6 +45,10 @@
     gap: 0.5rem;
     align-items: center;
     border-top: 1px solid var(--designentur-footer-default-divider);
+
+    .eds-contrast & {
+      border-top-color: var(--designentur-footer-contrast-divider);
+    }
     padding: 1rem 1.5rem;
 
     @include breakpoint.for-desktop {

--- a/apps/documentation/src/components/Footer/Footer.scss
+++ b/apps/documentation/src/components/Footer/Footer.scss
@@ -17,20 +17,16 @@
     }
   }
 
-  &__social {
-    display: flex;
-    margin-top: 1rem;
-
-    .eds-icon-button {
-      width: unset;
-      height: unset;
-    }
-  }
-
   &__link {
     display: block;
     width: fit-content;
     margin-bottom: 1rem;
+
+    :where(&) {
+      border: none;
+      background: none;
+      padding-inline: 0;
+    }
   }
 
   &__description {
@@ -49,11 +45,6 @@
     @include breakpoint.for-desktop {
       padding-left: 3rem;
       padding-right: 3rem;
-    }
-
-    &__item {
-      border-right: 1px solid var(--designentur-footer-default-divider);
-      padding-right: 0.5rem;
     }
   }
 }

--- a/apps/documentation/src/components/Footer/Footer.scss
+++ b/apps/documentation/src/components/Footer/Footer.scss
@@ -21,6 +21,7 @@
     display: block;
     width: fit-content;
     margin-bottom: 1rem;
+    text-align: start;
 
     :where(&) {
       border: none;

--- a/apps/documentation/src/components/Footer/Footer.tsx
+++ b/apps/documentation/src/components/Footer/Footer.tsx
@@ -1,17 +1,19 @@
 import React, { RefObject } from 'react';
-import { Link } from 'gatsby';
 import classNames from 'classnames';
-import { IconButton } from '@entur/button';
-import { FacebookIcon, InstagramIcon, LinkedinIcon } from '@entur/icons';
-import { Link as DSLink, Heading3 } from '@entur/typography';
+import {
+  CookieFilledIcon,
+  EmailIcon,
+  FigmaIcon,
+  GithubIcon,
+} from '@entur/icons';
+import { Link, Heading3 } from '@entur/typography';
 
 import { Logo } from '@components/Logo/Logo';
-import { Theme, useSettings } from '@providers/SettingsContext';
+import { useSettings } from '@providers/SettingsContext';
 
 import './Footer.scss';
 
 const Footer = ({
-  forceColorMode,
   footerRef,
   className,
   contrast,
@@ -29,83 +31,59 @@ const Footer = ({
     >
       <div className="footer__grid-container">
         <div>
-          <Logo colorMode={contrast ? "dark" : colorMode} />
+          <Logo colorMode={contrast ? 'dark' : colorMode} />
           <p className="footer__description">
             Entur Linje er designsystemet til Entur. Det hjelper designere og
             utviklere å bygge konsistente digitale tjenester.
           </p>
-          <div className="footer__social">
-            <IconButton
-              as="a"
-              href="https://www.facebook.com/entur.org/"
-              aria-label="Entur på Facebook (ekstern lenke)"
-            >
-              <FacebookIcon size="24" />
-            </IconButton>
-            <IconButton
-              as="a"
-              href="https://www.instagram.com/entur_as/"
-              aria-label="Entur på Instagram (ekstern lenke)"
-            >
-              <InstagramIcon size="24" />
-            </IconButton>
-            <IconButton
-              as="a"
-              href="https://www.linkedin.com/company/entur-as"
-              aria-label="Entur på LinkedIn (ekstern lenke)"
-            >
-              <LinkedinIcon size="24" />
-            </IconButton>
-          </div>
         </div>
         <nav aria-label="Om nettstedet">
           <Heading3 margin="bottom">Om nettstedet</Heading3>
-          <DSLink as={Link} to="/kom-i-gang" className="footer__link">
-            Kom i gang
-          </DSLink>
-          <DSLink as={Link} to="/identitet" className="footer__link">
-            Identitet
-          </DSLink>
-          <DSLink as={Link} to="/komponenter" className="footer__link">
-            Komponenter
-          </DSLink>
-          <DSLink as={Link} to="/tokens" className="footer__link">
-            Tokens
-          </DSLink>
-          <DSLink as={Link} to="/universell-utforming" className="footer__link">
-            Universell utforming
-          </DSLink>
-          <DSLink
+          <Link
             href="https://uustatus.no/nb/erklaringer/publisert/7c5b8f79-7c24-4144-8084-afde897edded"
             className="footer__link"
           >
             Tilgjengelighetserklæring
-          </DSLink>
+          </Link>
+          <Link
+            as="button"
+            type="button"
+            onClick={() => window.__ucCmp.showFirstLayer()}
+            className="footer__link"
+          >
+            <CookieFilledIcon inline aria-hidden="true" /> Endre hvilken
+            informasjon vi får lagre
+          </Link>
         </nav>
         <div>
           <Heading3 margin="bottom">Kom i kontakt med oss</Heading3>
-          <DSLink
+          <Link
             href="https://entur.slack.com/archives/C899QSPB7"
             className="footer__link"
           >
             #talk-designsystem på Slack
-          </DSLink>
-          <DSLink
+          </Link>
+          <Link
             href="https://github.com/entur/design-system"
             className="footer__link"
           >
-            GitHub
-          </DSLink>
-          <DSLink
+            <GithubIcon inline aria-hidden="true" /> GitHub
+          </Link>
+          <Link
+            href="https://www.figma.com/files/911324992315480847/team/903289363381269328"
+            className="footer__link"
+          >
+            <FigmaIcon inline aria-hidden="true" /> Figma (krever innlogging)
+          </Link>
+          <Link
             href="mailto:teamdesignsystem@entur.org"
             className="footer__link"
           >
-            teamdesignsystem@entur.org
-          </DSLink>
+            <EmailIcon inline aria-hidden="true" /> teamdesignsystem@entur.org
+          </Link>
         </div>
       </div>
       <div className="footer__entur-banner">
-        <span className="eds-label footer__entur-banner__item">Entur.no</span>
         <span className="eds-label">© {new Date().getFullYear()} Entur AS</span>
       </div>
     </footer>

--- a/apps/documentation/src/components/Footer/Footer.tsx
+++ b/apps/documentation/src/components/Footer/Footer.tsx
@@ -2,15 +2,8 @@ import React, { RefObject } from 'react';
 import { Link } from 'gatsby';
 import classNames from 'classnames';
 import { IconButton } from '@entur/button';
-import { GridContainer, GridItem } from '@entur/grid';
-import {
-  FacebookIcon,
-  InstagramIcon,
-  LinkedinIcon,
-  TwitterIcon,
-} from '@entur/icons';
-import { Link as DSLink, Heading3, LeadParagraph } from '@entur/typography';
-import { colors, space } from '@entur/tokens';
+import { FacebookIcon, InstagramIcon, LinkedinIcon } from '@entur/icons';
+import { Link as DSLink, Heading3 } from '@entur/typography';
 
 import { Logo } from '@components/Logo/Logo';
 import { Theme, useSettings } from '@providers/SettingsContext';
@@ -21,137 +14,102 @@ const Footer = ({
   forceColorMode,
   footerRef,
   className,
+  contrast,
+  ...rest
 }: {
-  forceColorMode?: Theme;
-  footerRef?: RefObject<HTMLDivElement>;
-  className?: string;
-}) => {
-  const year = new Date();
+  footerRef?: RefObject<HTMLElement>;
+  contrast?: boolean;
+} & React.ComponentPropsWithoutRef<'footer'>) => {
   const { colorMode } = useSettings();
   return (
-    <div ref={footerRef} className={classNames('footer', className)}>
-      <GridContainer spacing="extraLarge" className="footer__grid-container">
-        <GridItem small={12} medium={6} large={4}>
-          <LeadParagraph margin="none" className="footer__lead">
-            Entur leverer digitale tjenester til Norges kollektivtransport.
-          </LeadParagraph>
-        </GridItem>
-        <GridItem small={12} medium={6} large={4}>
-          <Heading3 margin="bottom">Sidestruktur</Heading3>
-          <LinkWrapper to="/kom-i-gang" className="footer__link">
+    <footer
+      ref={footerRef}
+      className={classNames('footer', className, { 'eds-contrast': contrast })}
+      {...rest}
+    >
+      <div className="footer__grid-container">
+        <div>
+          <Logo colorMode={contrast ? "dark" : colorMode} />
+          <p className="footer__description">
+            Entur Linje er designsystemet til Entur. Det hjelper designere og
+            utviklere å bygge konsistente digitale tjenester.
+          </p>
+          <div className="footer__social">
+            <IconButton
+              as="a"
+              href="https://www.facebook.com/entur.org/"
+              aria-label="Entur på Facebook (ekstern lenke)"
+            >
+              <FacebookIcon size="24" />
+            </IconButton>
+            <IconButton
+              as="a"
+              href="https://www.instagram.com/entur_as/"
+              aria-label="Entur på Instagram (ekstern lenke)"
+            >
+              <InstagramIcon size="24" />
+            </IconButton>
+            <IconButton
+              as="a"
+              href="https://www.linkedin.com/company/entur-as"
+              aria-label="Entur på LinkedIn (ekstern lenke)"
+            >
+              <LinkedinIcon size="24" />
+            </IconButton>
+          </div>
+        </div>
+        <nav aria-label="Om nettstedet">
+          <Heading3 margin="bottom">Om nettstedet</Heading3>
+          <DSLink as={Link} to="/kom-i-gang" className="footer__link">
             Kom i gang
-          </LinkWrapper>
-          <LinkWrapper to="/identitet" className="footer__link">
+          </DSLink>
+          <DSLink as={Link} to="/identitet" className="footer__link">
             Identitet
-          </LinkWrapper>
-          <LinkWrapper to="/komponenter" className="footer__link">
+          </DSLink>
+          <DSLink as={Link} to="/komponenter" className="footer__link">
             Komponenter
-          </LinkWrapper>
-          <LinkWrapper to="/tokens" className="footer__link">
+          </DSLink>
+          <DSLink as={Link} to="/tokens" className="footer__link">
             Tokens
-          </LinkWrapper>
-          <LinkWrapper
-            to="/identitet/introduksjon/stil-og-tone"
+          </DSLink>
+          <DSLink as={Link} to="/universell-utforming" className="footer__link">
+            Universell utforming
+          </DSLink>
+          <DSLink
+            href="https://uustatus.no/nb/erklaringer/publisert/7c5b8f79-7c24-4144-8084-afde897edded"
             className="footer__link"
           >
-            Stil og tone
-          </LinkWrapper>
-          <LinkWrapper to="/universell-utforming" className="footer__link">
-            Universell utforming
-          </LinkWrapper>
-        </GridItem>
-        <GridItem small={12} medium={6} large={4}>
-          <Heading3 margin="bottom">Informasjon</Heading3>
-          <div className="footer__link">
-            <LinkWrapper
-              external
-              href="https://entur.slack.com/archives/C899QSPB7"
-            >
-              #talk-designsystem på Slack
-            </LinkWrapper>
-          </div>
-          <div className="footer__link">
-            <LinkWrapper
-              external
-              href="https://uustatus.no/nb/erklaringer/publisert/7c5b8f79-7c24-4144-8084-afde897edded"
-            >
-              Tilgjengelighetserklæring
-            </LinkWrapper>
-          </div>
-          <SocialMediaLinks />
-        </GridItem>
-      </GridContainer>
-      <div className="footer__entur-banner">
-        <Logo colorMode={forceColorMode || colorMode} />
-        <div style={{ float: 'right', position: 'relative', top: '0.9rem' }}>
-          <span
-            className="eds-label"
-            style={{
-              borderRight: `1px solid ${colors.greys.grey70}`,
-              paddingRight: space.small,
-            }}
+            Tilgjengelighetserklæring
+          </DSLink>
+        </nav>
+        <div>
+          <Heading3 margin="bottom">Kom i kontakt med oss</Heading3>
+          <DSLink
+            href="https://entur.slack.com/archives/C899QSPB7"
+            className="footer__link"
           >
-            Entur.no
-          </span>
-          <span className="eds-label" style={{ paddingLeft: space.small }}>
-            © {year.getFullYear()} Entur AS
-          </span>
+            #talk-designsystem på Slack
+          </DSLink>
+          <DSLink
+            href="https://github.com/entur/design-system"
+            className="footer__link"
+          >
+            GitHub
+          </DSLink>
+          <DSLink
+            href="mailto:teamdesignsystem@entur.org"
+            className="footer__link"
+          >
+            teamdesignsystem@entur.org
+          </DSLink>
         </div>
       </div>
-    </div>
-  );
-};
-
-const SocialMediaLinks = ({ style }: { style?: React.CSSProperties }) => {
-  return (
-    <>
-      <Heading3 style={style} margin="bottom">
-        Følg oss på
-      </Heading3>
-      <div style={{ display: 'flex' }}>
-        <IconButton
-          as="a"
-          style={{ width: 'unset', height: 'unset' }}
-          href="https://www.facebook.com/entur.org/"
-          aria-label="Entur på Facebook (ekstern lenke)"
-        >
-          <FacebookIcon size="24" />
-        </IconButton>
-        <IconButton
-          as="a"
-          style={{ width: 'unset', height: 'unset' }}
-          href="https://www.instagram.com/entur_as/"
-          aria-label="Entur på Instagram (ekstern lenke)"
-        >
-          <InstagramIcon size="24" />
-        </IconButton>
-        <IconButton
-          as="a"
-          style={{ width: 'unset', height: 'unset' }}
-          href="https://twitter.com/entur_as"
-          aria-label="Entur på Twitter (ekstern lenke)"
-        >
-          <TwitterIcon size="24" />
-        </IconButton>
-        <IconButton
-          as="a"
-          style={{ width: 'unset', height: 'unset' }}
-          href="https://www.linkedin.com/company/entur-as"
-          aria-label="Entur på LinkedIn (ekstern lenke)"
-        >
-          <LinkedinIcon size="24" />
-        </IconButton>
+      <div className="footer__entur-banner">
+        <span className="eds-label footer__entur-banner__item">Entur.no</span>
+        <span className="eds-label">© {new Date().getFullYear()} Entur AS</span>
       </div>
-    </>
+    </footer>
   );
 };
-
-function LinkWrapper(props: any) {
-  return (
-    <DSLink as={Link} {...props}>
-      {props.children}
-    </DSLink>
-  );
-}
 
 export default Footer;

--- a/apps/documentation/src/components/Footer/Footer.tsx
+++ b/apps/documentation/src/components/Footer/Footer.tsx
@@ -1,5 +1,6 @@
 import React, { RefObject } from 'react';
 import { Link } from 'gatsby';
+import classNames from 'classnames';
 import { IconButton } from '@entur/button';
 import { GridContainer, GridItem } from '@entur/grid';
 import {
@@ -19,14 +20,16 @@ import './Footer.scss';
 const Footer = ({
   forceColorMode,
   footerRef,
+  className,
 }: {
   forceColorMode?: Theme;
   footerRef?: RefObject<HTMLDivElement>;
+  className?: string;
 }) => {
   const year = new Date();
   const { colorMode } = useSettings();
   return (
-    <div ref={footerRef} className="footer">
+    <div ref={footerRef} className={classNames('footer', className)}>
       <GridContainer spacing="extraLarge" className="footer__grid-container">
         <GridItem small={12} medium={6} large={4}>
           <LeadParagraph margin="none" className="footer__lead">

--- a/apps/documentation/src/components/Footer/Footer.tsx
+++ b/apps/documentation/src/components/Footer/Footer.tsx
@@ -48,7 +48,7 @@ const Footer = ({
           <Link
             as="button"
             type="button"
-            onClick={() => window.__ucCmp.showFirstLayer()}
+            onClick={() => window.__ucCmp?.showFirstLayer()}
             className="footer__link"
           >
             <CookieFilledIcon inline aria-hidden="true" /> Endre hvilken

--- a/apps/documentation/src/components/Navigations/SideNavigation/MobileSideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/MobileSideNavigation.tsx
@@ -10,7 +10,6 @@ import SideNavigation from './SideNavigation';
 import './SideNavigation.scss';
 
 type MobileMenuProps = {
-  className?: string;
   menuItems: MenuItem[];
   openSidebar: boolean;
   setOpenSidebar: React.Dispatch<React.SetStateAction<boolean>>;

--- a/apps/documentation/src/components/Navigations/SideNavigation/MobileSideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/MobileSideNavigation.tsx
@@ -31,6 +31,7 @@ const MobileSideNavigation: React.FC<MobileMenuProps> = ({
         open={openSidebar}
         onDismiss={() => setOpenSidebar(false)}
         title="Navigasjonsmeny"
+        overlay
         className="side-navigation__drawer"
       >
         <SideNavigation

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.scss
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.scss
@@ -30,13 +30,11 @@
   }
 
   &-wrapper {
-    position: fixed;
-    z-index: eds.$z-indexes-sticky;
-    top: variables.$navbar-height;
-    height: calc(100dvh - variables.$navbar-height);
-    overflow-y: scroll;
-    width: variables.$side-navigation-width--large-desktop;
-    background: var(--components-menu-sidenavigation-standard-background);
+    position: sticky;
+    top: var(--navbar-height);
+    max-height: calc(100dvh - var(--navbar-height));
+    overflow-y: auto;
+    width: 100%;
   }
 
   &__drawer {
@@ -71,6 +69,10 @@
       z-index: eds.$z-indexes-toast;
       transform: scale(1.25);
       transition: transform eds.$timings-medium ease-in-out;
+
+      @media screen and (min-width: map.get(variables.$breakpoints, 'tablet')) {
+        display: none;
+      }
 
       &:focus-visible {
         outline: eds.$outlines-focus;

--- a/apps/documentation/src/components/Navigations/TableOfContent/MdxTableOfContent.tsx
+++ b/apps/documentation/src/components/Navigations/TableOfContent/MdxTableOfContent.tsx
@@ -15,7 +15,6 @@ interface TableOfContentQuery {
     nodes: {
       frontmatter: {
         route: string;
-        removeToc: boolean;
       };
       tableOfContents: {
         items?: MdxHeading[];
@@ -49,7 +48,6 @@ const MdxTableOfContent = () => {
         nodes {
           frontmatter {
             route
-            removeToc
           }
           tableOfContents
         }
@@ -64,7 +62,7 @@ const MdxTableOfContent = () => {
         removeTrailingSlash(node.frontmatter.route) ===
         removeTrailingSlash(pathname),
     );
-    if (!currentDoc || currentDoc.frontmatter.removeToc) return [];
+    if (!currentDoc) return [];
     return flattenHeadings(currentDoc.tableOfContents?.items);
   }, [data, pathname]);
 

--- a/apps/documentation/src/components/Navigations/TableOfContent/SanityTableOfContent.tsx
+++ b/apps/documentation/src/components/Navigations/TableOfContent/SanityTableOfContent.tsx
@@ -39,10 +39,14 @@ const extractHeadingsFromPortableText = (content: any): TocHeading[] => {
 const SanityTableOfContent: React.FC<SanityTableOfContentProps> = ({
   content,
 }) => {
-  const headings = useMemo(
-    () => extractHeadingsFromPortableText(content),
-    [content],
-  );
+  const headings = useMemo(() => {
+    const seen = new Set<string>();
+    return extractHeadingsFromPortableText(content).filter(h => {
+      if (seen.has(h.id)) return false;
+      seen.add(h.id);
+      return true;
+    });
+  }, [content]);
 
   return <TableOfContent headings={headings} />;
 };

--- a/apps/documentation/src/components/Navigations/TableOfContent/TableOfContent.tsx
+++ b/apps/documentation/src/components/Navigations/TableOfContent/TableOfContent.tsx
@@ -156,7 +156,7 @@ const TableOfContent: React.FC<TableOfContentProps> = ({ headings }) => {
   return (
     <>
       <nav className="table-of-content-sidebar" aria-label="Innhold">
-        <Heading4 as="h2" style={{ margin: 0 }}>
+        <Heading4 as="h2" style={{ margin: 0, marginBlockEnd: '1rem' }}>
           Innhold
         </Heading4>
         <TocList

--- a/apps/documentation/src/components/Navigations/TopNavigation/MobileTopNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/TopNavigation/MobileTopNavigation.tsx
@@ -31,7 +31,7 @@ const MobileTopNavigation: React.FC<MobileTopNavigationProps> = ({
 
   return (
     <nav
-      className={classNames('mobile-topnav', {
+      className={classNames('mobile-topnav', className, {
         'eds-contrast':
           typeof window !== 'undefined' && window.location.pathname === '/',
       })}

--- a/apps/documentation/src/components/Navigations/TopNavigation/MobileTopNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/TopNavigation/MobileTopNavigation.tsx
@@ -4,10 +4,6 @@ import classNames from 'classnames';
 import { Location } from '@reach/router';
 
 import { useContrast } from '@entur/layout';
-import { IconButton } from '@entur/button';
-import { GithubIcon } from '@entur/icons';
-import { Tooltip } from '@entur/tooltip';
-
 import SettingsPanel from '../SettingsPanel';
 import { useSettings } from '@providers/SettingsContext';
 import { Search } from '@components/Search/Search';
@@ -45,16 +41,6 @@ const MobileTopNavigation: React.FC<MobileTopNavigationProps> = ({
           />
         </Link>
         <Search />
-        <Tooltip content="Entur Linje på GitHub">
-          <IconButton
-            className="top-navigation__github"
-            aria-label="Entur Linje på Github"
-            as="a"
-            href="https://github.com/entur/design-system"
-          >
-            <GithubIcon aria-hidden />
-          </IconButton>
-        </Tooltip>
         <SettingsPanel />
       </div>
       <div className="mobile-topnav__links mobile-topnav__links__scroll-gradient">

--- a/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.scss
+++ b/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use '../../../styles/variables' as variables;
 @use '@entur/tokens/dist/styles.scss' as eds;
 @use '@entur/utils/dist/breakpoints.scss' as *;
@@ -7,7 +8,10 @@
   align-items: center;
   position: fixed;
   top: 0;
-  left: 0;
+
+  @media screen and (min-width: map.get(variables.$breakpoints, 'tablet')) {
+    position: sticky;
+  }
   overflow-x: initial;
   padding-inline: eds.$space-extra-large2;
   justify-content: space-between;

--- a/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.scss
+++ b/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.scss
@@ -38,12 +38,6 @@
       outline-offset: eds.$outline-offsets-focus;
     }
   }
-  &__github {
-    display: flex;
-    gap: eds.$space-extra-small;
-    margin-left: eds.$space-small;
-  }
-
   nav {
     display: contents;
   }

--- a/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.scss
+++ b/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.scss
@@ -44,6 +44,10 @@
     margin-left: eds.$space-small;
   }
 
+  nav {
+    display: contents;
+  }
+
   .searchmodal__button {
     margin-left: auto;
   }

--- a/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.scss
+++ b/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.scss
@@ -39,7 +39,7 @@
     }
   }
   nav {
-    display: contents;
+    display: flex;
   }
 
   .searchmodal__button {

--- a/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.tsx
@@ -18,7 +18,7 @@ import logoDark from '@media/logo/logoDark.svg';
 
 import './TopNavigation.scss';
 
-const TopNavigation = () => {
+const TopNavigation = ({ className, ...rest }: React.ComponentPropsWithoutRef<'nav'>) => {
   const { colorMode } = useSettings();
   const isContrast = useContrast();
   const location = useLocation();
@@ -32,10 +32,11 @@ const TopNavigation = () => {
       window.matchMedia('(prefers-color-scheme: dark)').matches);
   return (
     <nav
-      className={classNames('top-navigation', {
+      className={classNames('top-navigation', className, {
         'top-navigation--frontpage eds-contrast': isFrontpage,
       })}
       aria-label="Navigasjon, hovedseksjoner"
+      {...rest}
     >
       <Link to="/" className="top-navigation__logo">
         <img

--- a/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.tsx
@@ -3,11 +3,8 @@ import { Link } from 'gatsby';
 import { Location, useLocation } from '@reach/router';
 import classNames from 'classnames';
 
-import { IconButton } from '@entur/button';
-import { GithubIcon } from '@entur/icons';
 import { useContrast } from '@entur/layout';
 import { TopNavigationItem } from '@entur/menu';
-import { Tooltip } from '@entur/tooltip';
 
 import SettingsPanel from '../SettingsPanel';
 import { useSettings } from '@providers/SettingsContext';
@@ -58,16 +55,6 @@ const TopNavigation = ({
         <NavItem to="/universell-utforming">Universell utforming</NavItem>
       </nav>
       <Search />
-      <Tooltip content="Entur Linje på GitHub">
-        <IconButton
-          className="top-navigation__github"
-          aria-label="Entur Linje på Github"
-          as="a"
-          href="https://github.com/entur/design-system"
-        >
-          <GithubIcon aria-hidden />
-        </IconButton>
-      </Tooltip>
       <SettingsPanel />
     </header>
   );

--- a/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/TopNavigation/TopNavigation.tsx
@@ -18,7 +18,10 @@ import logoDark from '@media/logo/logoDark.svg';
 
 import './TopNavigation.scss';
 
-const TopNavigation = ({ className, ...rest }: React.ComponentPropsWithoutRef<'nav'>) => {
+const TopNavigation = ({
+  className,
+  ...rest
+}: React.ComponentPropsWithoutRef<'header'>) => {
   const { colorMode } = useSettings();
   const isContrast = useContrast();
   const location = useLocation();
@@ -31,11 +34,10 @@ const TopNavigation = ({ className, ...rest }: React.ComponentPropsWithoutRef<'n
       typeof window !== 'undefined' &&
       window.matchMedia('(prefers-color-scheme: dark)').matches);
   return (
-    <nav
+    <header
       className={classNames('top-navigation', className, {
         'top-navigation--frontpage eds-contrast': isFrontpage,
       })}
-      aria-label="Navigasjon, hovedseksjoner"
       {...rest}
     >
       <Link to="/" className="top-navigation__logo">
@@ -46,13 +48,15 @@ const TopNavigation = ({ className, ...rest }: React.ComponentPropsWithoutRef<'n
           alt="Entur logo, klikk for å gå til startsiden"
         />
       </Link>
-      <NavItem to="/kom-i-gang">Kom i gang</NavItem>
-      <NavItem to="/identitet">Identitet</NavItem>
-      <NavItem to="/komponenter">Komponenter</NavItem>
-      <NavItem to="/tokens">Tokens</NavItem>
-      <NavItem to="/monster">Mønster</NavItem>
-      <NavItem to="/ressurser">Ressurser</NavItem>
-      <NavItem to="/universell-utforming">Universell utforming</NavItem>
+      <nav aria-label="Navigasjon, hovedseksjoner">
+        <NavItem to="/kom-i-gang">Kom i gang</NavItem>
+        <NavItem to="/identitet">Identitet</NavItem>
+        <NavItem to="/komponenter">Komponenter</NavItem>
+        <NavItem to="/tokens">Tokens</NavItem>
+        <NavItem to="/monster">Mønster</NavItem>
+        <NavItem to="/ressurser">Ressurser</NavItem>
+        <NavItem to="/universell-utforming">Universell utforming</NavItem>
+      </nav>
       <Search />
       <Tooltip content="Entur Linje på GitHub">
         <IconButton
@@ -65,7 +69,7 @@ const TopNavigation = ({ className, ...rest }: React.ComponentPropsWithoutRef<'n
         </IconButton>
       </Tooltip>
       <SettingsPanel />
-    </nav>
+    </header>
   );
 };
 

--- a/apps/documentation/src/components/PageHeader/BasePageHeader.tsx
+++ b/apps/documentation/src/components/PageHeader/BasePageHeader.tsx
@@ -5,7 +5,7 @@ import { ComponentIcon, GithubIcon, SourceCodeIcon } from '@entur/icons';
 import { ActionChip } from '@entur/chip';
 import { Flex, Grid } from '@entur/layout/beta';
 import { Badge } from '@entur/layout';
-import { sanitizeEnturPackageName } from 'src/utils/utils';
+import { isBetaTag, sanitizeEnturPackageName } from 'src/utils/utils';
 import { NpmTag } from './NpmTag';
 import './PageHeader.scss';
 
@@ -51,7 +51,7 @@ export const BasePageHeader: React.FC<BasePageHeaderProps> = ({
           </Heading1>
           {tag && (
             <Badge
-              variant={tag === 'beta' ? 'warning' : 'positive'}
+              variant={isBetaTag(tag) ? 'warning' : 'positive'}
               type="status"
             >
               {tag}
@@ -90,7 +90,7 @@ export const BasePageHeader: React.FC<BasePageHeaderProps> = ({
                   className="ds-npm-tag"
                   href={`https://github.com/entur/design-system/tree/main/packages/${sanitizeEnturPackageName(
                     npmPackage,
-                  )}${tag === 'beta' ? '/src/beta' : ''}`}
+                  )}${isBetaTag(tag) ? '/src/beta' : ''}`}
                 >
                   <ActionChip>
                     Github <GithubIcon aria-hidden="true" />

--- a/apps/documentation/src/components/PageHeader/NpmTag.tsx
+++ b/apps/documentation/src/components/PageHeader/NpmTag.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { graphql, useStaticQuery } from 'gatsby';
 import { Tag } from '@entur/layout';
 import { Flex } from '@entur/layout/beta';
-import { sanitizeEnturPackageName } from 'src/utils/utils';
+import { isBetaTag, sanitizeEnturPackageName } from 'src/utils/utils';
 
 import './NpmTag.scss';
 
@@ -31,7 +31,7 @@ export const NpmTag: React.FC<{ packageName: string; tag?: string }> = ({
     <Flex gap="s">
       <Tag>
         {fullPackageName}
-        {tag === 'beta' ? '/beta' : ''}
+        {isBetaTag(tag) ? '/beta' : ''}
       </Tag>
       <Tag>v{currentPackage?.version}</Tag>
     </Flex>

--- a/apps/documentation/src/components/PageHeader/PageHeader.tsx
+++ b/apps/documentation/src/components/PageHeader/PageHeader.tsx
@@ -1,99 +1,33 @@
 import React from 'react';
-import { useLocation } from '@reach/router';
-import { graphql, useStaticQuery } from 'gatsby';
-import { Heading1, Label, LeadParagraph } from '@entur/typography';
-import { useSettings } from '@providers/SettingsContext';
-import { PackageChangelog } from './PackageChangelog';
-import { NpmChip } from './NpmChip';
-import { CopyableText } from '@entur/alert';
-import './PageHeader.scss';
+import { BasePageHeader } from './BasePageHeader';
 
-type Props = {
-  category?: string;
-  forceNoLeadText?: boolean;
+type Frontmatter = {
   title?: string;
+  description?: string;
+  parent?: string;
+  menu?: string;
+  npmPackage?: string;
+  tag?: string;
+  figmaLink?: string;
 };
 
-const PageHeader: React.FC<Props> = ({ title, category, forceNoLeadText }) => {
-  const location = useLocation();
-  const data = useStaticQuery(graphql`
-    query {
-      allMdx {
-        nodes {
-          frontmatter {
-            title
-            npmPackage
-            route
-            description
-            parent
-            menu
-          }
-        }
-      }
-    }
-  `);
+type Props = {
+  frontmatter?: Frontmatter;
+};
 
-  const currentDoc = data.allMdx.nodes.find(node =>
-    new RegExp(`^${node.frontmatter.route}$`).test(location.pathname),
-  );
-
-  const npmPackage = currentDoc?.frontmatter?.npmPackage || '';
-
-  const categoryToShow = category || currentDoc?.frontmatter.menu || '';
-  const titleToShow = title || currentDoc?.frontmatter?.title || '';
-  const { packageManager, userType } = useSettings();
-  const leadText = forceNoLeadText
-    ? null
-    : currentDoc?.frontmatter?.description;
-  const installText =
-    packageManager === 'yarn'
-      ? `yarn add @entur/${npmPackage}`
-      : `npm install @entur/${npmPackage}`;
-  const cssImport = `@import '@entur/${npmPackage}/dist/styles.css';`;
+const PageHeader: React.FC<Props> = ({ frontmatter }) => {
+  if (!frontmatter?.title) return null;
 
   return (
-    <header>
-      {categoryToShow && (
-        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-          <Label
-            as="div"
-            style={{ letterSpacing: '1px', marginBottom: '0.5rem' }}
-          >
-            {categoryToShow.toUpperCase()}
-          </Label>
-          {npmPackage && userType === 'developer' && (
-            <span style={{ float: 'right' }}>
-              <PackageChangelog packageName={npmPackage} />
-            </span>
-          )}
-        </div>
-      )}
-      <div style={{ display: 'flex', alignItems: 'center' }}>
-        <Heading1 margin="none" style={{ marginRight: '1rem' }}>
-          {titleToShow}
-        </Heading1>
-        {npmPackage && userType === 'developer' && (
-          <NpmChip packageName={npmPackage} />
-        )}
-      </div>
-      {leadText && <LeadParagraph>{leadText}</LeadParagraph>}
-      {npmPackage && userType === 'developer' && (
-        <div className="page-header__import-wrapper">
-          <CopyableText
-            successMessage="Innstalleringstekst ble kopiert til utklippstavla."
-            className="page-header__import-wrapper__copy-button"
-          >
-            {installText}
-          </CopyableText>
-          <CopyableText
-            successMessage="CSS-importen ble kopiert til utklippstavla."
-            className="page-header__import-wrapper__copy-button"
-          >
-            {cssImport}
-          </CopyableText>
-        </div>
-      )}
-    </header>
+    <BasePageHeader
+      title={frontmatter.title}
+      category={frontmatter.parent}
+      subcategory={frontmatter.menu}
+      description={frontmatter.description}
+      npmPackage={frontmatter.npmPackage}
+      tag={frontmatter.tag}
+      figmaLink={frontmatter.figmaLink}
+    />
   );
 };
 

--- a/apps/documentation/src/layouts/DocLayout.tsx
+++ b/apps/documentation/src/layouts/DocLayout.tsx
@@ -3,6 +3,7 @@ import { PageProps } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
 import { MDXComponents } from 'mdx/types';
 import { SkipToContent } from '@entur/a11y';
+import { Grid, GridItem, LayoutProvider } from '@entur/layout/beta';
 import Footer from '@components/Footer/Footer';
 import TopNavigationLayout from './TopNavigationLayout';
 import components from '../utils/MdxProvider-utils';
@@ -11,37 +12,39 @@ import PageHeader from '@components/PageHeader/PageHeader';
 import MdxTableOfContent from '@components/Navigations/TableOfContent/MdxTableOfContent';
 import { scrollToHashOnLoad } from '../utils/scrollUtils';
 
-const DocLayout = ({
-  children,
-  location,
-  disableToc = false,
-  pageContext,
-}: PageProps & { disableToc?: boolean }) => {
+const DocLayout = ({ children, location, pageContext }: PageProps) => {
   useEffect(() => {
     scrollToHashOnLoad();
   }, [location.pathname, location.hash]);
 
   const frontmatter = (pageContext as any)?.frontmatter;
-  const showHeader = !disableToc && !frontmatter?.removeHeader;
+  const showHeader = !frontmatter?.removeHeader;
 
   return (
     <>
       <SkipToContent mainId="main">Gå til hovedinnhold</SkipToContent>
-      <TopNavigationLayout />
-      <SideNavigationLayout location={location} />
-
-      <div className="page">
-        <div className="site-content">
-          <main id="main">
-            {showHeader && <PageHeader />}
-            {!disableToc && <MdxTableOfContent />}
+      <LayoutProvider breakpoints={{ m: 960 }}>
+        <Grid
+          className="doc-layout"
+          templateColumns={{ s: '1fr', m: '18rem 1fr' }}
+          gap="none"
+        >
+          <GridItem as={TopNavigationLayout} colSpan={{ s: 1, m: '1 / -1' }} />
+          <GridItem
+            as={SideNavigationLayout}
+            location={location}
+            className="side-nav-column"
+          />
+          <GridItem as="main" id="main" className="page">
+            {showHeader && <PageHeader frontmatter={frontmatter} />}
+            <MdxTableOfContent />
             <MDXProvider components={components as MDXComponents}>
               {children}
             </MDXProvider>
-          </main>
-        </div>
-        <Footer className="footer--light" />
-      </div>
+          </GridItem>
+          <GridItem as={Footer} colSpan={{ s: 1, m: '1 / -1' }} />
+        </Grid>
+      </LayoutProvider>
     </>
   );
 };

--- a/apps/documentation/src/layouts/DocLayout.tsx
+++ b/apps/documentation/src/layouts/DocLayout.tsx
@@ -3,7 +3,7 @@ import { PageProps } from 'gatsby';
 import { MDXProvider } from '@mdx-js/react';
 import { MDXComponents } from 'mdx/types';
 import { SkipToContent } from '@entur/a11y';
-import SiteFooter from '@components/Footer/SiteFooter';
+import Footer from '@components/Footer/Footer';
 import TopNavigationLayout from './TopNavigationLayout';
 import components from '../utils/MdxProvider-utils';
 import SideNavigationLayout from './SideNavigationLayout';
@@ -39,8 +39,8 @@ const DocLayout = ({
               {children}
             </MDXProvider>
           </main>
-          <SiteFooter />
         </div>
+        <Footer className="footer--light" />
       </div>
     </>
   );

--- a/apps/documentation/src/layouts/SideNavigationLayout.tsx
+++ b/apps/documentation/src/layouts/SideNavigationLayout.tsx
@@ -65,7 +65,6 @@ const SideNavigationLayout = ({
         currentLocation={location}
       />
       <MobileSideNavigation
-        className="side-navigation--mobile"
         menuItems={menuItems}
         openSidebar={openSidebar}
         setOpenSidebar={setOpenSidebar}

--- a/apps/documentation/src/layouts/SideNavigationLayout.tsx
+++ b/apps/documentation/src/layouts/SideNavigationLayout.tsx
@@ -6,9 +6,10 @@ import { PageProps, graphql, useStaticQuery } from 'gatsby';
 
 const SideNavigationLayout = ({
   location,
+  ...rest
 }: {
   location: PageProps['location'];
-}) => {
+} & React.ComponentPropsWithoutRef<'nav'>) => {
   const [openSidebar, setOpenSidebar] = React.useState(false);
 
   const MenuData = useStaticQuery(graphql`
@@ -22,7 +23,6 @@ const SideNavigationLayout = ({
             parent
             menu
             order
-            removeToc
             npmPackage
             tags
             categoryIndex
@@ -58,18 +58,19 @@ const SideNavigationLayout = ({
   ]);
 
   return (
-    <nav aria-label="Sidemeny">
-      <div className="side-navigation--desktop">
-        <SideNavigation menuItems={menuItems} currentLocation={location} />
-      </div>
-      <div className="side-navigation--mobile">
-        <MobileSideNavigation
-          menuItems={menuItems}
-          openSidebar={openSidebar}
-          setOpenSidebar={setOpenSidebar}
-          currentLocation={location}
-        />
-      </div>
+    <nav aria-label="Sidemeny" {...rest}>
+      <SideNavigation
+        className="side-navigation--desktop"
+        menuItems={menuItems}
+        currentLocation={location}
+      />
+      <MobileSideNavigation
+        className="side-navigation--mobile"
+        menuItems={menuItems}
+        openSidebar={openSidebar}
+        setOpenSidebar={setOpenSidebar}
+        currentLocation={location}
+      />
     </nav>
   );
 };

--- a/apps/documentation/src/layouts/TopNavigationLayout.tsx
+++ b/apps/documentation/src/layouts/TopNavigationLayout.tsx
@@ -4,11 +4,17 @@ import MobileTopNavigation from '@components/Navigations/TopNavigation/MobileTop
 import { useWindowDimensions } from '@entur/utils';
 import { pxToRem } from 'src/utils/utils';
 
-const TopNavigationLayout: React.FC = () => {
+const TopNavigationLayout: React.FC<
+  React.HTMLAttributes<HTMLElement>
+> = props => {
   const { width } = useWindowDimensions();
   const remWidth = pxToRem(width);
   const isMobile = remWidth !== undefined && remWidth < 60;
-  return isMobile ? <MobileTopNavigation /> : <TopNavigation />;
+  return isMobile ? (
+    <MobileTopNavigation {...props} />
+  ) : (
+    <TopNavigation {...props} />
+  );
 };
 
 export default TopNavigationLayout;

--- a/apps/documentation/src/pages/identitet/verktoykassen/typografi.mdx
+++ b/apps/documentation/src/pages/identitet/verktoykassen/typografi.mdx
@@ -5,7 +5,6 @@ parent: Identitet
 route: /identitet/verktoykassen/typografi
 menu: Verktøykassen
 order: 6
-removeToc: false
 ---
 
 import { graphql, Link } from "gatsby"

--- a/apps/documentation/src/pages/index.tsx
+++ b/apps/documentation/src/pages/index.tsx
@@ -33,7 +33,7 @@ import './index.scss';
 const Index = () => {
   const { width } = useWindowDimensions();
   const [backgroundHeight, setBackgroundHeight] = useState(0);
-  const footerRef = useRef<HTMLDivElement>(null);
+  const footerRef = useRef<HTMLElement>(null);
   const mainRef = useRef<HTMLDivElement>(null);
 
   const _width = Math.floor(width ?? 0 / 100);
@@ -168,7 +168,7 @@ const Index = () => {
               </SecondaryButton>
             </div>
           </main>
-          <Footer footerRef={footerRef} forceColorMode="contrast" />
+          <Footer footerRef={footerRef} contrast />
         </div>
       </Contrast>
     </>

--- a/apps/documentation/src/styles/index.scss
+++ b/apps/documentation/src/styles/index.scss
@@ -31,6 +31,11 @@
 
 :root {
   color-scheme: light dark;
+  --navbar-height: #{variables.$navbar-height--mobile};
+
+  @media screen and (min-width: map.get(variables.$breakpoints, 'tablet')) {
+    --navbar-height: #{variables.$navbar-height};
+  }
 }
 
 [data-color-mode='light'] {
@@ -46,62 +51,24 @@ body {
 }
 
 .page {
-  height: 100%;
-  width: 100%;
-  overflow-y: auto;
-  position: relative;
-  top: variables.$navbar-height;
   display: flex;
   flex-direction: column;
-
-  @media screen and (min-width: map.get(variables.$breakpoints, 'mobile-small')) {
-    top: variables.$navbar-height--mobile;
-  }
+  margin: eds.$space-extra-large eds.$space-extra-large eds.$space-default;
+  transition: max-width eds.$timings-fast ease-out, margin-left eds.$timings-fast ease-out;
 
   @media screen and (min-width: map.get(variables.$breakpoints, 'tablet')) {
-    left: calc(variables.$side-navigation-width--desktop + eds.$space-extra-large);
-    width: calc(100% - #{variables.$side-navigation-width--desktop} - #{variables.$site-content-right-margin} - #{variables.$site-content-left-margin});
-  }
-
-  .site-content {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    margin: eds.$space-extra-large eds.$space-extra-large eds.$space-default;
-    transition: max-width eds.$timings-fast ease-out, margin-left eds.$timings-fast ease-out;
-
-    @media screen and (min-width: map.get(variables.$breakpoints, 'tablet')) {
-      max-width: 45rem;
-      margin: 2rem 2rem 1rem 3rem;
-    }
-
-    main {
-      flex: 1;
-      // custom paragraph spacing for documentation site
-      // & > {
-      //   h2,
-      //   h3 {
-      //     margin-top: 3rem;
-      //   }
-      //   h2:first-of-type {
-      //     margin-top: 4rem;
-      //   }
-      //   h4 {
-      //     margin-top: 4rem;
-      //   }
-
-      //   // two adjacent neighbors
-      //   [class^='eds-h'] + [class^='eds-h'] {
-      //     margin-top: 2rem;
-      //   }
-      // }
-    }
+    max-width: 45rem;
+    margin: 2rem 2rem 1rem 3rem;
   }
 }
 
 // code {
 //   font-size: 14px; //Override  for code, as rem is redefined
 // }
+
+.side-nav-column {
+  background: var(--components-menu-sidenavigation-standard-background);
+}
 
 .eds-link.gatsby-header-links {
   background-image: none;

--- a/apps/documentation/src/styles/index.scss
+++ b/apps/documentation/src/styles/index.scss
@@ -51,14 +51,15 @@ body {
 }
 
 .page {
-  display: flex;
-  flex-direction: column;
+  min-width: 0;
   margin: eds.$space-extra-large eds.$space-extra-large eds.$space-default;
+  padding-top: var(--navbar-height);
   transition: max-width eds.$timings-fast ease-out, margin-left eds.$timings-fast ease-out;
 
   @media screen and (min-width: map.get(variables.$breakpoints, 'tablet')) {
     max-width: 45rem;
     margin: 2rem 2rem 1rem 3rem;
+    padding-top: 0;
   }
 }
 

--- a/apps/documentation/src/styles/index.scss
+++ b/apps/documentation/src/styles/index.scss
@@ -51,6 +51,8 @@ body {
   overflow-y: auto;
   position: relative;
   top: variables.$navbar-height;
+  display: flex;
+  flex-direction: column;
 
   @media screen and (min-width: map.get(variables.$breakpoints, 'mobile-small')) {
     top: variables.$navbar-height--mobile;
@@ -64,7 +66,7 @@ body {
   .site-content {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    flex: 1;
     margin: eds.$space-extra-large eds.$space-extra-large eds.$space-default;
     transition: max-width eds.$timings-fast ease-out, margin-left eds.$timings-fast ease-out;
 
@@ -88,7 +90,7 @@ body {
       //     margin-top: 4rem;
       //   }
 
-      //   // two adjacent headers
+      //   // two adjacent neighbors
       //   [class^='eds-h'] + [class^='eds-h'] {
       //     margin-top: 2rem;
       //   }

--- a/apps/documentation/src/utils/MdxProvider-utils.tsx
+++ b/apps/documentation/src/utils/MdxProvider-utils.tsx
@@ -3,7 +3,6 @@ import Props from '@components/Props/Props';
 import Playground from '@components/Playground/Playground';
 import { DoDontCard, DoDontGroup } from '@components/Cards/DoDont';
 import BaseCardDesignEntur from '@components/Cards/BaseCardDesignEntur';
-import PageHeader from '@components/PageHeader/PageHeader';
 import { ImageDisplay } from '@components/Media/ImageDisplay';
 import { ImportStatement } from '@components/Common/ImportStatement';
 import { IconButton, PrimaryButton, SecondaryButton } from '@entur/button';
@@ -163,7 +162,6 @@ const components = {
   DoDontGroup,
   DoDontCard,
   BaseCardDesignEntur,
-  PageHeader,
   ImageDisplay,
   Checkbox,
   Radio,

--- a/apps/documentation/src/utils/scrollUtils.ts
+++ b/apps/documentation/src/utils/scrollUtils.ts
@@ -5,7 +5,9 @@ const getNavbarHeightPx = () => {
   const val = getComputedStyle(document.documentElement)
     .getPropertyValue('--navbar-height')
     .trim();
-  return (parseFloat(val) + 1.5) * 16;
+  const height = parseFloat(val);
+  if (isNaN(height)) return SCROLL_OFFSET_REM * 16;
+  return (height + 1.5) * 16;
 };
 
 export const scrollToElement = (elementId: string, offset?: number) => {

--- a/apps/documentation/src/utils/scrollUtils.ts
+++ b/apps/documentation/src/utils/scrollUtils.ts
@@ -1,10 +1,18 @@
 export const SCROLL_OFFSET_REM = 5.5;
 
+const getNavbarHeightPx = () => {
+  if (typeof window === 'undefined') return SCROLL_OFFSET_REM * 16;
+  const val = getComputedStyle(document.documentElement)
+    .getPropertyValue('--navbar-height')
+    .trim();
+  return (parseFloat(val) + 0.5) * 16;
+};
+
 export const scrollToElement = (elementId: string, offset?: number) => {
   const element = document.getElementById(elementId);
   if (!element) return;
 
-  const scrollOffset = (offset ?? SCROLL_OFFSET_REM) * 16;
+  const scrollOffset = offset !== undefined ? offset * 16 : getNavbarHeightPx();
   const top =
     element.getBoundingClientRect().top + window.scrollY - scrollOffset;
 

--- a/apps/documentation/src/utils/scrollUtils.ts
+++ b/apps/documentation/src/utils/scrollUtils.ts
@@ -5,7 +5,7 @@ const getNavbarHeightPx = () => {
   const val = getComputedStyle(document.documentElement)
     .getPropertyValue('--navbar-height')
     .trim();
-  return (parseFloat(val) + 0.5) * 16;
+  return (parseFloat(val) + 1.5) * 16;
 };
 
 export const scrollToElement = (elementId: string, offset?: number) => {

--- a/apps/documentation/src/utils/utils.ts
+++ b/apps/documentation/src/utils/utils.ts
@@ -72,6 +72,8 @@ export function getSanitizedPath({
   return `/${sanitizedCategory}/${sanitizedSubcategory}/${sanitizedTitle}`;
 }
 
+export const isBetaTag = (tag?: string) => tag?.toLowerCase() === 'beta';
+
 export function sanitizeEnturPackageName(packageName: string) {
   const normalizedPackageName = packageName.replace(/\/beta$/, '');
   const packageKey = normalizedPackageName.split('@entur/')?.at(-1);


### PR DESCRIPTION
## 💡 Hvorfor?

Dokumentasjonssiden hadde flere strukturelle problemer: toppnavigasjonen var ikke sticky etter layout-endringer, sidefoten ble ikke vist på alle sider, innholdsfortegnelsen ble skjult på en del sider uten god grunn, og PageHeader-komponenten var inkonsistent mellom MDX- og Sanity-sider.

## 🔧 Hvordan?

**Layout med CSS Grid:**
- `DocLayout` bruker nå CSS Grid i stedet for posisjonering
- `GridItem as=`-prop eliminerer unødvendige wrapper-elementer
- Sidemenyens bakgrunn strekker seg nå til bunnen av siden
- `--navbar-height` CSS-variabel brukes konsekvent for scroll-offset

**Semantisk HTML:**
- Toppnavigasjon: rot-element er nå `<header>`, lenker er pakket inn i `<nav>`
- Footer: overflødig wrapper-nesting fjernet, native CSS Grid, semantisk `<footer>`-element
- GitHub-lenke fjernet fra toppnavigasjon (finnes allerede i footer)

**Innholdsfortegnelse:**
- Vises nå på alle sider (fjernet `removeToc`/`disableToc`-mekanismer)
- Fikset bug der flere punkter fikk aktiv-klasse samtidig på Sanity-sider
- Skjules når færre enn 2 overskrifter

**PageHeader:**
- MDX- og Sanity-sider bruker nå samme `BasePageHeader`-komponent
- Fikset bug der beta-badge fikk feil variant når Sanity lagrer `"Beta"` med stor forbokstav

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [x] 📝 Dokumentasjonsoppdatering
- [x] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

<!-- Legg ved hvis det hjelper å forstå endringen -->

## 💬 Tilleggsnotater

<!-- Andre tanker, bekymringer eller relevante lenker -->

## ✅ Sjekkliste

- [ ] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [ ] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden