### PR TITLE
fix(alert): replace copy-text-to-clipboard with navigator.clipboard.writeText

### DIFF
--- a/apps/documentation/package.json
+++ b/apps/documentation/package.json
@@ -47,7 +47,6 @@
     "@mdx-js/react": "3.1.1",
     "@portabletext/react": "3.2.4",
     "classnames": "2.5.1",
-    "copy-text-to-clipboard": "2.2.0",
     "fast-fuzzy": "1.12.0",
     "gatsby": "5.16.1",
     "gatsby-plugin-image": "3.16.0",

--- a/apps/documentation/src/components/Codeblock/CodeBlock.tsx
+++ b/apps/documentation/src/components/Codeblock/CodeBlock.tsx
@@ -5,8 +5,6 @@ import { useToast } from '@entur/alert';
 import { ActionChip } from '@entur/chip';
 import { ExpandablePanel } from '@entur/expand';
 import { CopyIcon, SourceCodeIcon } from '@entur/icons';
-import copy from 'copy-text-to-clipboard';
-
 // @ts-expect-error mangler typer for theme-fil
 import theme from './themeForCodeBlock';
 
@@ -64,10 +62,11 @@ export const CodeBlock = ({
             size="small"
             type="button"
             onClick={() => {
-              copy(children);
-              addToast({
-                title: 'Innhold kopiert!',
-                content: '',
+              navigator.clipboard.writeText(children).then(() => {
+                addToast({
+                  title: 'Innhold kopiert!',
+                  content: '',
+                });
               });
             }}
           >

--- a/apps/documentation/src/components/IconList/IconList.tsx
+++ b/apps/documentation/src/components/IconList/IconList.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ComponentType } from 'react';
 import classNames from 'classnames';
-import copy from 'copy-text-to-clipboard';
 import { Searcher, search } from 'fast-fuzzy';
 import { useToast } from '@entur/alert';
 import { IconButton, SecondaryButton } from '@entur/button';
@@ -201,10 +200,11 @@ const IconList: React.FC<IconListProps> = ({ icons: allIconComponents }) => {
     .startsWith('partner');
 
   const handleIconClick = (iconName: string) => () => {
-    copy(iconName);
-    addToast({
-      title: `"${iconName}"\u00A0kopiert!`,
-      content: 'Du finner det i utklippstavla',
+    navigator.clipboard.writeText(iconName).then(() => {
+      addToast({
+        title: `"${iconName}"\u00A0kopiert!`,
+        content: 'Du finner det i utklippstavla',
+      });
     });
   };
 

--- a/apps/documentation/src/components/TokensTable/CopyButton.tsx
+++ b/apps/documentation/src/components/TokensTable/CopyButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useToast } from '@entur/alert';
-import copy from 'copy-text-to-clipboard';
 import { SecondaryButton } from '@entur/button';
 import { CopyIcon } from '@entur/icons';
 
@@ -26,11 +25,12 @@ export const CopyButton: React.FC<Props> = ({ textToCopy, children }) => {
     <SecondaryButton
       size="small"
       onClick={() => {
-        copy(textToCopy);
-        setCopied(true);
-        addToast({
-          title: 'Kopiert!',
-          content: 'Tokenet ble kopiert til utklippstavla',
+        navigator.clipboard.writeText(textToCopy).then(() => {
+          setCopied(true);
+          addToast({
+            title: 'Kopiert!',
+            content: 'Tokenet ble kopiert til utklippstavla',
+          });
         });
       }}
       className="eds-copy-button"

--- a/apps/documentation/src/components/UU/CopyButton.tsx
+++ b/apps/documentation/src/components/UU/CopyButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useToast } from '@entur/alert';
-import copy from 'copy-text-to-clipboard';
 import { SecondaryButton } from '@entur/button';
 import { CopyIcon } from '@entur/icons';
 
@@ -26,11 +25,12 @@ export const CopyButton: React.FC<Props> = ({ textToCopy, children }) => {
     <SecondaryButton
       size="small"
       onClick={() => {
-        copy(textToCopy);
-        setCopied(true);
-        addToast({
-          title: 'Kopiert!',
-          content: 'Tokenet ble kopiert til utklippstavla',
+        navigator.clipboard.writeText(textToCopy).then(() => {
+          setCopied(true);
+          addToast({
+            title: 'Kopiert!',
+            content: 'Tokenet ble kopiert til utklippstavla',
+          });
         });
       }}
       className="eds-copy-button"

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -33,8 +33,7 @@
     "@entur/tooltip": "workspace:^",
     "@entur/typography": "workspace:^",
     "@entur/utils": "workspace:^",
-    "classnames": "^2.5.1",
-    "copy-text-to-clipboard": "^2.2.0"
+    "classnames": "^2.5.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/packages/alert/src/CopyableText.tsx
+++ b/packages/alert/src/CopyableText.tsx
@@ -47,7 +47,11 @@ export const CopyableText = ({
       await navigator.clipboard.writeText(_textToCopy);
       addToast({ title: successHeading, content: _successMessage });
     } catch {
-      // clipboard write failed silently
+      addToast({
+        title: 'Kopiering feilet',
+        content: 'Kunne ikke kopiere til utklippstavlen.',
+        variant: 'information',
+      });
     }
     onClick?.(e);
   };

--- a/packages/alert/src/CopyableText.tsx
+++ b/packages/alert/src/CopyableText.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import copy from 'copy-text-to-clipboard';
 
 import { IconButton } from '@entur/button';
 import { CopyIcon } from '@entur/icons';
@@ -40,16 +39,16 @@ export const CopyableText = ({
   ...rest
 }: CopyableTextProps): JSX.Element => {
   const { addToast } = useToast();
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
   const _textToCopy = textToCopy ?? children;
   const _successMessage =
     successMessage ?? `${_textToCopy} ble kopiert til utklippstavlen.`;
-  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    buttonRef.current &&
-      copy(_textToCopy, {
-        target: buttonRef.current,
-      }) &&
+  const handleClick = async (e: React.MouseEvent<HTMLDivElement>) => {
+    try {
+      await navigator.clipboard.writeText(_textToCopy);
       addToast({ title: successHeading, content: _successMessage });
+    } catch {
+      // clipboard write failed silently
+    }
     onClick?.(e);
   };
   return (
@@ -68,7 +67,6 @@ export const CopyableText = ({
           className="eds-copyable-text__button"
           aria-label={ariaLabel}
           type="button"
-          ref={buttonRef}
         >
           <CopyIcon className={'eds-copyable-text__button__icon'} />
         </IconButton>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5666,7 +5666,6 @@ __metadata:
     "@testing-library/user-event": "npm:14.6.1"
     "@vitejs/plugin-react": "npm:^5.0.1"
     classnames: "npm:^2.5.1"
-    copy-text-to-clipboard: "npm:^2.2.0"
     jest: "npm:^29.0.0"
     jest-environment-jsdom: "npm:^29.0.0"
     ts-jest: "npm:^29.0.0"
@@ -5870,7 +5869,6 @@ __metadata:
     "@types/react-syntax-highlighter": "npm:15.5.13"
     "@types/wcag-contrast": "npm:3.0.3"
     classnames: "npm:2.5.1"
-    copy-text-to-clipboard: "npm:2.2.0"
     fast-fuzzy: "npm:1.12.0"
     firebase-tools: "npm:14.27.0"
     gatsby: "npm:5.16.1"
@@ -18150,13 +18148,6 @@ __metadata:
   version: 0.7.0
   resolution: "cookie@npm:0.7.0"
   checksum: 10c0/15c20c9b85431c8565b1750f9bccff0bd289b943d956e25fffce3b146e57934075965c8305a4e3a65a70622c9ed483e013daf9159d9c50f5c3f97f2e7c8117ac
-  languageName: node
-  linkType: hard
-
-"copy-text-to-clipboard@npm:2.2.0, copy-text-to-clipboard@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "copy-text-to-clipboard@npm:2.2.0"
-  checksum: 10c0/a4e9dafdfeb46b0f16f13fae4d27a484eae6c6c0cc313bedbc13b713f01c0ef804ee69a2e0cd55b8d0a6186997ccdf56fdda4018a364f87c34b1d8ad8f73bd72
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 💡 Hvorfor?

`copy-text-to-clipboard` er et eksternt bibliotek som ikke lenger er nødvendig – nettleserstøtten for [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText) er god nok til å bruke `navigator.clipboard.writeText` direkte.

Relatert: ETU-73919

## 🔧 Hvordan?

Fjerner `copy-text-to-clipboard`-importene og bytter til `navigator.clipboard.writeText` i alle berørte filer:

- `packages/alert/src/CopyableText.tsx` – bruker `async/await` med `try/catch`
- Docs-komponenter (`CodeBlock`, `IconList`, `CopyButton` ×2) – bruker `.then()`

`buttonRef` i `CopyableText` er også fjernet da den kun ble brukt som `target`-argument til det gamle biblioteket.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [x] 🧹 Refaktorering (ingen funksjonelle endringer)

## 🖼️ Skjermbilder

Ikke aktuelt.

## 💬 Tilleggsnotater

`navigator.clipboard` krever sikker kontekst (HTTPS eller localhost). Dokumentasjonssiden og konsumentapper kjører på HTTPS, så dette er uproblematisk.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden

AI-assistant: Claude Code (claude-sonnet-4-6)