### PR TITLE
Forbedringer for Sanity ComponentDoc-malen

### DIFF
--- a/apps/documentation/src/components/Navigations/TableOfContent/SanityTableOfContent.tsx
+++ b/apps/documentation/src/components/Navigations/TableOfContent/SanityTableOfContent.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { TableOfContentInline } from './TableOfContent';
 import type { TocHeading } from './TableOfContent';
+import { sanitizeText } from 'src/utils/utils';
 
 interface SanityTableOfContentProps {
   content: any;
@@ -10,6 +11,14 @@ export const extractHeadingsFromPortableText = (content: any): TocHeading[] => {
   if (!content) return [];
 
   const headings: TocHeading[] = [];
+  const seen = new Map<string, number>();
+
+  const getUniqueId = (text: string) => {
+    const base = sanitizeText(text);
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    return count === 0 ? base : `${base}-${count + 1}`;
+  };
 
   const processBlock = (block: any) => {
     if (block._type === 'block' && block.style?.startsWith('h')) {
@@ -17,8 +26,12 @@ export const extractHeadingsFromPortableText = (content: any): TocHeading[] => {
       const title =
         block.children?.map((child: any) => child.text || '').join('') || '';
 
-      if (title && block._key) {
-        headings.push({ id: block._key, title, depth: level });
+      if (title) {
+        headings.push({
+          id: getUniqueId(title),
+          title,
+          depth: level,
+        });
       }
     }
 

--- a/apps/documentation/src/components/Navigations/TableOfContent/SanityTableOfContent.tsx
+++ b/apps/documentation/src/components/Navigations/TableOfContent/SanityTableOfContent.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { TableOfContentInline } from './TableOfContent';
 import type { TocHeading } from './TableOfContent';
-import { sanitizeText } from 'src/utils/utils';
+import { getUniqueId } from '@components/sanity/HeadingIdContext';
 
 interface SanityTableOfContentProps {
   content: any;
@@ -13,13 +13,6 @@ export const extractHeadingsFromPortableText = (content: any): TocHeading[] => {
   const headings: TocHeading[] = [];
   const seen = new Map<string, number>();
 
-  const getUniqueId = (text: string) => {
-    const base = sanitizeText(text);
-    const count = seen.get(base) ?? 0;
-    seen.set(base, count + 1);
-    return count === 0 ? base : `${base}-${count + 1}`;
-  };
-
   const processBlock = (block: any) => {
     if (block._type === 'block' && block.style?.startsWith('h')) {
       const level = parseInt(block.style.replace('h', ''));
@@ -28,7 +21,7 @@ export const extractHeadingsFromPortableText = (content: any): TocHeading[] => {
 
       if (title) {
         headings.push({
-          id: getUniqueId(title),
+          id: getUniqueId(title, seen),
           title,
           depth: level,
         });

--- a/apps/documentation/src/components/Playground/Playground.scss
+++ b/apps/documentation/src/components/Playground/Playground.scss
@@ -5,7 +5,6 @@
 .playground {
   &__header {
     display: flex;
-    margin-top: 1rem;
   }
   &__live-preview-and-props-wrapper {
     display: flex;

--- a/apps/documentation/src/components/Playground/Playground.tsx
+++ b/apps/documentation/src/components/Playground/Playground.tsx
@@ -10,8 +10,7 @@ import { SourceCodeIcon } from '@entur/icons';
 import { Contrast } from '@entur/layout';
 import { Flex } from '@entur/layout/beta';
 import { componentColors } from '@entur/tokens';
-import { Heading5 } from '@entur/typography';
-import { Heading } from '@entur/typography/beta';
+import { Heading3, Heading5, Paragraph } from '@entur/typography';
 import { ConditionalWrapper } from '@entur/utils';
 import { useSettings } from '@providers/SettingsContext';
 
@@ -24,6 +23,7 @@ import PropsList from './PropsList';
 import theme from './themeForPlayground';
 import { packages } from './packages-scope';
 import { documentationComponents } from './documentation-scope';
+import { utilsScope } from './utils-scope';
 
 import './Playground.scss';
 
@@ -33,6 +33,7 @@ type PlaygroundProps = {
   props?: InitialAdvancedProp[];
   style?: React.CSSProperties;
   title?: string;
+  description?: string;
   defaultContrast?: boolean;
   defaultDarkMode?: boolean;
   defaultShowEditor?: boolean;
@@ -53,6 +54,7 @@ const Playground: React.FC<PlaygroundProps> = ({
   props,
   style,
   title,
+  description,
   defaultContrast = false,
   defaultDarkMode = false,
   defaultShowEditor = false,
@@ -82,7 +84,12 @@ const Playground: React.FC<PlaygroundProps> = ({
 
   const Element = colorMode === 'contrast' ? Contrast : 'div';
 
-  const finalScope = { ...packages, ...documentationComponents, ...scope };
+  const finalScope = {
+    ...utilsScope,
+    ...packages,
+    ...documentationComponents,
+    ...scope,
+  };
 
   const scaledPreviewStyle: React.CSSProperties | undefined = previewScale
     ? {
@@ -109,12 +116,9 @@ const Playground: React.FC<PlaygroundProps> = ({
       theme={theme}
     >
       <div className="playground__header">
-        <Flex direction="column" gap="none" justify="center">
-          {title && (
-            <Heading as="h3" size="lg" spacing="none">
-              {title}
-            </Heading>
-          )}
+        <Flex direction="column" justify="center">
+          {title && <Heading3>{title}</Heading3>}
+          {description && <Paragraph>{description}</Paragraph>}
           {!hideColorModeOption && (
             <div className="playground__color-mode-select">
               <SegmentedControl

--- a/apps/documentation/src/components/Playground/utils-scope.ts
+++ b/apps/documentation/src/components/Playground/utils-scope.ts
@@ -1,0 +1,5 @@
+import * as intDate from '@internationalized/date';
+
+export const utilsScope = {
+  ...intDate,
+};

--- a/apps/documentation/src/components/sanity/CodeExampleResolver.tsx
+++ b/apps/documentation/src/components/sanity/CodeExampleResolver.tsx
@@ -41,6 +41,7 @@ type ContainerStyleEntry = {
 
 type CodeExampleType = {
   title?: string;
+  description?: string;
   codeDisplayType: 'playground' | 'plain' | 'copyable';
   playgroundCode?: {
     code?: string;
@@ -106,6 +107,7 @@ type CodeExampleProps = {
 export const CodeExampleResolver = ({ value }: CodeExampleProps) => {
   const {
     title,
+    description,
     codeDisplayType,
     playgroundCode,
     playgroundProps,
@@ -165,6 +167,7 @@ export const CodeExampleResolver = ({ value }: CodeExampleProps) => {
           )}
           hideColorModeOption={(selectedProps?.length ?? 0) == 0}
           title={title}
+          description={description}
         />
       ) : codeDisplayType === 'copyable' && copyableText ? (
         <CopyableText

--- a/apps/documentation/src/components/sanity/HeadingAnchor.scss
+++ b/apps/documentation/src/components/sanity/HeadingAnchor.scss
@@ -1,0 +1,18 @@
+.heading-anchor {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+
+  .heading-anchor__copy-button {
+    opacity: 0;
+    transition: opacity 0.15s ease;
+
+    &:focus-visible {
+      opacity: 1;
+    }
+  }
+
+  &:hover .heading-anchor__copy-button {
+    opacity: 1;
+  }
+}

--- a/apps/documentation/src/components/sanity/HeadingAnchor.tsx
+++ b/apps/documentation/src/components/sanity/HeadingAnchor.tsx
@@ -6,26 +6,43 @@ import { useHeadingId } from './HeadingIdContext';
 import './HeadingAnchor.scss';
 
 type HeadingAnchorProps = {
-  headingText: string;
+  headingText?: string;
+  headingId?: string;
   children: React.ReactNode;
   HeadingComponent: React.ElementType;
 };
 
 export const HeadingAnchor: React.FC<HeadingAnchorProps> = ({
   headingText,
+  headingId,
   HeadingComponent,
   children,
 }) => {
-  const { getUniqueId } = useHeadingId();
-  const id = useMemo(() => getUniqueId(headingText), []);
+  const { getId } = useHeadingId();
+  const generatedId = useMemo(
+    () => (headingText ? getId(headingText) : ''),
+    [getId, headingText],
+  );
+  const id = headingId ?? generatedId;
   const { addToast } = useToast();
 
   const copyLink = () => {
     if (!id) return;
     const url = `${window.location.origin}${window.location.pathname}#${id}`;
     history.replaceState(null, '', `#${id}`);
-    navigator.clipboard.writeText(url);
-    addToast({ title: 'Kopiert!', content: 'Lenke kopiert til utklippstavla' });
+    navigator.clipboard.writeText(url).then(
+      () =>
+        addToast({
+          title: 'Kopiert!',
+          content: 'Lenke kopiert til utklippstavla',
+        }),
+      () =>
+        addToast({
+          title: 'Kopiering feilet',
+          content: 'Kunne ikke kopiere lenken til utklippstavla',
+          variant: 'information',
+        }),
+    );
   };
 
   return (

--- a/apps/documentation/src/components/sanity/HeadingAnchor.tsx
+++ b/apps/documentation/src/components/sanity/HeadingAnchor.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo } from 'react';
+import { useToast } from '@entur/alert';
+import { IconButton } from '@entur/button';
+import { CopyIcon } from '@entur/icons';
+import { useHeadingId } from './HeadingIdContext';
+import './HeadingAnchor.scss';
+
+type HeadingAnchorProps = {
+  headingText: string;
+  children: React.ReactNode;
+  HeadingComponent: React.ElementType;
+};
+
+export const HeadingAnchor: React.FC<HeadingAnchorProps> = ({
+  headingText,
+  HeadingComponent,
+  children,
+}) => {
+  const { getUniqueId } = useHeadingId();
+  const id = useMemo(() => getUniqueId(headingText), []);
+  const { addToast } = useToast();
+
+  const copyLink = () => {
+    if (!id) return;
+    const url = `${window.location.origin}${window.location.pathname}#${id}`;
+    history.replaceState(null, '', `#${id}`);
+    navigator.clipboard.writeText(url);
+    addToast({ title: 'Kopiert!', content: 'Lenke kopiert til utklippstavla' });
+  };
+
+  return (
+    <div className="heading-anchor">
+      <HeadingComponent id={id}>{children}</HeadingComponent>
+      {id && (
+        <IconButton
+          className="heading-anchor__copy-button"
+          onClick={copyLink}
+          aria-label="Kopier lenke til seksjon"
+        >
+          <CopyIcon size={16} />
+        </IconButton>
+      )}
+    </div>
+  );
+};

--- a/apps/documentation/src/components/sanity/HeadingIdContext.tsx
+++ b/apps/documentation/src/components/sanity/HeadingIdContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useRef } from 'react';
+import { sanitizeText } from 'src/utils/utils';
+
+type HeadingIdContextType = {
+  getUniqueId: (text: string) => string;
+};
+
+const HeadingIdContext = createContext<HeadingIdContextType>({
+  getUniqueId: sanitizeText,
+});
+
+export const HeadingIdProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const seen = useRef(new Map<string, number>());
+
+  const getUniqueId = (text: string) => {
+    const base = sanitizeText(text);
+    const count = seen.current.get(base) ?? 0;
+    seen.current.set(base, count + 1);
+    return count === 0 ? base : `${base}-${count + 1}`;
+  };
+
+  return (
+    <HeadingIdContext.Provider value={{ getUniqueId }}>
+      {children}
+    </HeadingIdContext.Provider>
+  );
+};
+
+export const useHeadingId = () => useContext(HeadingIdContext);

--- a/apps/documentation/src/components/sanity/HeadingIdContext.tsx
+++ b/apps/documentation/src/components/sanity/HeadingIdContext.tsx
@@ -1,28 +1,32 @@
 import React, { createContext, useContext, useRef } from 'react';
 import { sanitizeText } from 'src/utils/utils';
 
+export const getUniqueId = (
+  text: string,
+  seen: Map<string, number>,
+): string => {
+  const base = sanitizeText(text);
+  const count = seen.get(base) ?? 0;
+  seen.set(base, count + 1);
+  return count === 0 ? base : `${base}-${count + 1}`;
+};
+
 type HeadingIdContextType = {
-  getUniqueId: (text: string) => string;
+  getId: (text: string) => string;
 };
 
 const HeadingIdContext = createContext<HeadingIdContextType>({
-  getUniqueId: sanitizeText,
+  getId: sanitizeText,
 });
 
 export const HeadingIdProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const seen = useRef(new Map<string, number>());
-
-  const getUniqueId = (text: string) => {
-    const base = sanitizeText(text);
-    const count = seen.current.get(base) ?? 0;
-    seen.current.set(base, count + 1);
-    return count === 0 ? base : `${base}-${count + 1}`;
-  };
+  const getId = (text: string) => getUniqueId(text, seen.current);
 
   return (
-    <HeadingIdContext.Provider value={{ getUniqueId }}>
+    <HeadingIdContext.Provider value={{ getId }}>
       {children}
     </HeadingIdContext.Provider>
   );

--- a/apps/documentation/src/components/sanity/PortableText.tsx
+++ b/apps/documentation/src/components/sanity/PortableText.tsx
@@ -31,22 +31,47 @@ import { GuidelineResolver } from './GuidelineResolver';
 import { PropsTableResolver } from './PropsTableResolver';
 import { InlineIcon } from './types';
 import { isEnturIcon } from 'src/utils/utils';
+import { HeadingAnchor } from './HeadingAnchor';
+import { HeadingIdProvider } from './HeadingIdContext';
+
+const getBlockText = (value: any) =>
+  value.children?.map((c: any) => c.text || '').join('') || '';
 
 const createComponents = (context?: {
   npmPackage?: string;
 }): Partial<PortableTextReactComponents> => ({
   block: {
     h2: ({ children, value }) => (
-      <Heading2 id={value._key}>{children}</Heading2>
+      <HeadingAnchor
+        headingText={getBlockText(value)}
+        HeadingComponent={Heading2}
+      >
+        {children}
+      </HeadingAnchor>
     ),
     h3: ({ children, value }) => (
-      <Heading3 id={value._key}>{children}</Heading3>
+      <HeadingAnchor
+        headingText={getBlockText(value)}
+        HeadingComponent={Heading3}
+      >
+        {children}
+      </HeadingAnchor>
     ),
     h4: ({ children, value }) => (
-      <Heading4 id={value._key}>{children}</Heading4>
+      <HeadingAnchor
+        headingText={getBlockText(value)}
+        HeadingComponent={Heading4}
+      >
+        {children}
+      </HeadingAnchor>
     ),
     h5: ({ children, value }) => (
-      <Heading5 id={value._key}>{children}</Heading5>
+      <HeadingAnchor
+        headingText={getBlockText(value)}
+        HeadingComponent={Heading5}
+      >
+        {children}
+      </HeadingAnchor>
     ),
     normal: ({ children }) => <Paragraph>{children}</Paragraph>,
   },
@@ -142,6 +167,8 @@ type ExtendedPortableTextProps = PortableTextProps & {
 
 export const PortableText = ({ value, context }: ExtendedPortableTextProps) => {
   return (
-    <PortableTextReact components={createComponents(context)} value={value} />
+    <HeadingIdProvider>
+      <PortableTextReact components={createComponents(context)} value={value} />
+    </HeadingIdProvider>
   );
 };

--- a/apps/documentation/src/templates/ComponentDocTemplate.tsx
+++ b/apps/documentation/src/templates/ComponentDocTemplate.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { HeadProps, PageProps, graphql } from 'gatsby';
 import { SEO } from '@components/seo/SEO';
 import { getSanitizedPath } from '@components/Navigations/SideNavigation/utils';
@@ -8,6 +8,7 @@ import { useSetTocHeadings } from '@components/Navigations/TableOfContent/TocCon
 import { BasePageHeader } from '@components/PageHeader/BasePageHeader';
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@entur/tab';
 import { PortableText } from '@components/sanity/PortableText';
+import { scrollToElement } from '../utils/scrollUtils';
 
 type ComponentDoc = {
   title: string;
@@ -74,6 +75,24 @@ export default function ComponentDocTemplate({
   );
 }
 
+const buildHeadingToTabMap = (
+  tabs: Array<{ title?: string; _rawContent?: any }>,
+): Map<string, number> => {
+  const map = new Map<string, number>();
+  tabs.forEach((tab, index) => {
+    const headings = extractHeadingsFromPortableText(tab._rawContent);
+    headings.forEach(h => map.set(h.id, index));
+  });
+  return map;
+};
+
+const getInitialTabIndex = (headingToTab: Map<string, number>): number => {
+  if (typeof window === 'undefined') return 0;
+  const hash = window.location.hash.substring(1);
+  if (!hash) return 0;
+  return headingToTab.get(hash) ?? 0;
+};
+
 const TabsSection = React.memo(function TabsSection({
   tabs,
   context,
@@ -81,8 +100,39 @@ const TabsSection = React.memo(function TabsSection({
   tabs: Array<{ title?: string; _rawContent?: any }>;
   context: { npmPackage?: string };
 }) {
-  const [activeIndex, setActiveIndex] = useState(0);
+  const headingToTab = useMemo(() => buildHeadingToTabMap(tabs), [tabs]);
+
+  const [activeIndex, setActiveIndex] = useState(() =>
+    getInitialTabIndex(headingToTab),
+  );
   const shouldRenderAsTabs = tabs.length > 1;
+
+  const scrollToHash = useCallback(() => {
+    const hash = window.location.hash.substring(1);
+    if (hash) {
+      requestAnimationFrame(() => scrollToElement(hash));
+    }
+  }, []);
+
+  useEffect(() => {
+    scrollToHash();
+  }, [scrollToHash]);
+
+  useEffect(() => {
+    const onHashChange = () => {
+      const hash = window.location.hash.substring(1);
+      if (!hash) return;
+      const tabIndex = headingToTab.get(hash);
+      if (tabIndex !== undefined && tabIndex !== activeIndex) {
+        setActiveIndex(tabIndex);
+        requestAnimationFrame(() => scrollToElement(hash));
+      } else {
+        scrollToElement(hash);
+      }
+    };
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, [headingToTab, activeIndex]);
 
   const activeContent = tabs[activeIndex]?._rawContent ?? tabs[0]?._rawContent;
   const activeHeadings = useMemo(

--- a/apps/documentation/src/utils/MdxProvider-utils.tsx
+++ b/apps/documentation/src/utils/MdxProvider-utils.tsx
@@ -23,6 +23,18 @@ import {
   Text,
   UnorderedList,
 } from '@entur/typography/beta';
+import { HeadingAnchor } from '@components/sanity/HeadingAnchor';
+
+const MdxH2 = (props: any) => <Heading as="h2" variant="title-2" {...props} />;
+const MdxH3 = (props: any) => (
+  <Heading as="h3" variant="subtitle-1" {...props} />
+);
+const MdxH4 = (props: any) => (
+  <Heading as="h4" variant="subtitle-2" {...props} />
+);
+const MdxH5 = (props: any) => (
+  <Heading as="h5" variant="section-1" {...props} />
+);
 import {
   DataCell,
   EditableCell,
@@ -89,10 +101,26 @@ const preToCodeBlock = (preProps: any) => {
 const components = {
   // DS components - using new beta components
   h1: (props: any) => <Heading as="h1" variant="title-1" {...props} />,
-  h2: (props: any) => <Heading as="h2" variant="title-2" {...props} />,
-  h3: (props: any) => <Heading as="h3" variant="subtitle-1" {...props} />,
-  h4: (props: any) => <Heading as="h4" variant="subtitle-2" {...props} />,
-  h5: (props: any) => <Heading as="h5" variant="section-1" {...props} />,
+  h2: ({ id, children }: any) => (
+    <HeadingAnchor headingId={id} HeadingComponent={MdxH2}>
+      {children}
+    </HeadingAnchor>
+  ),
+  h3: ({ id, children }: any) => (
+    <HeadingAnchor headingId={id} HeadingComponent={MdxH3}>
+      {children}
+    </HeadingAnchor>
+  ),
+  h4: ({ id, children }: any) => (
+    <HeadingAnchor headingId={id} HeadingComponent={MdxH4}>
+      {children}
+    </HeadingAnchor>
+  ),
+  h5: ({ id, children }: any) => (
+    <HeadingAnchor headingId={id} HeadingComponent={MdxH5}>
+      {children}
+    </HeadingAnchor>
+  ),
   h6: (props: any) => <Heading as="h6" variant="section-2" {...props} />,
   p: (props: any) => <Text variant="paragraph" {...props} />,
   a: (props: any) => <Link {...props} />,

--- a/apps/documentation/src/utils/scrollUtils.ts
+++ b/apps/documentation/src/utils/scrollUtils.ts
@@ -29,6 +29,7 @@ export const handleHashLinkClick = (
 
   event.preventDefault();
   const elementId = href.substring(1);
+  history.replaceState(null, '', href);
   scrollToElement(elementId);
 };
 

--- a/apps/documentation/src/utils/utils.ts
+++ b/apps/documentation/src/utils/utils.ts
@@ -30,6 +30,19 @@ export function isEnturIcon(iconName: string): iconName is keyof typeof icons {
   return iconName in icons;
 }
 
+export function sanitizeText(text: string): string {
+  if (!text) return '';
+  return text
+    .toLowerCase()
+    .replaceAll('æ', 'ae')
+    .replaceAll('ø', 'o')
+    .replaceAll('å', 'a')
+    .replaceAll('&', 'og')
+    .replace(/\?$/, '')
+    .replace(/ +/g, '-')
+    .replace(/[^a-zA-Z0-9-]+-/g, '');
+}
+
 export function getSanitizedPath({
   category,
   subcategory,
@@ -43,19 +56,6 @@ export function getSanitizedPath({
   categoryIndex?: number;
   isCategoryLandingPage?: boolean;
 }) {
-  function sanitizeText(text: string) {
-    if (!text) return undefined;
-    return text
-      .toLowerCase()
-      .replaceAll('æ', 'ae')
-      .replaceAll('ø', 'o')
-      .replaceAll('å', 'a')
-      .replaceAll('&', 'og')
-      .replace(/\?$/, '')
-      .replace(/ +/g, '-')
-      .replace(/[^a-zA-Z0-9-]+-/g, '');
-  }
-
   const sanitizedCategory = sanitizeText(category);
 
   // If this is a category landing page, return just the category path

--- a/apps/studio-linje/schemaTypes/objects/codeExample.ts
+++ b/apps/studio-linje/schemaTypes/objects/codeExample.ts
@@ -31,6 +31,15 @@ export const codeExample = defineType({
       hidden: ({ parent }) => parent?.codeDisplayType === 'copyable',
     }),
     defineField({
+      name: 'description',
+      title: 'Beskrivelse',
+      type: 'text',
+      rows: 2,
+      description:
+        'Kort beskrivelse som vises under tittelen og over eksempelet.',
+      hidden: ({ parent }) => parent?.codeDisplayType === 'copyable',
+    }),
+    defineField({
       name: 'playgroundCode',
       title: 'Playground‑kode',
       type: 'playgroundCode',


### PR DESCRIPTION
## 💡 Hvorfor?

Sanity ComponentDoc-malen mangler funksjonalitet for delbare lenker, beskrivelser på kodeeksempler, og navigering til spesifikke seksjoner innenfor faner.

## 🔧 Hvordan?

### Kopierbar seksjon-lenke på overskrifter
- Ny `HeadingAnchor`-komponent som wrapper overskrifter med en `IconButton` (CopyIcon) som vises ved hover
- Kopier-knappen kopierer full URL med hash og viser toast-varsel
- URL-hash oppdateres ved klikk via `history.replaceState`

### Overskrift-IDer fra innholdstekst
- IDer genereres nå fra overskriftsteksten via `sanitizeText` i stedet for Sanity `_key`
- `HeadingIdContext` dedupliserer IDer (f.eks. to like overskrifter → `tittel`, `tittel-2`)
- Samme dedupliseringslogikk i `extractHeadingsFromPortableText` (ToC) og `HeadingAnchor` (render)
- `sanitizeText` eksportert som delt funksjon fra `utils.ts`

### Hash-basert deep-linking for ComponentDoc-faner
- URL-hash ved sidelast eller hashchange switcher til riktig fane og scroller til seksjonen
- `buildHeadingToTabMap` mapper overskrift-ID → fane-indeks

### Beskrivelse-felt for Playground-eksempler
- Nytt `description`-felt i Sanity `codeExample`-schema
- Vises som `Paragraph` under tittel og over visuelt eksempel

### ToC oppdaterer URL-hash
- `handleHashLinkClick` setter nå `history.replaceState` med hashen

## 🧩 Type endring

- [x] 🚀 Ny funksjonalitet
- [x] 📝 Dokumentasjonsoppdatering

## 💬 Tilleggsnotater

- Sanity studio-schema er oppdatert — krever deploy av studio for at `description`-feltet skal bli tilgjengelig
- Basert på `ETU-73109-split-datepicker-docs`-branchen

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden

AI-assistant: Claude Code (claude-opus-4-6)