### PR TITLE
fix(icons): reduce CSS specificity of icon selectors

### DIFF
--- a/packages/icons/src/index.scss
+++ b/packages/icons/src/index.scss
@@ -19,43 +19,43 @@
 
   &__metro {
     color: var(--basecolors-shape-metro-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-metro-contrast);
     }
   }
   &__bus {
     color: var(--basecolors-shape-bus-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-bus-contrast);
     }
   }
   &__plane {
     color: var(--basecolors-shape-plane-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-plane-contrast);
     }
   }
   &__helicopter {
     color: var(--basecolors-shape-helicopter-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-helicopter-contrast);
     }
   }
   &__tram {
     color: var(--basecolors-shape-tram-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-tram-contrast);
     }
   }
   &__funicular {
     color: var(--basecolors-shape-funicular-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-funicular-contrast);
     }
   }
   &__cableway {
     color: var(--basecolors-shape-cableway-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-cableway-contrast);
     }
   }
@@ -63,13 +63,13 @@
   &__taxi,
   &__snowcoach {
     color: var(--basecolors-shape-taxi-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-taxi-contrast);
     }
   }
   &__bicycle {
     color: var(--basecolors-shape-bicycle-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-bicycle-contrast);
     }
   }
@@ -78,20 +78,20 @@
   &__strolling,
   &__running {
     color: var(--basecolors-shape-walk-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-walk-contrast);
     }
   }
   &__train {
     color: var(--basecolors-shape-train-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-train-contrast);
     }
   }
   &__ferry,
   &__carferry {
     color: var(--basecolors-shape-ferry-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-ferry-contrast);
     }
   }
@@ -99,7 +99,7 @@
   &__citybike,
   &__carsharing {
     color: var(--basecolors-shape-mobility-default);
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       color: var(--basecolors-shape-mobility-contrast);
     }
   }
@@ -107,7 +107,7 @@
   :where(.svg-exclamation) {
     fill: var(--basecolors-frame-default);
 
-    .eds-contrast & {
+    :where(.eds-contrast) & {
       fill: var(--basecolors-frame-contrast);
     }
   }


### PR DESCRIPTION
## 💡 Hvorfor?

Klasser i `@entur/icons` har for høy spesifisitet (0,2,0) og overskriver komponentstiler som avhenger av ikoner der spesifisitet er lavere. Dette gjør det vanskelig for komponenter som bruker ikoner internt å style dem riktig.

Relatert: ETU-73689

## 🔧 Hvordan?

Wrapper alle modifier-selektorer (`.eds-icon__metro`, `.eds-icon__bus`, osv.) og `.eds-contrast`-selektorer i `:where()` for å senke spesifisiteten fra (0,2,0) til (0,1,0). Samme mønster som allerede brukes i `@entur/button` og `@entur/travel`.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [x] 💥 Breaking change (krever kodeendringer hos brukere)

## 💣 Breaking changes (om aktuelt)

Ikon-modifier-selektorer (`.eds-icon__metro`, `.eds-icon__bus`, osv.) og `.eds-contrast`-kontekstselektorer har nå lavere CSS-spesifisitet. Konsumenter som avhenger av at disse selektorene vinner over enkelt-klasse-selektorer kan måtte justere stilene sine.

I praksis er dette usannsynlig — hele poenget med endringen er at den høye spesifisiteten var uønsket.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden

Auditert alle pakker som refererer `.eds-icon` i CSS — ingen property-konflikter funnet. Ikon-modifierne setter kun `color`/`fill`, mens andre pakker styler layout-properties (`margin`, `font-size`, osv.).