### PR TITLE
fix(tokens/datepicker): rename color variables to align with Figma

### DIFF
--- a/packages/datepicker/src/DatePicker/Calendar.scss
+++ b/packages/datepicker/src/DatePicker/Calendar.scss
@@ -128,7 +128,7 @@
 
       &:active {
         background-color: var(--components-datepicker-calendar-datefill-selected);
-        color: var(--components-datepicker-calendar-text-range-endpoint);
+        color: var(--components-datepicker-calendar-text-selected);
       }
 
       &--between-months {
@@ -142,18 +142,18 @@
       }
 
       &--selected {
-        background-color: var(--components-datepicker-calendar-datefill-range-endpoint);
-        color: var(--components-datepicker-calendar-text-range-endpoint);
+        background-color: var(--components-datepicker-calendar-datefill-selected);
+        color: var(--components-datepicker-calendar-text-selected);
         border-radius: 4px;
 
         &:hover {
-          background-color: var(--components-datepicker-calendar-datefill-range-endpoint-hover);
-          color: var(--components-datepicker-calendar-text-range-endpoint);
+          background-color: var(--components-datepicker-calendar-datefill-selected-hover);
+          color: var(--components-datepicker-calendar-text-selected);
         }
 
         &:active {
-          background-color: var(--components-datepicker-calendar-datefill-range-endpoint);
-          color: var(--components-datepicker-calendar-text-range-endpoint);
+          background-color: var(--components-datepicker-calendar-datefill-selected);
+          color: var(--components-datepicker-calendar-text-selected);
         }
       }
 
@@ -170,12 +170,12 @@
 
       &--selection-start,
       &--selection-end {
-        background-color: var(--components-datepicker-calendar-datefill-range-endpoint);
-        color: var(--components-datepicker-calendar-text-range-endpoint);
+        background-color: var(--components-datepicker-calendar-datefill-selected);
+        color: var(--components-datepicker-calendar-text-selected);
 
         &:hover {
-          background-color: var(--components-datepicker-calendar-datefill-range-endpoint-hover);
-          color: var(--components-datepicker-calendar-text-range-endpoint);
+          background-color: var(--components-datepicker-calendar-datefill-selected-hover);
+          color: var(--components-datepicker-calendar-text-selected);
         }
       }
 

--- a/packages/datepicker/src/componentVariables.scss
+++ b/packages/datepicker/src/componentVariables.scss
@@ -11,15 +11,14 @@
   --components-datepicker-calendar-dateborder: #{$stroke-neutral};
   --components-datepicker-calendar-datefill-hover: #{$fill-secondary-hover-light};
   --components-datepicker-calendar-datefill-range: #{$fill-selected-default-tint};
-  --components-datepicker-calendar-datefill-range-endpoint: #{$fill-primary-default-light};
-  --components-datepicker-calendar-datefill-range-endpoint-hover: #{$fill-background-contrast-lightalt-2};
+  --components-datepicker-calendar-datefill-selected-hover: #{$fill-background-contrast-lightalt-2};
   --components-datepicker-calendar-datefill-range-hover: #{$fill-selected-hover-tint};
   --components-datepicker-calendar-datefill-selected: #{$fill-primary-default-light};
   --components-datepicker-calendar-icon: #{$shape-accent};
   --components-datepicker-calendar-stroke-today: #{$stroke-highlight};
   --components-datepicker-calendar-text-accent: #{$text-accent};
   --components-datepicker-calendar-text-disabled: #{$text-neutralalt};
-  --components-datepicker-calendar-text-range-endpoint: #{$text-light};
+  --components-datepicker-calendar-text-selected: #{$text-light};
   --components-datepicker-calendar-text-subdued: #{$text-subdued};
 }
 
@@ -29,15 +28,14 @@
   --components-datepicker-calendar-border: #{$stroke-colorless};
   --components-datepicker-calendar-dateborder: #{$stroke-darkalt};
   --components-datepicker-calendar-datefill-hover: #{$fill-selected-hover-dark};
-  --components-datepicker-calendar-datefill-range: #{$fill-selected-default-tintdark};
-  --components-datepicker-calendar-datefill-range-endpoint: #{$fill-primary-default-contrast};
-  --components-datepicker-calendar-datefill-range-endpoint-hover: #{$fill-primary-hover-contrast};
-  --components-datepicker-calendar-datefill-range-hover: #{$fill-selected-hover-tintdark};
+  --components-datepicker-calendar-datefill-range: #{$fill-selected-default-darktint};
+  --components-datepicker-calendar-datefill-selected-hover: #{$fill-primary-hover-contrast};
+  --components-datepicker-calendar-datefill-range-hover: #{$fill-selected-hover-darktint};
   --components-datepicker-calendar-datefill-selected: #{$fill-primary-default-contrast};
   --components-datepicker-calendar-icon: #{$shape-lightalt};
   --components-datepicker-calendar-stroke-today: #{$stroke-highlight};
   --components-datepicker-calendar-text-accent: #{$text-lightalt};
   --components-datepicker-calendar-text-disabled: #{$text-neutral};
