### PR TITLE
fix(menu/logo): announce logo as single cohesive image for screen readers

### DIFF
--- a/packages/menu/src/Logo.test.tsx
+++ b/packages/menu/src/Logo.test.tsx
@@ -60,3 +60,21 @@ test('forwards additional props', () => {
   const { container } = render(<Logo data-testid="logo" />);
   expect(container.firstChild).toHaveAttribute('data-testid', 'logo');
 });
+
+test('SVG has combined aria-label with product name', () => {
+  const { container } = render(<Logo productName="Miljødata" />);
+  const svg = container.querySelector('svg');
+  expect(svg).toHaveAttribute('aria-label', 'Entur Miljødata logo');
+});
+
+test('SVG has "Entur logo" aria-label without product name', () => {
+  const { container } = render(<Logo />);
+  const svg = container.querySelector('svg');
+  expect(svg).toHaveAttribute('aria-label', 'Entur logo');
+});
+
+test('product name span is aria-hidden', () => {
+  const { container } = render(<Logo productName="Tavla" />);
+  const span = container.querySelector('.eds-logo__product-name');
+  expect(span).toHaveAttribute('aria-hidden', 'true');
+});

--- a/packages/menu/src/Logo.tsx
+++ b/packages/menu/src/Logo.tsx
@@ -53,22 +53,30 @@ export const Logo: LogoComponent = React.forwardRef(
         href={typeof Element !== 'string' || Element === 'a' ? href : undefined}
         {...rest}
       >
-        <EnturSvgLogo className="eds-logo__svg" />
+        <EnturSvgLogo
+          className="eds-logo__svg"
+          label={productName ? `Entur ${productName} logo` : 'Entur logo'}
+        />
         {productName && (
-          <span className="eds-logo__product-name">{productName}</span>
+          <span className="eds-logo__product-name" aria-hidden="true">
+            {productName}
+          </span>
         )}
       </Element>
     );
   },
 );
 
-const EnturSvgLogo: React.FC<{ className?: string }> = ({ className }) => (
+const EnturSvgLogo: React.FC<{ className?: string; label: string }> = ({
+  className,
+  label,
+}) => (
   <svg
     className={className}
     viewBox="0 0 68.625 20.8254"
     xmlns="http://www.w3.org/2000/svg"
     role="img"
-    aria-label="Entur"
+    aria-label={label}
     focusable="false"
   >
     {/* E */}


### PR DESCRIPTION
## 💡 Hvorfor?

Skjermlesere annonserte Entur-SVG og produktnavnet som to separate elementer. En bruker hørte først «Entur, bilde», og måtte navigere til neste element for å høre produktnavnet. Dette bryter med WCAG 1.3.1 – logoen skal oppfattes som én samlet enhet.

Ref: [ETU-74412](https://entur.atlassian.net/browse/ETU-74412)

## 🔧 Hvordan?

- SVG `aria-label` inkluderer nå produktnavn og «logo»-suffiks, f.eks. `"Entur Miljødata logo"` (eller `"Entur logo"` uten produktnavn)
- Produktnavn-`<span>` har fått `aria-hidden="true"` slik at teksten ikke annonseres dobbelt
- Tre nye tester verifiserer ny a11y-oppførsel

## 🧩 Type endring

- [x] 🐞 Feilretting

## 💬 Tilleggsnotater

Basert på tilbakemelding fra Andreas Jacobsen i Slack.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden

AI-assistant: Claude Code (claude-opus-4-6)

[ETU-74412]: https://entur.atlassian.net/browse/ETU-74412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