### PR TITLE
refactor: replace useRandomId with React useId across packages

### DIFF
--- a/packages/datepicker/src/DatePicker/CalendarGrid.tsx
+++ b/packages/datepicker/src/DatePicker/CalendarGrid.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import { useId } from 'react';
 
 import { useLocale } from '@react-aria/i18n';
 import { useCalendarGrid } from '@react-aria/calendar';
 import { CalendarState } from '@react-stately/calendar';
 import { CalendarDate, getWeeksInMonth } from '@internationalized/date';
 
-import { useRandomId } from '@entur/utils';
 import { VisuallyHidden } from '@entur/a11y';
 
 import { getWeekNumberForDate } from '../shared/utils';
@@ -39,7 +38,7 @@ export const CalendarGrid = ({
   ariaLabelForDate,
   ...rest
 }: CalendarGridProps) => {
-  const calendarGridId = useRandomId('eds-calendar');
+  const calendarGridId = `eds-calendar${useId()}`;
   const { locale } = useLocale();
 
   const { gridProps, headerProps, weekDays } = useCalendarGrid(rest, state);

--- a/packages/datepicker/src/DatePicker/DateField.tsx
+++ b/packages/datepicker/src/DatePicker/DateField.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useRef } from 'react';
+import React, { ReactNode, useEffect, useId, useRef } from 'react';
 
 import {
   DateFieldStateOptions,
@@ -16,12 +16,7 @@ import type {
 } from '@react-types/datepicker';
 
 import { BaseFormControl, BaseFormControlProps } from '@entur/form';
-import {
-  ConditionalWrapper,
-  VariantType,
-  mergeRefs,
-  useRandomId,
-} from '@entur/utils';
+import { ConditionalWrapper, VariantType, mergeRefs } from '@entur/utils';
 
 import { FieldSegment } from '../shared/FieldSegment';
 import {
@@ -200,7 +195,7 @@ export const DateField = <DateType extends DateValue>({
 
   useEffect(() => onValidate?.(!state.isInvalid), [state.isInvalid]);
 
-  const id = useRandomId('datefield');
+  const id = `datefield${useId()}`;
 
   return (
     <ConditionalWrapper

--- a/packages/datepicker/src/DatePicker/NativeDatePicker.tsx
+++ b/packages/datepicker/src/DatePicker/NativeDatePicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import {
   BaseFormControl,
   isFilled,
@@ -6,7 +6,7 @@ import {
   useVariant,
 } from '@entur/form';
 import { DateIcon } from '@entur/icons';
-import { VariantType, useOnMount, useRandomId } from '@entur/utils';
+import { VariantType, useOnMount } from '@entur/utils';
 
 /** @deprecated use variant="information" instead */
 const info = 'info';
@@ -50,7 +50,7 @@ export const NativeDatePicker = React.forwardRef<
     },
     ref: React.Ref<HTMLInputElement>,
   ) => {
-    const nativedatepickerId = useRandomId('eds-nativetimepicker');
+    const nativedatepickerId = `eds-nativetimepicker${useId()}`;
     return (
       <BaseFormControl
         style={style}

--- a/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx
+++ b/packages/datepicker/src/DatePicker/RangeCalendarGrid.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
+import { useId } from 'react';
 
 import { useLocale } from '@react-aria/i18n';
 import { useCalendarGrid } from '@react-aria/calendar';
 import { RangeCalendarState } from '@react-stately/calendar';
 import { CalendarDate, getWeeksInMonth } from '@internationalized/date';
 
-import { useRandomId } from '@entur/utils';
 import { VisuallyHidden } from '@entur/a11y';
 
 import { getWeekNumberForDate } from '../shared/utils';
@@ -33,7 +32,7 @@ export const RangeCalendarGrid = ({
   ariaLabelForDate,
   ...rest
 }: RangeCalendarGridProps) => {
-  const calendarGridId = useRandomId('eds-calendar');
+  const calendarGridId = `eds-calendar${useId()}`;
   const { locale } = useLocale();
 
   const gridStartDate = startDate ?? state.visibleRange.start;

--- a/packages/datepicker/src/TimePicker/NativeTimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/NativeTimePicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import classNames from 'classnames';
 import {
   BaseFormControl,
@@ -6,7 +6,7 @@ import {
   useInputGroupContext,
   useVariant,
 } from '@entur/form';
-import { VariantType, useOnMount, useRandomId } from '@entur/utils';
+import { VariantType, useOnMount } from '@entur/utils';
 
 import './NativeTimePicker.scss';
 
@@ -36,7 +36,7 @@ export const NativeTimePicker = React.forwardRef<
     { className, style, onChange, label, feedback, variant, prepend, ...rest },
     ref: React.Ref<HTMLInputElement>,
   ) => {
-    const nativetimepickerId = useRandomId('eds-native-timepicker');
+    const nativetimepickerId = `eds-native-timepicker${useId()}`;
     return (
       <BaseFormControl
         style={style}

--- a/packages/datepicker/src/TimePicker/TimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/TimePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useId, useRef } from 'react';
 import classNames from 'classnames';
 import { useTimeField } from '@react-aria/datepicker';
 import { I18nProvider, useLocale } from '@react-aria/i18n';
@@ -13,7 +13,7 @@ import type {
 
 import { VisuallyHidden } from '@entur/a11y';
 import { BaseFormControl, BaseFormControlProps } from '@entur/form';
-import { VariantType, useRandomId } from '@entur/utils';
+import { VariantType } from '@entur/utils';
 
 import { FieldSegment } from '../shared/FieldSegment';
 import { TimePickerArrowButton } from './TimePickerArrowButton';
@@ -138,7 +138,7 @@ export const TimePicker = <TimeType extends TimeValue>({
 }: TimePickerProps<TimeType>) => {
   let { locale } = useLocale();
   if (customLocale) locale = customLocale;
-  const timePickerId = useRandomId('eds-timepicker');
+  const timePickerId = `eds-timepicker${useId()}`;
 
   const timeZone =
     forcedTimeZone ??
@@ -177,7 +177,7 @@ export const TimePicker = <TimeType extends TimeValue>({
     state,
     timeFieldRef,
   );
-  const id = useRandomId('timepicker');
+  const id = `timepicker${useId()}`;
 
   const getCurrentTime = () => {
     const getCurrentTimeWithCorrectType = convertValueToType({

--- a/packages/dropdown/src/MultiSelect.tsx
+++ b/packages/dropdown/src/MultiSelect.tsx
@@ -2,6 +2,7 @@ import React, {
   Dispatch,
   SetStateAction,
   useEffect,
+  useId,
   useLayoutEffect,
   useRef,
   useState,
@@ -25,7 +26,7 @@ import {
 import { VisuallyHidden } from '@entur/a11y';
 import { BaseFormControl } from '@entur/form';
 import { space } from '@entur/tokens';
-import { mergeRefs, useRandomId } from '@entur/utils';
+import { mergeRefs } from '@entur/utils';
 
 import {
   DropdownFieldAppendix,
@@ -193,7 +194,7 @@ export const MultiSelect = React.forwardRef(
       selectedItems.length === normalizedItems.length;
 
     // special 'item' used as Select All entry in the dropdown list
-    const selectAllUniqueId = useRandomId('select-all');
+    const selectAllUniqueId = `select-all${useId()}`;
     const selectAll: NormalizedDropdownItemType<string> = React.useMemo(
       () => ({
         value: selectAllUniqueId,

--- a/packages/dropdown/src/NativeDropdown.tsx
+++ b/packages/dropdown/src/NativeDropdown.tsx
@@ -1,8 +1,8 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useId } from 'react';
 import { BaseFormControl } from '@entur/form';
 import { DownArrowIcon } from '@entur/icons';
 import { LoadingDots } from '@entur/loader';
-import { VariantType, useRandomId } from '@entur/utils';
+import { VariantType } from '@entur/utils';
 
 import { useResolvedItems } from './useResolvedItems';
 import {
@@ -91,7 +91,7 @@ export const NativeDropdown = forwardRef(
   ) => {
     const { items: normalizedItems, loading } =
       useResolvedItems<ValueType>(items);
-    const nativeDropdownId = useRandomId('eds-dropdown-native');
+    const nativeDropdownId = `eds-dropdown-native${useId()}`;
 
     return (
       <BaseFormControl

--- a/packages/expand/src/AccordionItem.tsx
+++ b/packages/expand/src/AccordionItem.tsx
@@ -1,5 +1,4 @@
-import React, { CSSProperties } from 'react';
-import { useRandomId } from '@entur/utils';
+import React, { CSSProperties, useId } from 'react';
 import { BaseExpandablePanel } from './BaseExpandablePanel';
 import { useAccordion } from './Accordion';
 
@@ -39,7 +38,7 @@ export const AccordionItem = React.forwardRef<
     },
     ref,
   ) => {
-    const randomId = useRandomId('eds-accordion-item');
+    const randomId = `eds-accordion-item${useId()}`;
     const id = overrideId || randomId;
     const { isOpen, toggle } = useAccordion({ id, defaultOpen });
 

--- a/packages/expand/src/ExpandablePanel.tsx
+++ b/packages/expand/src/ExpandablePanel.tsx
@@ -1,5 +1,4 @@
-import React, { CSSProperties } from 'react';
-import { useRandomId } from '@entur/utils';
+import React, { CSSProperties, useId } from 'react';
 import { BaseExpandablePanel } from './BaseExpandablePanel';
 
 export type ExpandablePanelProps = Omit<
@@ -44,7 +43,7 @@ export const ExpandablePanel = React.forwardRef<
     },
     ref,
   ) => {
-    const randomId = useRandomId('eds-expandable');
+    const randomId = `eds-expandable${useId()}`;
     const id = overrideId || randomId;
 
     const [internalOpen, setInternalOpen] =

--- a/packages/expand/src/ExpandableText.tsx
+++ b/packages/expand/src/ExpandableText.tsx
@@ -1,7 +1,5 @@
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, useId } from 'react';
 import classNames from 'classnames';
-
-import { useRandomId } from '@entur/utils';
 import { ExpandableTextButton } from './ExpandableTextButton';
 import { BaseExpand } from './BaseExpand';
 import {
@@ -71,7 +69,7 @@ export const ExpandableText = React.forwardRef<
     },
     ref,
   ) => {
-    const randomId = useRandomId('eds-expandable-text');
+    const randomId = `eds-expandable-text${useId()}`;
     const [internalOpen, setInternalOpen] =
       React.useState<boolean>(defaultOpen);
     const isControlled = controlledOpen !== undefined;

--- a/packages/form/src/TextArea.tsx
+++ b/packages/form/src/TextArea.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useId } from 'react';
 import classNames from 'classnames';
 
-import { VariantType, mergeRefs, useOnMount, useRandomId } from '@entur/utils';
+import { VariantType, mergeRefs, useOnMount } from '@entur/utils';
 
 import { useVariant } from './VariantProvider';
 import { BaseFormControl } from './BaseFormControl';
@@ -65,7 +65,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     },
     ref: React.Ref<HTMLTextAreaElement>,
   ) => {
-    const textAreaId = useRandomId('eds-textarea');
+    const textAreaId = `eds-textarea${useId()}`;
     const textareaRef = React.useRef<HTMLTextAreaElement>(null);
     return (
       <BaseFormControl

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useId } from 'react';
 import classNames from 'classnames';
 
 import { IconButton } from '@entur/button';
 import { CloseSmallIcon } from '@entur/icons';
 import { Placement } from '@entur/tooltip';
-import { VariantType, mergeRefs, useRandomId } from '@entur/utils';
+import { VariantType, mergeRefs } from '@entur/utils';
 
 import { BaseFormControl } from './BaseFormControl';
 import { useInputGroupContext } from './InputGroupContext';
@@ -100,7 +100,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     },
     ref: React.Ref<HTMLInputElement>,
   ) => {
-    const randomId = useRandomId('eds-textfield');
+    const randomId = `eds-textfield${useId()}`;
     const textFieldId = labelProps && labelProps.id ? labelProps.id : randomId;
     const textFieldRef = React.useRef<HTMLInputElement>(null);
     const { setFilled } = useInputGroupContext();

--- a/packages/form/src/inputPanel/InputPanelBase.tsx
+++ b/packages/form/src/inputPanel/InputPanelBase.tsx
@@ -1,6 +1,6 @@
-import React, { useRef } from 'react';
+import React, { useId, useRef } from 'react';
 import classNames from 'classnames';
-import { mergeRefs, useForceUpdate, useRandomId } from '@entur/utils';
+import { mergeRefs, useForceUpdate } from '@entur/utils';
 import { Checkbox } from '../Checkbox';
 import { Radio } from '../Radio';
 
@@ -85,7 +85,7 @@ export const InputPanelBase = React.forwardRef<
 
     const inputRef = useRef<HTMLInputElement>(null);
 
-    const defaultId = useRandomId('eds-inputpanel');
+    const defaultId = `eds-inputpanel${useId()}`;
     const inputPanelId = id || defaultId;
     const forceUpdate = useForceUpdate();
 

--- a/packages/form/src/segmentedControl/SegmentedControl.tsx
+++ b/packages/form/src/segmentedControl/SegmentedControl.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useId } from 'react';
 import classNames from 'classnames';
 import { Label } from '@entur/typography';
-import { ExtendableProps, useRandomId } from '@entur/utils';
+import { ExtendableProps } from '@entur/utils';
 import './SegmentedControl.scss';
 
 type SegmentedContextProps = {
@@ -86,7 +86,7 @@ export const SegmentedControl = React.forwardRef<
       defaultValue ?? null,
     );
     const [focusedValue, setFocusedValue] = React.useState<string | null>(null);
-    const id = useRandomId('eds-segmented-control');
+    const id = `eds-segmented-control${useId()}`;
 
     const isControlled = deprecatedValue !== undefined || value !== undefined;
     const currentValue =

--- a/packages/menu/src/Pagination.tsx
+++ b/packages/menu/src/Pagination.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import classNames from 'classnames';
 
 import { DownArrowIcon, LeftArrowIcon, RightArrowIcon } from '@entur/icons';
 import { VisuallyHidden } from '@entur/a11y';
 import { Label } from '@entur/typography';
-import { useRandomId } from '@entur/utils';
 
 import { PaginationPage } from './PaginationPage';
 import { PaginationInput } from './PaginationInput';
@@ -111,7 +110,7 @@ export const Pagination = ({
   ...rest
 }: PaginationProps) => {
   const [listedEntries, setListedEntries] = useState<Array<number | '…'>>([]);
-  const paginationId = useRandomId('eds-pagination');
+  const paginationId = `eds-pagination${useId()}`;
 
   const isFirstPostSelected = currentPage === 1;
   const isLastPostSelected = currentPage === pageCount;

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId, useRef } from 'react';
 import classNames from 'classnames';
-import { mergeRefs, useRandomId } from '@entur/utils';
+import { mergeRefs } from '@entur/utils';
 import { VisuallyHidden } from '@entur/a11y';
 
 export type TableProps = {
@@ -35,7 +35,7 @@ export const Table = React.forwardRef<HTMLTableElement, TableProps>(
     },
     ref,
   ) => {
-    const sortableHeaderId = useRandomId('sortable-header');
+    const sortableHeaderId = `sortable-header${useId()}`;
 
     const tableRef = useRef<HTMLTableElement>(null);
 

--- a/packages/tooltip/src/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, useEffect, useRef, useState } from 'react';
+import React, { cloneElement, useEffect, useId, useRef, useState } from 'react';
 
 import classNames from 'classnames';
 import {
@@ -11,7 +11,6 @@ import {
   useFloating,
 } from '@floating-ui/react';
 
-import { useRandomId } from '@entur/utils';
 import { CloseIcon } from '@entur/icons';
 import { IconButton } from '@entur/button';
 import { borderRadiuses, space } from '@entur/tokens';
@@ -110,7 +109,7 @@ export const Tooltip = ({
 }: TooltipProps) => {
   const [showTooltip, setShowTooltip] = useState(isOpen ?? false);
   const tooltipArrowRef = useRef(null);
-  const tooltipId = useRandomId('eds-tooltip');
+  const tooltipId = `eds-tooltip${useId()}`;
   const hoverOpenTimer = useRef<ReturnType<typeof setTimeout>>();
   const hoverCloseTimer = useRef<ReturnType<typeof setTimeout>>();
 


### PR DESCRIPTION
## 💡 Hvorfor?

`useRandomId` fra `@entur/utils` er et wrapper-hook rundt Reacts innebygde `useId()`. Wrapperen er overflødig og legger til et unødvendig lag med indirection. Ved å bruke `useId()` direkte fjerner vi avhengigheten til utility-hooken i komponentene.

Relatert: ETU-74155

## 🔧 Hvordan?

I alle 18 berørte komponentfiler:

- Fjernet `useRandomId`-import fra `@entur/utils`
- Lagt til `useId` i React-importen
- Erstattet `useRandomId('prefix')` med `` `prefix${useId()}` ``

`useRandomId`-hooken beholdes i `@entur/utils` siden det er en del av den offentlige API-en.

## 🧩 Type endring

- [x] 🧹 Refaktorering (ingen funksjonelle endringer)

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [x] TypeScript-sjekk kjørt — ingen nye feil innført