-  --components-datepicker-calendar-text-range-endpoint: #{$text-dark};
+  --components-datepicker-calendar-text-selected: #{$text-dark};
   --components-datepicker-calendar-text-subdued: #{$text-darkalt};
 }

--- a/packages/tokens/src/component.json
+++ b/packages/tokens/src/component.json
@@ -1719,13 +1719,7 @@
             "rootAlias": "Blue/20"
           },
           {
-            "name": "Components/datepicker/Calendar/DateFill-Range-Endpoint",
-            "value": "#181c56",
-            "var": "Fill/Primary/Default/Light",
-            "rootAlias": "Lavender/90"
-          },
-          {
-            "name": "Components/datepicker/Calendar/DateFill-Range-Endpoint-Hover",
+            "name": "Components/datepicker/Calendar/DateFill-Selected-Hover",
             "value": "#292b6a",
             "var": "Fill/Background/Contrast/LightAlt-2",
             "rootAlias": "Blue/100"
@@ -1767,7 +1761,7 @@
             "rootAlias": "Grey/50"
           },
           {
-            "name": "Components/datepicker/Calendar/Text-Range-Endpoint",
+            "name": "Components/datepicker/Calendar/Text-Selected",
             "value": "#ffffff",
             "var": "Text/Light",
             "rootAlias": "White/Alpha-100"
@@ -8037,17 +8031,11 @@
           {
             "name": "Components/datepicker/Calendar/DateFill-Range",
             "value": "#525360",
-            "var": "Fill/Selected/Default/TintDark",
+            "var": "Fill/Selected/Default/DarkTint",
             "rootAlias": "Ebony/70"
           },
           {
-            "name": "Components/datepicker/Calendar/DateFill-Range-Endpoint",
-            "value": "#aeb7e2",
-            "var": "Fill/Primary/Default/Contrast",
-            "rootAlias": "Lavender/40"
-          },
-          {
-            "name": "Components/datepicker/Calendar/DateFill-Range-Endpoint-Hover",
+            "name": "Components/datepicker/Calendar/DateFill-Selected-Hover",
             "value": "#c7cdeb",
             "var": "Fill/Primary/Hover/Contrast",
             "rootAlias": "Lavender/30"
@@ -8055,7 +8043,7 @@
           {
             "name": "Components/datepicker/Calendar/DateFill-Range-Hover",
             "value": "#5e5f6c",
-            "var": "Fill/Selected/Hover/TintDark",
+            "var": "Fill/Selected/Hover/DarkTint",
             "rootAlias": "Ebony/65"
           },
           {
@@ -8089,7 +8077,7 @@
             "rootAlias": "Grey/70"
           },
           {
-            "name": "Components/datepicker/Calendar/Text-Range-Endpoint",
+            "name": "Components/datepicker/Calendar/Text-Selected",
             "value": "#08091c",
             "var": "Text/Dark",
             "rootAlias": "Ebony/100"

--- a/packages/tokens/src/semantic.json
+++ b/packages/tokens/src/semantic.json
@@ -345,7 +345,7 @@
             "rootAlias": "Blue/20"
           },
           {
-            "name": "Fill/Selected/Default/TintDark",
+            "name": "Fill/Selected/Default/DarkTint",
             "value": "#525360",
             "var": "Ebony/70",
             "rootAlias": "Ebony/70"
@@ -381,7 +381,7 @@
             "rootAlias": "Blue/30"
           },
           {
-            "name": "Fill/Selected/Hover/TintDark",
+            "name": "Fill/Selected/Hover/DarkTint",
             "value": "#5e5f6c",
             "var": "Ebony/65",
             "rootAlias": "Ebony/65"


### PR DESCRIPTION
## 💡 Hvorfor?

Fixup for #408 – fargetoken-navn i Figma ble oppdatert etter at PR-en ble merget, og kode + token-JSON må reflektere de nye navnene.

## 🔧 Hvordan?

**Tokens (`semantic.json`, `component.json`):**
- `Fill/Selected/Default/TintDark` → `Fill/Selected/Default/DarkTint`
- `Fill/Selected/Hover/TintDark` → `Fill/Selected/Hover/DarkTint`
- `DateFill-Range-Endpoint` fjernet (var duplikat av eksisterende `DateFill-Selected`)
- `DateFill-Range-Endpoint-Hover` → `DateFill-Selected-Hover`
- `Text-Range-Endpoint` → `Text-Selected`

**SCSS (`Calendar.scss`, `componentVariables.scss`):**
- Oppdatert alle CSS custom properties til å bruke de nye token-navnene

## 🧩 Type endring

- [x] 🐞 Feilretting
- [x] 🧹 Refaktorering (ingen funksjonelle endringer)

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden