### PR TITLE
fix(form, datepicker, dropdown): announce feedback text to screen readers by default

### DIFF
--- a/apps/documentation/src/pages/komponenter/skjemaelementer/dropdown.mdx
+++ b/apps/documentation/src/pages/komponenter/skjemaelementer/dropdown.mdx
@@ -447,6 +447,14 @@ Her finner du en native dropdown med standard-props.
   scope={{cities}}
 />
 
+## Tilgjengelighet
+
+`feedback` vises i en live region med `role="status"`, slik at skjermlesere leser opp meldingen når den kommer. Du trenger derfor ikke legge til en egen `aria-live`-region rundt feltet. Det gir dobbel opplesing.
+
+Ikonet ved siden av meldingen er skjult for skjermlesere. Teksten må derfor være selvforklarende og tydelig formidle om det er en feilmelding eller et varsel.
+
+Du kan styre opplesingen med `ariaAlertOnFeedback`. Standardverdien `'status'` gir en høflig opplesing, `'alert'` avbryter skjermleseren umiddelbart – bruk den bare til meldinger som hindrer brukeren i å komme videre – og `false` skrur av opplesingen helt. Med `feedbackProps` kan du sette egne `role`- og `aria-live`-verdier på feedback-teksten.
+
 ## Props
 
 ### Dropdown

--- a/apps/documentation/src/pages/komponenter/skjemaelementer/textarea.mdx
+++ b/apps/documentation/src/pages/komponenter/skjemaelementer/textarea.mdx
@@ -27,6 +27,14 @@ Text areas er lange tekstfelt som lar brukeren skrive tekst over flere linjer. T
 
 For tekst som går over flere linjer, bruk heller [Text field](/komponenter/skjemaelementer/textfield).
 
+## Tilgjengelighet
+
+`feedback` vises i en live region med `role="status"`, slik at skjermlesere leser opp meldingen når den kommer. Du trenger derfor ikke legge til en egen `aria-live`-region rundt feltet. Det gir dobbel opplesing.
+
+Ikonet ved siden av meldingen er skjult for skjermlesere. Teksten må derfor være selvforklarende og tydelig formidle om det er en feilmelding eller et varsel.
+
+Du kan styre opplesingen med `ariaAlertOnFeedback`. Standardverdien `'status'` gir en høflig opplesing, `'alert'` avbryter skjermleseren umiddelbart – bruk den bare til meldinger som hindrer brukeren i å komme videre – og `false` skrur av opplesingen helt. Med `feedbackProps` kan du sette egne `role`- og `aria-live`-verdier på feedback-teksten.
+
 ## Props
 
 ### TextArea

--- a/apps/documentation/src/pages/komponenter/skjemaelementer/textfield.mdx
+++ b/apps/documentation/src/pages/komponenter/skjemaelementer/textfield.mdx
@@ -42,6 +42,14 @@ https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes
 
   For tekst som går over flere linjer, bruk heller [Text area](/komponenter/skjemaelementer/textarea).
 
+## Tilgjengelighet
+
+`feedback` vises i en live region med `role="status"`, slik at skjermlesere leser opp meldingen når den kommer. Du trenger derfor ikke legge til en egen `aria-live`-region rundt feltet. Det gir dobbel opplesing.
+
+Ikonet ved siden av meldingen er skjult for skjermlesere. Teksten må derfor være selvforklarende og tydelig formidle om det er en feilmelding eller et varsel.
+
+Du kan styre opplesingen med `ariaAlertOnFeedback`. Standardverdien `'status'` gir en høflig opplesing, `'alert'` avbryter skjermleseren umiddelbart – bruk den bare til meldinger som hindrer brukeren i å komme videre – og `false` skrur av opplesingen helt. Med `feedbackProps` kan du sette egne `role`- og `aria-live`-verdier på feedback-teksten.
+
 ## Props
 
 ### TextField

--- a/apps/documentation/src/pages/komponenter/skjemaelementer/timepicker.mdx
+++ b/apps/documentation/src/pages/komponenter/skjemaelementer/timepicker.mdx
@@ -167,6 +167,8 @@ Hvert tidssegment er tilgjengelig med tastaturet og alle interagerbare elementer
 
 Hvis du endrer `locale` (dvs. språk) må du sende inn verdier på riktig språk til `leftArrowButtonAriaLabel`- og `rightArrowButtonAriaLabel`-props-ene.
 
+`feedback` vises i en live region med `role="status"`, slik at skjermlesere leser opp meldingen når den kommer. Ikonet ved siden av meldingen er skjult for skjermlesere, så teksten må være selvforklarende og tydelig formidle om det er en feilmelding eller et varsel. Du kan styre opplesingen med `ariaAlertOnFeedback`, der standardverdien `'status'` gir en høflig opplesing, `'alert'` avbryter skjermleseren umiddelbart og `false` skrur av opplesingen helt, og med `feedbackProps` kan du sette egne `role`- og `aria-live`-verdier.
+
 ### Mer kompakt fritektsvariant (B2B)
 
 For grensesnitt der et kompakt skjemafelt og mulighet til å kopiere og lime inn fullstendige tidspunkt er viktig kan man bruke `SimpleTimePicker`. Denne varianten inneholder

--- a/apps/documentation/src/pages/stand.tsx
+++ b/apps/documentation/src/pages/stand.tsx
@@ -934,7 +934,6 @@ const Stand = () => {
                 className="stand__question__field"
                 feedback={errorMessage ?? undefined}
                 variant={errorMessage ? 'negative' : undefined}
-                ariaAlertOnFeedback="status"
               />
               <PrimaryButton type="submit">Legg til</PrimaryButton>
             </form>

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
@@ -260,7 +260,7 @@
       "defaultValue": {
         "value": true
       },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
+      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = role=\"status\" (venter til brukeren er ferdig)\n'alert' = role=\"alert\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
@@ -258,9 +258,9 @@
     },
     "ariaAlertOnFeedback": {
       "defaultValue": {
-        "value": false
+        "value": true
       },
-      "description": "",
+      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/BaseFormControl.json
@@ -4,6 +4,38 @@
   "displayName": "BaseFormControl",
   "methods": [],
   "props": {
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "status"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "packages/form/src/BaseFormControl.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "packages/form/src/BaseFormControl.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
+    },
     "disabled": {
       "defaultValue": {
         "value": false
@@ -254,23 +286,6 @@
       "required": false,
       "type": {
         "name": "boolean | undefined"
-      }
-    },
-    "ariaAlertOnFeedback": {
-      "defaultValue": {
-        "value": true
-      },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = role=\"status\" (venter til brukeren er ferdig)\n'alert' = role=\"alert\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
-      "name": "ariaAlertOnFeedback",
-      "declarations": [
-        {
-          "fileName": "packages/form/src/BaseFormControl.tsx",
-          "name": "TypeLiteral"
-        }
-      ],
-      "required": false,
-      "type": {
-        "name": "boolean | \"alert\" | \"status\" | undefined"
       }
     },
     "after": {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
@@ -487,7 +487,7 @@
       "defaultValue": {
         "value": "true"
       },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
+      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = role=\"status\" (venter til brukeren er ferdig)\n'alert' = role=\"alert\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
@@ -484,8 +484,10 @@
       }
     },
     "ariaAlertOnFeedback": {
-      "defaultValue": null,
-      "description": "",
+      "defaultValue": {
+        "value": "true"
+      },
+      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
@@ -378,6 +378,38 @@
         "name": "CSSProperties | undefined"
       }
     },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "'status'"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
+    },
     "prepend": {
       "defaultValue": null,
       "description": "Tekst eller ikon som vises foran skjema-elementet",
@@ -481,23 +513,6 @@
       "required": false,
       "type": {
         "name": "boolean | undefined"
-      }
-    },
-    "ariaAlertOnFeedback": {
-      "defaultValue": {
-        "value": "true"
-      },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = role=\"status\" (venter til brukeren er ferdig)\n'alert' = role=\"alert\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
-      "name": "ariaAlertOnFeedback",
-      "declarations": [
-        {
-          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
-          "name": "TypeLiteral"
-        }
-      ],
-      "required": false,
-      "type": {
-        "name": "boolean | \"alert\" | \"status\" | undefined"
       }
     },
     "after": {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DatePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DatePicker.json
@@ -469,6 +469,38 @@
         "name": "((date: CalendarDate) => string) | undefined"
       }
     },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "'status'"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
+    },
     "prepend": {
       "defaultValue": null,
       "description": "Tekst eller ikon som vises foran skjema-elementet",
@@ -572,21 +604,6 @@
       "required": false,
       "type": {
         "name": "boolean | undefined"
-      }
-    },
-    "ariaAlertOnFeedback": {
-      "defaultValue": null,
-      "description": "",
-      "name": "ariaAlertOnFeedback",
-      "declarations": [
-        {
-          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
-          "name": "TypeLiteral"
-        }
-      ],
-      "required": false,
-      "type": {
-        "name": "boolean | \"alert\" | \"status\" | undefined"
       }
     },
     "after": {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Dropdown.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Dropdown.json
@@ -404,6 +404,38 @@
       "type": {
         "name": "string | undefined"
       }
+    },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "'status'"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
     }
   }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FeedbackText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FeedbackText.json
@@ -14,7 +14,7 @@
           "name": "TypeLiteral"
         }
       ],
-      "required": true,
+      "required": false,
       "type": {
         "name": "ReactNode"
       }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/FeedbackText.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/FeedbackText.json
@@ -6,7 +6,7 @@
   "props": {
     "children": {
       "defaultValue": null,
-      "description": "Teksten som vises",
+      "description": "Teksten som vises. Uten tekst rendres en tom (usynlig) container,\nslik at en aria-live-region kan eksistere i DOM før meldingen settes",
       "name": "children",
       "declarations": [
         {
@@ -46,9 +46,9 @@
           "name": "TypeLiteral"
         }
       ],
-      "required": true,
+      "required": false,
       "type": {
-        "name": "VariantType | \"error\" | \"info\""
+        "name": "VariantType | \"error\" | \"info\" | undefined"
       }
     },
     "className": {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/MultiSelect.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/MultiSelect.json
@@ -375,6 +375,38 @@
         "name": "string | undefined"
       }
     },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "'status'"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
+    },
     "selectedItems": {
       "defaultValue": {
         "value": "[]"

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NativeDatePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NativeDatePicker.json
@@ -101,6 +101,38 @@
       "type": {
         "name": "ReactNode"
       }
+    },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "'status'"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
     }
   }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/NativeTimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/NativeTimePicker.json
@@ -82,6 +82,38 @@
       "type": {
         "name": "ReactNode"
       }
+    },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "'status'"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
     }
   }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SearchableDropdown.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SearchableDropdown.json
@@ -411,6 +411,38 @@
         "name": "string | undefined"
       }
     },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "'status'"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
+    },
     "itemFilter": {
       "defaultValue": {
         "value": "isFunctionWithQueryArgument(initialItems)\n        ? noFilter\n        : lowerCaseFilterTest"

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SimpleTimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SimpleTimePicker.json
@@ -252,6 +252,38 @@
         "name": "CSSProperties | undefined"
       }
     },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "'status'"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
+    },
     "labelTooltipButtonAriaLabel": {
       "defaultValue": null,
       "description": "Forklarende tekst for knappen som åpner labelTooltip",
@@ -340,21 +372,6 @@
       "required": false,
       "type": {
         "name": "boolean | undefined"
-      }
-    },
-    "ariaAlertOnFeedback": {
-      "defaultValue": null,
-      "description": "",
-      "name": "ariaAlertOnFeedback",
-      "declarations": [
-        {
-          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
-          "name": "TypeLiteral"
-        }
-      ],
-      "required": false,
-      "type": {
-        "name": "boolean | \"alert\" | \"status\" | undefined"
       }
     },
     "after": {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TextArea.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TextArea.json
@@ -191,19 +191,34 @@
     },
     "ariaAlertOnFeedback": {
       "defaultValue": {
-        "value": "true"
+        "value": "'status'"
       },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "packages/form/src/TextArea.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
       "required": false,
       "type": {
         "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "packages/form/src/BaseFormControl.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
       }
     }
   }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TextArea.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TextArea.json
@@ -188,6 +188,23 @@
       "type": {
         "name": "\"vertical\" | \"none\" | undefined"
       }
+    },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "true"
+      },
+      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "packages/form/src/TextArea.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
     }
   }
 }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
@@ -285,9 +285,9 @@
     },
     "ariaAlertOnFeedback": {
       "defaultValue": {
-        "value": false
+        "value": "true"
       },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\n'status' = aria-live=\"polite\" (venter til bruker er ferdig)\nundefined/false = ingen automatisk annonsering",
+      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
@@ -287,7 +287,7 @@
       "defaultValue": {
         "value": "true"
       },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
+      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = role=\"status\" (venter til brukeren er ferdig)\n'alert' = role=\"alert\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TextField.json
@@ -285,19 +285,34 @@
     },
     "ariaAlertOnFeedback": {
       "defaultValue": {
-        "value": "true"
+        "value": "'status'"
       },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = role=\"status\" (venter til brukeren er ferdig)\n'alert' = role=\"alert\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {
-          "fileName": "packages/form/src/TextField.tsx",
+          "fileName": "packages/form/src/BaseFormControl.tsx",
           "name": "TypeLiteral"
         }
       ],
       "required": false,
       "type": {
         "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "packages/form/src/BaseFormControl.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
       }
     }
   }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
@@ -305,6 +305,38 @@
         "name": "CSSProperties | undefined"
       }
     },
+    "ariaAlertOnFeedback": {
+      "defaultValue": {
+        "value": "'status'"
+      },
+      "description": "Styrer hvordan feedback-teksten annonseres av skjermlesere.\nStandarden 'status' lar skjermleseren annonsere meldingen når\nbrukeren er ferdig med det den holder på med, og live region-en\nrendres da alltid i DOM, også før meldingen finnes.\ntrue/'alert' gir role=\"alert\", som avbryter skjermleseren og\nannonserer meldingen umiddelbart – bruk den bare til meldinger som\nhindrer brukeren i å komme videre. false skrur av automatisk\nannonsering.",
+      "name": "ariaAlertOnFeedback",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | \"alert\" | \"status\" | undefined"
+      }
+    },
+    "feedbackProps": {
+      "defaultValue": null,
+      "description": "Ekstra props som sendes til feedback-teksten. Egne `role`- og\n`aria-live`-verdier her overstyrer ariaAlertOnFeedback",
+      "name": "feedbackProps",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "HTMLAttributes<HTMLElement> | undefined"
+      }
+    },
     "prepend": {
       "defaultValue": null,
       "description": "Tekst eller ikon som vises foran skjema-elementet",
@@ -423,23 +455,6 @@
       "required": false,
       "type": {
         "name": "boolean | undefined"
-      }
-    },
-    "ariaAlertOnFeedback": {
-      "defaultValue": {
-        "value": "true"
-      },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = role=\"status\" (venter til brukeren er ferdig)\n'alert' = role=\"alert\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
-      "name": "ariaAlertOnFeedback",
-      "declarations": [
-        {
-          "fileName": "node_modules/@entur/form/dist/BaseFormControl.d.ts",
-          "name": "TypeLiteral"
-        }
-      ],
-      "required": false,
-      "type": {
-        "name": "boolean | \"alert\" | \"status\" | undefined"
       }
     },
     "after": {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
@@ -429,7 +429,7 @@
       "defaultValue": {
         "value": "true"
       },
-      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
+      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = role=\"status\" (venter til brukeren er ferdig)\n'alert' = role=\"alert\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
@@ -426,8 +426,10 @@
       }
     },
     "ariaAlertOnFeedback": {
-      "defaultValue": null,
-      "description": "",
+      "defaultValue": {
+        "value": "true"
+      },
+      "description": "Setter feedback-tekstens rolle for skjermlesere.\ntrue/'status' = aria-live=\"polite\" (venter til brukeren er ferdig)\n'alert' = aria-live=\"assertive\" (avbryter umiddelbart)\nfalse = ingen automatisk annonsering",
       "name": "ariaAlertOnFeedback",
       "declarations": [
         {

--- a/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
@@ -124,7 +124,7 @@
     "outputs": ["CalendarGrid.json"]
   },
   "datepicker/src/DatePicker/DateField.tsx": {
-    "hash": "b5edbb48e99c4974b0bce7579d7459da",
+    "hash": "1eb389aa6ee7eda08413fc8cb99dc4f6",
     "outputs": ["DateField.json"]
   },
   "datepicker/src/DatePicker/DatePicker.tsx": {
@@ -132,19 +132,19 @@
     "outputs": ["DatePicker.json"]
   },
   "datepicker/src/DatePicker/NativeDatePicker.tsx": {
-    "hash": "fd59b50cb6bb737982aefcbedf1948c8",
+    "hash": "0c423bd649ad344db659f269b39fd9a4",
     "outputs": ["NativeDatePicker.json"]
   },
   "datepicker/src/TimePicker/NativeTimePicker.tsx": {
-    "hash": "287edf91faaccea3449fd4f649539b4f",
+    "hash": "f70a79fb42704e64363f1c38e4e06b92",
     "outputs": ["NativeTimePicker.json"]
   },
   "datepicker/src/TimePicker/SimpleTimePicker.tsx": {
-    "hash": "43a8b19441ebaf35db4f9bb4d253615e",
+    "hash": "2db5741209e095ca9b4bff7e84e4f772",
     "outputs": ["SimpleTimePicker.json"]
   },
   "datepicker/src/TimePicker/TimePicker.tsx": {
-    "hash": "3e90394d60396488cf4c4c73ca96d9b6",
+    "hash": "cc15b508ac998af42df723b2e6fba056",
     "outputs": ["TimePicker.json"]
   },
   "datepicker/src/TimePicker/TimePickerArrowButton.tsx": {
@@ -160,19 +160,19 @@
     "outputs": ["FieldSegment.json"]
   },
   "dropdown/src/Dropdown.tsx": {
-    "hash": "2385c97e21037664a9efa973cf74a5a7",
+    "hash": "22777c0984dd9900d958a1a20ad6f7d7",
     "outputs": ["Dropdown.json"]
   },
   "dropdown/src/MultiSelect.tsx": {
-    "hash": "360185b1f719321e9728478028b766d3",
+    "hash": "3c241433dd1741f80b1ad80f9b7eb37a",
     "outputs": ["MultiSelect.json"]
   },
   "dropdown/src/NativeDropdown.tsx": {
-    "hash": "769370d0660f7030c4fdb8e07c554155",
+    "hash": "5367cc2a4915cfff6d0dac7b5ec444d8",
     "outputs": ["NativeDropdown.json"]
   },
   "dropdown/src/SearchableDropdown.tsx": {
-    "hash": "56128d532a96a014e9bededbb0d45d69",
+    "hash": "cbecefdb5ee1753a19760cdbcc31ab9f",
     "outputs": ["SearchableDropdown.json"]
   },
   "dropdown/src/components/DropdownList.tsx": {
@@ -224,7 +224,7 @@
     "outputs": ["FileUpload.json"]
   },
   "form/src/BaseFormControl.tsx": {
-    "hash": "0f951ac0829ab91bfe452d5a80b4eec0",
+    "hash": "53de9b3c4146482ced3c73028d98c77a",
     "outputs": ["BaseFormControl.json"]
   },
   "form/src/Checkbox.tsx": {
@@ -232,7 +232,7 @@
     "outputs": ["Checkbox.json"]
   },
   "form/src/FeedbackText.tsx": {
-    "hash": "eb5c58d27083a1b85d786d69d64e8267",
+    "hash": "a57b788b7912f9a4a753ec515eaebd6e",
     "outputs": ["FeedbackText.json"]
   },
   "form/src/Fieldset.tsx": {
@@ -264,11 +264,11 @@
     "outputs": ["Switch.json"]
   },
   "form/src/TextArea.tsx": {
-    "hash": "521d2f034b6d36bf2a71ff28ed00b1f9",
+    "hash": "40d513676525e54841b398e9b5a7d77e",
     "outputs": ["TextArea.json"]
   },
   "form/src/TextField.tsx": {
-    "hash": "564ec4b785ec633f84da33e6dbc72afd",
+    "hash": "051f8aa2971cf3d7267f149f17286963",
     "outputs": ["TextField.json"]
   },
   "form/src/VariantProvider.tsx": {
@@ -452,7 +452,7 @@
     "outputs": ["TopNavigationItem.json"]
   },
   "modal/src/Drawer.tsx": {
-    "hash": "e59082c08a21c11a963cc5740dff8309",
+    "hash": "452f58123c7627b933c2c96ac8c15ddb",
     "outputs": ["Drawer.json"]
   },
   "modal/src/Modal.tsx": {
@@ -700,10 +700,6 @@
     "hash": "78028597a1b5a58cbdb00672075cfdf3",
     "outputs": ["RangeCalendarCell.json"]
   },
-  "datepicker/src/DatePicker/RangeCalendarGrid.tsx": {
-    "hash": "b074f3d4133cb9c965b2914b6d913bae",
-    "outputs": ["RangeCalendarGrid.json"]
-  },
   "datepicker/src/DatePicker/CalendarBase.tsx": {
     "hash": "b1efaa23aaaec28b5f4512c20ca08896",
     "outputs": ["CalendarBase.json"]
@@ -713,11 +709,11 @@
     "outputs": []
   },
   "menu/src/beta/SideNavigation/SideNavigation.tsx": {
-    "hash": "fdf22f55d0b67b59b298ca3592919ee7",
+    "hash": "754f7f8ca7ddbac5b9215b127d2ae03d",
     "outputs": ["SideNavigationBeta.json"]
   },
   "menu/src/beta/SideNavigation/SideNavigationExpandableItem.tsx": {
-    "hash": "846bcf1ab7d734e6fddc745c8e055b8a",
+    "hash": "521661ec4006d514682e1bd17131a233",
     "outputs": ["SideNavigationBeta.ExpandableItem.json"]
   },
   "menu/src/beta/SideNavigation/SideNavigationGroup.tsx": {
@@ -725,11 +721,11 @@
     "outputs": ["SideNavigationBeta.Group.json"]
   },
   "menu/src/beta/SideNavigation/SideNavigationItem.tsx": {
-    "hash": "0fe3822a9b5476137297aae5c97cc585",
+    "hash": "3f849f51f6126f41e41d7be92bc3cdeb",
     "outputs": ["SideNavigationBeta.Item.json"]
   },
   "menu/src/beta/SideNavigation/SideNavigationItemContent.tsx": {
-    "hash": "b51ed3bad83aa205e495d7f7c06f03d7",
+    "hash": "b49fb98325c024d19c21d2a016a83f55",
     "outputs": ["SideNavigationBeta.ItemContent.json"]
   }
 }

--- a/packages/datepicker/src/DatePicker/DateField.tsx
+++ b/packages/datepicker/src/DatePicker/DateField.tsx
@@ -164,6 +164,7 @@ export const DateField = <DateType extends DateValue>({
   onValidate,
   dateFieldRef: ref,
   ariaAlertOnFeedback,
+  feedbackProps,
   ...rest
 }: DateFieldProps<DateType>) => {
   const { locale } = useLocale();
@@ -208,6 +209,7 @@ export const DateField = <DateType extends DateValue>({
       <BaseFormControl
         append={append}
         ariaAlertOnFeedback={ariaAlertOnFeedback}
+        feedbackProps={feedbackProps}
         className={classNames('eds-datefield', className, {
           'eds-datefield--has-tooltip': labelTooltip !== undefined,
         })}

--- a/packages/datepicker/src/DatePicker/DateField.tsx
+++ b/packages/datepicker/src/DatePicker/DateField.tsx
@@ -24,7 +24,6 @@ import {
   createCalendar,
   getAdjustedMaxDate,
   handleOnChange,
-  shouldUseAriaAlert,
 } from '../shared/utils';
 
 import './DateField.scss';
@@ -164,6 +163,7 @@ export const DateField = <DateType extends DateValue>({
   prepend,
   onValidate,
   dateFieldRef: ref,
+  ariaAlertOnFeedback,
   ...rest
 }: DateFieldProps<DateType>) => {
   const { locale } = useLocale();
@@ -207,9 +207,7 @@ export const DateField = <DateType extends DateValue>({
     >
       <BaseFormControl
         append={append}
-        ariaAlertOnFeedback={shouldUseAriaAlert(
-          variant ?? (state.isInvalid ? validationVariant : undefined),
-        )}
+        ariaAlertOnFeedback={ariaAlertOnFeedback}
         className={classNames('eds-datefield', className, {
           'eds-datefield--has-tooltip': labelTooltip !== undefined,
         })}

--- a/packages/datepicker/src/DatePicker/NativeDatePicker.tsx
+++ b/packages/datepicker/src/DatePicker/NativeDatePicker.tsx
@@ -123,7 +123,7 @@ const NativeDatePickerBase = React.forwardRef<
   return (
     <input
       ref={ref}
-      aria-invalid={currentVariant === 'error'}
+      aria-invalid={currentVariant === 'negative' || currentVariant === error}
       type="date"
       className="eds-form-control eds-native-date-picker"
       onChange={handleChange}

--- a/packages/datepicker/src/DatePicker/NativeDatePicker.tsx
+++ b/packages/datepicker/src/DatePicker/NativeDatePicker.tsx
@@ -1,6 +1,7 @@
 import React, { useId } from 'react';
 import {
   BaseFormControl,
+  FeedbackAnnouncementProps,
   isFilled,
   useInputGroupContext,
   useVariant,
@@ -30,7 +31,8 @@ export type NativeDatePickerProps = {
    * @default <DateIcon />
    */
   prepend?: React.ReactNode;
-} & React.InputHTMLAttributes<HTMLInputElement>;
+} & FeedbackAnnouncementProps &
+  React.InputHTMLAttributes<HTMLInputElement>;
 
 export const NativeDatePicker = React.forwardRef<
   HTMLInputElement,
@@ -46,6 +48,8 @@ export const NativeDatePicker = React.forwardRef<
       variant,
       disableLabelAnimation,
       prepend = <DateIcon inline />,
+      ariaAlertOnFeedback,
+      feedbackProps,
       ...rest
     },
     ref: React.Ref<HTMLInputElement>,
@@ -61,6 +65,8 @@ export const NativeDatePicker = React.forwardRef<
         variant={variant}
         labelId={nativedatepickerId}
         disableLabelAnimation={disableLabelAnimation}
+        ariaAlertOnFeedback={ariaAlertOnFeedback}
+        feedbackProps={feedbackProps}
         isFilled
       >
         <NativeDatePickerBase

--- a/packages/datepicker/src/TimePicker/NativeTimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/NativeTimePicker.tsx
@@ -115,7 +115,7 @@ const NativeTimePickerBase = React.forwardRef<
   return (
     <input
       ref={ref}
-      aria-invalid={currentVariant === 'error'}
+      aria-invalid={currentVariant === 'negative' || currentVariant === error}
       type="time"
       className="eds-form-control"
       onChange={handleChange}

--- a/packages/datepicker/src/TimePicker/NativeTimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/NativeTimePicker.tsx
@@ -2,6 +2,7 @@ import React, { useId } from 'react';
 import classNames from 'classnames';
 import {
   BaseFormControl,
+  FeedbackAnnouncementProps,
   isFilled,
   useInputGroupContext,
   useVariant,
@@ -26,14 +27,26 @@ export type NativeTimePickerProps = {
   variant?: VariantType | typeof error | typeof info;
   /** Tekst eller ikon som kommer før inputfelter */
   prepend?: React.ReactNode;
-} & React.InputHTMLAttributes<HTMLInputElement>;
+} & FeedbackAnnouncementProps &
+  React.InputHTMLAttributes<HTMLInputElement>;
 
 export const NativeTimePicker = React.forwardRef<
   HTMLInputElement,
   NativeTimePickerProps
 >(
   (
-    { className, style, onChange, label, feedback, variant, prepend, ...rest },
+    {
+      className,
+      style,
+      onChange,
+      label,
+      feedback,
+      variant,
+      prepend,
+      ariaAlertOnFeedback,
+      feedbackProps,
+      ...rest
+    },
     ref: React.Ref<HTMLInputElement>,
   ) => {
     const nativetimepickerId = `eds-native-timepicker${useId()}`;
@@ -47,6 +60,8 @@ export const NativeTimePicker = React.forwardRef<
         variant={variant}
         labelId={nativetimepickerId}
         disableLabelAnimation
+        ariaAlertOnFeedback={ariaAlertOnFeedback}
+        feedbackProps={feedbackProps}
       >
         <NativeTimePickerBase
           onChange={onChange}

--- a/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx
@@ -111,6 +111,8 @@ export const SimpleTimePicker = <TimeType extends TimeValue>({
   showSeconds,
   style,
   variant,
+  ariaAlertOnFeedback,
+  feedbackProps,
   ...rest
 }: SimpleTimePickerProps<TimeType>) => {
   const [inputText, setInputText] = useState('');
@@ -314,6 +316,8 @@ export const SimpleTimePicker = <TimeType extends TimeValue>({
         disabled={disabled}
         disableLabelAnimation
         feedback={feedback}
+        ariaAlertOnFeedback={ariaAlertOnFeedback}
+        feedbackProps={feedbackProps}
         label={label}
         labelProps={labelProps}
         labelTooltip={labelTooltip}

--- a/packages/datepicker/src/TimePicker/TimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/TimePicker.tsx
@@ -132,6 +132,7 @@ export const TimePicker = <TimeType extends TimeValue>({
   append,
   prepend,
   ariaAlertOnFeedback,
+  feedbackProps,
   ...rest
 }: TimePickerProps<TimeType>) => {
   let { locale } = useLocale();
@@ -223,6 +224,7 @@ export const TimePicker = <TimeType extends TimeValue>({
           </div>
         }
         ariaAlertOnFeedback={ariaAlertOnFeedback}
+        feedbackProps={feedbackProps}
         aria-describedby={timePickerId + 'description'}
         className={classNames('eds-timepicker', className, {
           'eds-timepicker--disabled': disabled,

--- a/packages/datepicker/src/TimePicker/TimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/TimePicker.tsx
@@ -17,12 +17,7 @@ import { VariantType } from '@entur/utils';
 
 import { FieldSegment } from '../shared/FieldSegment';
 import { TimePickerArrowButton } from './TimePickerArrowButton';
-import {
-  convertValueToType,
-  focusSegment,
-  modulo,
-  shouldUseAriaAlert,
-} from '../shared/utils';
+import { convertValueToType, focusSegment, modulo } from '../shared/utils';
 
 import './TimePicker.scss';
 
@@ -136,6 +131,7 @@ export const TimePicker = <TimeType extends TimeValue>({
   forcedTimeZone,
   append,
   prepend,
+  ariaAlertOnFeedback,
   ...rest
 }: TimePickerProps<TimeType>) => {
   let { locale } = useLocale();
@@ -226,7 +222,7 @@ export const TimePicker = <TimeType extends TimeValue>({
             />
           </div>
         }
-        ariaAlertOnFeedback={shouldUseAriaAlert(variant)}
+        ariaAlertOnFeedback={ariaAlertOnFeedback}
         aria-describedby={timePickerId + 'description'}
         className={classNames('eds-timepicker', className, {
           'eds-timepicker--disabled': disabled,

--- a/packages/datepicker/src/shared/utils.ts
+++ b/packages/datepicker/src/shared/utils.ts
@@ -281,36 +281,3 @@ export function getAdjustedMaxDate(maxDate?: DateValue) {
   if (maxDate !== undefined) return lastMillisecondOfDay(maxDate);
   return undefined;
 }
-
-/**
- * Determines which ARIA role should be applied to feedback text based on the variant.
- * - Critical errors get role="alert" (aria-live="assertive") for immediate announcement
- * - Warnings get role="status" (aria-live="polite") for non-interrupting announcement
- * - Info and success messages get no role (visual only)
- * @param variant The variant type
- * @returns 'alert', 'status', or false (no role)
- */
-export function shouldUseAriaAlert(
-  variant?:
-    | 'negative'
-    | 'warning'
-    | 'success'
-    | 'information'
-    | 'info'
-    | 'error',
-): 'alert' | 'status' | false {
-  if (!variant) return false;
-
-  // Critical errors: interrupt immediately
-  if (variant === 'negative' || variant === 'error') {
-    return 'alert';
-  }
-
-  // Warnings: announce politely when user is idle
-  if (variant === 'warning') {
-    return 'status';
-  }
-
-  // Info and success: no automatic announcement
-  return false;
-}

--- a/packages/datepicker/src/tests/Datepicker.test.tsx
+++ b/packages/datepicker/src/tests/Datepicker.test.tsx
@@ -261,8 +261,12 @@ test('maxDate works correctly for edge values', () => {
     </>,
   );
 
-  expect(screen.queryAllByRole('alert')[0]).toBeUndefined();
-  expect(screen.queryAllByRole('alert')[1]).toBeUndefined();
+  expect(screen.queryAllByRole('status')[0]).not.toHaveTextContent(
+    'Expected error',
+  );
+  expect(screen.queryAllByRole('status')[1]).not.toHaveTextContent(
+    'Expected error',
+  );
 
   rerender(
     <>
@@ -285,8 +289,8 @@ test('maxDate works correctly for edge values', () => {
     </>,
   );
 
-  expect(screen.getAllByRole('alert')[0]).toHaveTextContent('Expected error');
-  expect(screen.getAllByRole('alert')[1]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[0]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[1]).toHaveTextContent('Expected error');
 });
 
 test('gives errors correctly using maxDate as CalendarDate', () => {
@@ -314,8 +318,8 @@ test('gives errors correctly using maxDate as CalendarDate', () => {
     </>,
   );
 
-  expect(screen.getAllByRole('alert')[0]).toHaveTextContent('Expected error');
-  expect(screen.getAllByRole('alert')[1]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[0]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[1]).toHaveTextContent('Expected error');
 
   rerender(
     <>
@@ -338,8 +342,12 @@ test('gives errors correctly using maxDate as CalendarDate', () => {
     </>,
   );
 
-  expect(screen.queryAllByRole('alert')[0]).toBeUndefined();
-  expect(screen.queryAllByRole('alert')[1]).toBeUndefined();
+  expect(screen.queryAllByRole('status')[0]).not.toHaveTextContent(
+    'Expected error',
+  );
+  expect(screen.queryAllByRole('status')[1]).not.toHaveTextContent(
+    'Expected error',
+  );
 });
 
 test('gives errors correctly using maxDate as CalendarDateTime', () => {
@@ -367,8 +375,8 @@ test('gives errors correctly using maxDate as CalendarDateTime', () => {
     </>,
   );
 
-  expect(screen.getAllByRole('alert')[0]).toHaveTextContent('Expected error');
-  expect(screen.getAllByRole('alert')[1]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[0]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[1]).toHaveTextContent('Expected error');
 
   rerender(
     <>
@@ -391,8 +399,12 @@ test('gives errors correctly using maxDate as CalendarDateTime', () => {
     </>,
   );
 
-  expect(screen.queryAllByRole('alert')[0]).toBeUndefined();
-  expect(screen.queryAllByRole('alert')[1]).toBeUndefined();
+  expect(screen.queryAllByRole('status')[0]).not.toHaveTextContent(
+    'Expected error',
+  );
+  expect(screen.queryAllByRole('status')[1]).not.toHaveTextContent(
+    'Expected error',
+  );
 });
 
 test('gives errors correctly using minDate as CalendarDate', () => {
@@ -420,8 +432,8 @@ test('gives errors correctly using minDate as CalendarDate', () => {
     </>,
   );
 
-  expect(screen.getAllByRole('alert')[0]).toHaveTextContent('Expected error');
-  expect(screen.getAllByRole('alert')[1]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[0]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[1]).toHaveTextContent('Expected error');
 
   rerender(
     <>
@@ -444,8 +456,12 @@ test('gives errors correctly using minDate as CalendarDate', () => {
     </>,
   );
 
-  expect(screen.queryAllByRole('alert')[0]).toBeUndefined();
-  expect(screen.queryAllByRole('alert')[1]).toBeUndefined();
+  expect(screen.queryAllByRole('status')[0]).not.toHaveTextContent(
+    'Expected error',
+  );
+  expect(screen.queryAllByRole('status')[1]).not.toHaveTextContent(
+    'Expected error',
+  );
 });
 
 test('gives errors correctly using minDate as CalendarDateTime', () => {
@@ -473,8 +489,8 @@ test('gives errors correctly using minDate as CalendarDateTime', () => {
     </>,
   );
 
-  expect(screen.getAllByRole('alert')[0]).toHaveTextContent('Expected error');
-  expect(screen.getAllByRole('alert')[1]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[0]).toHaveTextContent('Expected error');
+  expect(screen.getAllByRole('status')[1]).toHaveTextContent('Expected error');
 
   rerender(
     <>
@@ -497,8 +513,12 @@ test('gives errors correctly using minDate as CalendarDateTime', () => {
     </>,
   );
 
-  expect(screen.queryAllByRole('alert')[0]).toBeUndefined();
-  expect(screen.queryAllByRole('alert')[1]).toBeUndefined();
+  expect(screen.queryAllByRole('status')[0]).not.toHaveTextContent(
+    'Expected error',
+  );
+  expect(screen.queryAllByRole('status')[1]).not.toHaveTextContent(
+    'Expected error',
+  );
 });
 
 test('shows selected granularity', () => {
@@ -702,7 +722,27 @@ test('onValidate fires on invalid date', async () => {
 }, 10000);
 
 describe('ARIA roles on feedback text', () => {
-  test('applies role="alert" for negative variant (immediate announcement)', () => {
+  test.each(['negative', 'error', 'warning', 'information', 'info', 'success'])(
+    'applies role="status" by default for %s variant (polite announcement)',
+    variant => {
+      const currentDate = new CalendarDate(1997, 7, 10);
+      const { container } = render(
+        <DateField
+          label="test"
+          selectedDate={currentDate}
+          onChange={() => undefined}
+          feedback="Dette er en melding"
+          variant={variant as any}
+          locale="en-GB"
+        />,
+      );
+
+      const feedbackElement = container.querySelector('.eds-feedback-text');
+      expect(feedbackElement).toHaveAttribute('role', 'status');
+    },
+  );
+
+  test('applies role="alert" when ariaAlertOnFeedback="alert"', () => {
     const currentDate = new CalendarDate(1997, 7, 10);
     const { container } = render(
       <DateField
@@ -711,98 +751,13 @@ describe('ARIA roles on feedback text', () => {
         onChange={() => undefined}
         feedback="Dette er en feilmelding"
         variant="negative"
+        ariaAlertOnFeedback="alert"
         locale="en-GB"
       />,
     );
 
     const feedbackElement = container.querySelector('.eds-feedback-text');
     expect(feedbackElement).toHaveAttribute('role', 'alert');
-  });
-
-  test('applies role="alert" for error variant (deprecated, immediate announcement)', () => {
-    const currentDate = new CalendarDate(1997, 7, 10);
-    const { container } = render(
-      <DateField
-        label="test"
-        selectedDate={currentDate}
-        onChange={() => undefined}
-        feedback="Dette er en feilmelding"
-        variant="error"
-        locale="en-GB"
-      />,
-    );
-
-    const feedbackElement = container.querySelector('.eds-feedback-text');
-    expect(feedbackElement).toHaveAttribute('role', 'alert');
-  });
-
-  test('applies role="status" for warning variant (polite announcement)', () => {
-    const currentDate = new CalendarDate(1997, 7, 10);
-    const { container } = render(
-      <DateField
-        label="test"
-        selectedDate={currentDate}
-        onChange={() => undefined}
-        feedback="Dette er en advarsel"
-        variant="warning"
-        locale="en-GB"
-      />,
-    );
-
-    const feedbackElement = container.querySelector('.eds-feedback-text');
-    expect(feedbackElement).toHaveAttribute('role', 'status');
-    expect(feedbackElement).not.toHaveAttribute('role', 'alert');
-  });
-
-  test('does NOT apply role="alert" for information variant', () => {
-    const currentDate = new CalendarDate(1997, 7, 10);
-    const { container } = render(
-      <DateField
-        label="test"
-        selectedDate={currentDate}
-        onChange={() => undefined}
-        feedback="Dette er en informasjonsmelding"
-        variant="information"
-        locale="en-GB"
-      />,
-    );
-
-    const feedbackElement = container.querySelector('.eds-feedback-text');
-    expect(feedbackElement).not.toHaveAttribute('role', 'alert');
-  });
-
-  test('does NOT apply role="alert" for info variant (deprecated)', () => {
-    const currentDate = new CalendarDate(1997, 7, 10);
-    const { container } = render(
-      <DateField
-        label="test"
-        selectedDate={currentDate}
-        onChange={() => undefined}
-        feedback="Dette er en informasjonsmelding"
-        variant="info"
-        locale="en-GB"
-      />,
-    );
-
-    const feedbackElement = container.querySelector('.eds-feedback-text');
-    expect(feedbackElement).not.toHaveAttribute('role', 'alert');
-  });
-
-  test('does NOT apply role="alert" for success variant', () => {
-    const currentDate = new CalendarDate(1997, 7, 10);
-    const { container } = render(
-      <DateField
-        label="test"
-        selectedDate={currentDate}
-        onChange={() => undefined}
-        feedback="Dette er en suksessmelding"
-        variant="success"
-        locale="en-GB"
-      />,
-    );
-
-    const feedbackElement = container.querySelector('.eds-feedback-text');
-    expect(feedbackElement).not.toHaveAttribute('role', 'alert');
   });
 });
 

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -279,6 +279,7 @@ export const Dropdown = React.forwardRef(
         style={style}
         variant={variant}
         {...toggleButtonProps}
+        aria-invalid={variant === 'negative' || variant === error}
         after={
           <DropdownList
             ariaLabelChosenSingular={ariaLabelChosenSingular}

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -15,7 +15,7 @@ import {
   useFloating,
 } from '@floating-ui/react-dom';
 
-import { BaseFormControl } from '@entur/form';
+import { BaseFormControl, FeedbackAnnouncementProps } from '@entur/form';
 import { space } from '@entur/tokens';
 import { VariantType, getActiveElement, mergeRefs } from '@entur/utils';
 
@@ -112,7 +112,7 @@ export type DropdownProps<ValueType> = {
    * @default ', valgt element, trykk for å fjerne'
    */
   ariaLabelSelectedItem?: string;
-};
+} & FeedbackAnnouncementProps;
 
 export const Dropdown = React.forwardRef(
   <ValueType extends NonNullable<any>>(

--- a/packages/dropdown/src/MultiSelect.tsx
+++ b/packages/dropdown/src/MultiSelect.tsx
@@ -570,7 +570,10 @@ export const MultiSelect = React.forwardRef(
               selectedItem={summarySelectedItems}
             />
           )}
-          <input {...inputProps} />
+          <input
+            {...inputProps}
+            aria-invalid={variant === 'negative' || variant === 'error'}
+          />
         </div>
         <DropdownFieldAppendix
           {...toggleButtonProps}

--- a/packages/dropdown/src/NativeDropdown.tsx
+++ b/packages/dropdown/src/NativeDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useId } from 'react';
-import { BaseFormControl } from '@entur/form';
+import { BaseFormControl, FeedbackAnnouncementProps } from '@entur/form';
 import { DownArrowIcon } from '@entur/icons';
 import { LoadingDots } from '@entur/loader';
 import { VariantType } from '@entur/utils';
@@ -66,7 +66,7 @@ export type NativeDropdownProps<ValueType> = {
    */
   disableLabelAnimation?: boolean;
   [key: string]: any;
-};
+} & FeedbackAnnouncementProps;
 
 export const NativeDropdown = forwardRef(
   <ValueType extends string | number>(
@@ -85,6 +85,8 @@ export const NativeDropdown = forwardRef(
       style,
       value,
       variant,
+      ariaAlertOnFeedback,
+      feedbackProps,
       ...rest
     }: NativeDropdownProps<ValueType>,
     ref: React.ForwardedRef<HTMLSelectElement>,
@@ -98,6 +100,8 @@ export const NativeDropdown = forwardRef(
         disabled={disabled}
         readOnly={readOnly}
         prepend={prepend}
+        ariaAlertOnFeedback={ariaAlertOnFeedback}
+        feedbackProps={feedbackProps}
         append={
           <FieldAppend
             hidden={disabled || readOnly}

--- a/packages/dropdown/src/SearchableDropdown.tsx
+++ b/packages/dropdown/src/SearchableDropdown.tsx
@@ -400,6 +400,7 @@ export const SearchableDropdown = React.forwardRef(
             'eds-dropdown__input--hidden': showSelectedItem,
           })}
           {...inputProps}
+          aria-invalid={variant === 'negative' || variant === 'error'}
         />
         <DropdownFieldAppendix
           {...toggleButtonProps}

--- a/packages/dropdown/src/tests/Dropdown.test.tsx
+++ b/packages/dropdown/src/tests/Dropdown.test.tsx
@@ -375,4 +375,41 @@ describe('Dropdown', () => {
     const result = await axe(container);
     expect(result).toHaveNoViolations();
   });
+
+  describe('aria-invalid', () => {
+    test.each(['negative', 'error'] as const)(
+      'is true for %s variant',
+      variant => {
+        const { container } = render(
+          <Dropdown
+            label="test label"
+            items={testItems}
+            selectedItem={null}
+            variant={variant}
+          />,
+        );
+
+        expect(container.querySelector('[role="combobox"]')).toHaveAttribute(
+          'aria-invalid',
+          'true',
+        );
+      },
+    );
+
+    test('is false for warning variant', () => {
+      const { container } = render(
+        <Dropdown
+          label="test label"
+          items={testItems}
+          selectedItem={null}
+          variant="warning"
+        />,
+      );
+
+      expect(container.querySelector('[role="combobox"]')).toHaveAttribute(
+        'aria-invalid',
+        'false',
+      );
+    });
+  });
 });

--- a/packages/dropdown/src/tests/MultiSelect.test.tsx
+++ b/packages/dropdown/src/tests/MultiSelect.test.tsx
@@ -738,4 +738,43 @@ describe('MultiSelect', () => {
     const result = await axe(container);
     expect(result).toHaveNoViolations();
   });
+
+  describe('aria-invalid', () => {
+    test.each(['negative', 'error'] as const)(
+      'is true for %s variant',
+      variant => {
+        const { container } = render(
+          <MultiSelect
+            label="test label"
+            items={testItems}
+            selectedItems={[]}
+            onChange={() => undefined}
+            variant={variant}
+          />,
+        );
+
+        expect(container.querySelector('input')).toHaveAttribute(
+          'aria-invalid',
+          'true',
+        );
+      },
+    );
+
+    test('is false for warning variant', () => {
+      const { container } = render(
+        <MultiSelect
+          label="test label"
+          items={testItems}
+          selectedItems={[]}
+          onChange={() => undefined}
+          variant="warning"
+        />,
+      );
+
+      expect(container.querySelector('input')).toHaveAttribute(
+        'aria-invalid',
+        'false',
+      );
+    });
+  });
 });

--- a/packages/dropdown/src/tests/SearchableDropdown.test.tsx
+++ b/packages/dropdown/src/tests/SearchableDropdown.test.tsx
@@ -469,4 +469,43 @@ describe('SearchableDropdown', () => {
     const result = await axe(container);
     expect(result).toHaveNoViolations();
   });
+
+  describe('aria-invalid', () => {
+    test.each(['negative', 'error'] as const)(
+      'is true for %s variant',
+      variant => {
+        const { container } = render(
+          <SearchableDropdown
+            label="test label"
+            items={testItems}
+            selectedItem={null}
+            onChange={() => undefined}
+            variant={variant}
+          />,
+        );
+
+        expect(container.querySelector('input')).toHaveAttribute(
+          'aria-invalid',
+          'true',
+        );
+      },
+    );
+
+    test('is false for warning variant', () => {
+      const { container } = render(
+        <SearchableDropdown
+          label="test label"
+          items={testItems}
+          selectedItem={null}
+          onChange={() => undefined}
+          variant="warning"
+        />,
+      );
+
+      expect(container.querySelector('input')).toHaveAttribute(
+        'aria-invalid',
+        'false',
+      );
+    });
+  });
 });

--- a/packages/form/src/BaseFormControl.test.tsx
+++ b/packages/form/src/BaseFormControl.test.tsx
@@ -165,6 +165,25 @@ test('uses alert role when ariaAlertOnFeedback is alert', () => {
   expect(region).toHaveTextContent('Feltet er påkrevd');
 });
 
+test('uses alert role when ariaAlertOnFeedback is true', () => {
+  const { container } = render(
+    <BaseFormControl
+      label="test"
+      labelId="testId"
+      ariaAlertOnFeedback
+      variant="negative"
+      feedback="Feltet er påkrevd"
+    >
+      <input />
+    </BaseFormControl>,
+  );
+
+  expect(container.querySelector('.eds-feedback-text')).toHaveAttribute(
+    'role',
+    'alert',
+  );
+});
+
 test('renders no live region when ariaAlertOnFeedback is false', () => {
   const { container, rerender } = render(
     <BaseFormControl label="test" labelId="testId" ariaAlertOnFeedback={false}>
@@ -190,6 +209,61 @@ test('renders no live region when ariaAlertOnFeedback is false', () => {
   expect(feedbackText).toHaveTextContent('Feltet er påkrevd');
   expect(feedbackText).not.toHaveAttribute('aria-live');
   expect(feedbackText).not.toHaveAttribute('role');
+});
+
+test('role from feedbackProps overrides the aria props', () => {
+  const { container } = render(
+    <BaseFormControl
+      label="test"
+      labelId="testId"
+      ariaAlertOnFeedback="alert"
+      feedbackProps={{ role: 'status' }}
+      variant="negative"
+      feedback="Feltet er påkrevd"
+    >
+      <input />
+    </BaseFormControl>,
+  );
+
+  expect(container.querySelector('.eds-feedback-text')).toHaveAttribute(
+    'role',
+    'status',
+  );
+});
+
+test('aria-live from feedbackProps replaces the implicit role', () => {
+  const { container } = render(
+    <BaseFormControl
+      label="test"
+      labelId="testId"
+      feedbackProps={{ 'aria-live': 'off' }}
+    >
+      <input />
+    </BaseFormControl>,
+  );
+
+  const region = container.querySelector('.eds-feedback-text');
+  expect(region).toBeInTheDocument();
+  expect(region).toHaveAttribute('aria-live', 'off');
+  expect(region).not.toHaveAttribute('role');
+});
+
+test('passes other feedbackProps on to the feedback text', () => {
+  const { container } = render(
+    <BaseFormControl
+      label="test"
+      labelId="testId"
+      feedbackProps={{ id: 'feedbackId', className: 'custom-feedback' }}
+      variant="negative"
+      feedback="Feltet er påkrevd"
+    >
+      <input />
+    </BaseFormControl>,
+  );
+
+  const region = container.querySelector('.eds-feedback-text');
+  expect(region).toHaveAttribute('id', 'feedbackId');
+  expect(region).toHaveClass('custom-feedback');
 });
 
 test('renders prepend- and append-containers', () => {

--- a/packages/form/src/BaseFormControl.test.tsx
+++ b/packages/form/src/BaseFormControl.test.tsx
@@ -87,6 +87,111 @@ test('renders variants correctly', () => {
   expect(wrapper).not.toHaveClass('eds-form-control-wrapper--success');
 });
 
+test('renders live region in DOM before feedback exists', () => {
+  const { container, rerender } = render(
+    <BaseFormControl label="test" labelId="testId">
+      <input />
+    </BaseFormControl>,
+  );
+
+  const region = container.querySelector('.eds-feedback-text');
+  expect(region).toBeInTheDocument();
+  expect(region).toHaveAttribute('role', 'status');
+  expect(region).not.toHaveAttribute('aria-live');
+  expect(region).toBeEmptyDOMElement();
+
+  rerender(
+    <BaseFormControl
+      label="test"
+      labelId="testId"
+      variant="negative"
+      feedback="Feltet er påkrevd"
+    >
+      <input />
+    </BaseFormControl>,
+  );
+
+  expect(region).toHaveAttribute('role', 'status');
+  expect(region).not.toHaveAttribute('aria-live');
+  expect(region).toHaveTextContent('Feltet er påkrevd');
+});
+
+test.each(['negative', 'warning', 'success', 'information'] as const)(
+  'uses status role by default for %s variant',
+  (variant: 'negative' | 'warning' | 'success' | 'information') => {
+    const { container } = render(
+      <BaseFormControl
+        label="test"
+        labelId="testId"
+        variant={variant}
+        feedback="Melding"
+      >
+        <input />
+      </BaseFormControl>,
+    );
+
+    const region = container.querySelector('.eds-feedback-text');
+    expect(region).toHaveAttribute('role', 'status');
+    expect(region).not.toHaveAttribute('aria-live');
+    expect(region).toHaveTextContent('Melding');
+  },
+);
+
+test('uses alert role when ariaAlertOnFeedback is alert', () => {
+  const { container, rerender } = render(
+    <BaseFormControl label="test" labelId="testId" ariaAlertOnFeedback="alert">
+      <input />
+    </BaseFormControl>,
+  );
+
+  const region = container.querySelector('.eds-feedback-text');
+  expect(region).toHaveAttribute('role', 'alert');
+  expect(region).not.toHaveAttribute('aria-live');
+  expect(region).toBeEmptyDOMElement();
+
+  rerender(
+    <BaseFormControl
+      label="test"
+      labelId="testId"
+      ariaAlertOnFeedback="alert"
+      variant="negative"
+      feedback="Feltet er påkrevd"
+    >
+      <input />
+    </BaseFormControl>,
+  );
+
+  expect(region).toHaveAttribute('role', 'alert');
+  expect(region).toHaveTextContent('Feltet er påkrevd');
+});
+
+test('renders no live region when ariaAlertOnFeedback is false', () => {
+  const { container, rerender } = render(
+    <BaseFormControl label="test" labelId="testId" ariaAlertOnFeedback={false}>
+      <input />
+    </BaseFormControl>,
+  );
+
+  expect(container.querySelector('.eds-feedback-text')).not.toBeInTheDocument();
+
+  rerender(
+    <BaseFormControl
+      label="test"
+      labelId="testId"
+      ariaAlertOnFeedback={false}
+      variant="negative"
+      feedback="Feltet er påkrevd"
+    >
+      <input />
+    </BaseFormControl>,
+  );
+
+  const feedbackText = container.querySelector('.eds-feedback-text');
+  expect(feedbackText).toHaveTextContent('Feltet er påkrevd');
+  expect(feedbackText).not.toHaveAttribute('aria-live');
+  expect(feedbackText).not.toHaveAttribute('role');
+});
+
 test('renders prepend- and append-containers', () => {
   const { container, rerender } = render(
     <BaseFormControl label="test" labelId="testId">

--- a/packages/form/src/BaseFormControl.tsx
+++ b/packages/form/src/BaseFormControl.tsx
@@ -18,61 +18,74 @@ const info = 'info';
 /** @deprecated use variant="negative" instead */
 const error = 'error';
 
-export type BaseFormControlProps = React.HTMLAttributes<HTMLDivElement> & {
-  /** Et skjemaelement med `eds-form-control`-klassen */
-  children: React.ReactNode;
-  /** Ekstra klassenavn */
-  className?: string;
-  /** Sett til true om skjema-elementet er disabled */
-  disabled?: boolean;
-  /** Sett til true om skjema-elementet er i read-only modus */
-  readOnly?: boolean;
-  /** Tekst eller ikon som vises foran skjema-elementet */
-  prepend?: React.ReactNode;
-  /** Tekst eller ikon som vises etter skjema-elementet */
-  append?: React.ReactNode;
-  /** Valideringsvariant */
-  variant?: VariantType | typeof error | typeof info;
-  /**Størrelsen på skjemaelementet
-   * @default "medium"
-   */
-  size?: 'medium' | 'large';
-  /** Label til inputfeltet */
-  label: React.ReactNode;
-  /** En tooltip som forklarer labelen til inputfeltet */
-  labelTooltip?: React.ReactNode;
-  /** Forklarende tekst for knappen som åpner labelTooltip */
-  labelTooltipButtonAriaLabel?: string;
-  labelTooltipPlacement?: Placement;
-  /** Illustrerer om inputfeltet er påkrevd eller ikke */
-  required?: boolean;
-  /** ID som settes på labelen til inputfeltet */
-  labelId: string;
-  /** Varselmelding, som vil komme under form-komponenten */
-  feedback?: string;
-  /** Om inputfeltet er fylt med data. Brukes for plassering av label */
-  isFilled?: boolean;
-  /**Ekstra props som sendes til label */
-  labelProps?: { [key: string]: any };
-  /** Ekstra styling */
-  style?: React.CSSProperties;
-  /** Plasserer labelen statisk på toppen av inputfeltet */
-  disableLabelAnimation?: boolean;
-  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
-  /** Setter feedback-tekstens rolle for skjermlesere.
-   * true/'status' = role="status" (venter til brukeren er ferdig)
-   * 'alert' = role="alert" (avbryter umiddelbart)
-   * false = ingen automatisk annonsering
-   * @default true
+/** Props som styrer hvordan feedback-teksten annonseres av skjermlesere.
+ * Deles av alle skjemakomponentene som rendrer en feedback-tekst */
+export type FeedbackAnnouncementProps = {
+  /** Styrer hvordan feedback-teksten annonseres av skjermlesere.
+   * Standarden 'status' lar skjermleseren annonsere meldingen når
+   * brukeren er ferdig med det den holder på med, og live region-en
+   * rendres da alltid i DOM, også før meldingen finnes.
+   * true/'alert' gir role="alert", som avbryter skjermleseren og
+   * annonserer meldingen umiddelbart – bruk den bare til meldinger som
+   * hindrer brukeren i å komme videre. false skrur av automatisk
+   * annonsering.
+   * @default 'status'
    */
   ariaAlertOnFeedback?: boolean | 'alert' | 'status';
-  /** Legg til et element etter feltet */
-  after?: React.ReactNode;
-  /** Legg til et element før feltet */
-  before?: React.ReactNode;
-  /** Aria-label som brukes når inputfeltet er i read-only modus */
-  ariaLabelOnReadOnly?: string;
+  /** Ekstra props som sendes til feedback-teksten. Egne `role`- og
+   * `aria-live`-verdier her overstyrer ariaAlertOnFeedback */
+  feedbackProps?: React.HTMLAttributes<HTMLElement>;
 };
+
+export type BaseFormControlProps = React.HTMLAttributes<HTMLDivElement> &
+  FeedbackAnnouncementProps & {
+    /** Et skjemaelement med `eds-form-control`-klassen */
+    children: React.ReactNode;
+    /** Ekstra klassenavn */
+    className?: string;
+    /** Sett til true om skjema-elementet er disabled */
+    disabled?: boolean;
+    /** Sett til true om skjema-elementet er i read-only modus */
+    readOnly?: boolean;
+    /** Tekst eller ikon som vises foran skjema-elementet */
+    prepend?: React.ReactNode;
+    /** Tekst eller ikon som vises etter skjema-elementet */
+    append?: React.ReactNode;
+    /** Valideringsvariant */
+    variant?: VariantType | typeof error | typeof info;
+    /**Størrelsen på skjemaelementet
+     * @default "medium"
+     */
+    size?: 'medium' | 'large';
+    /** Label til inputfeltet */
+    label: React.ReactNode;
+    /** En tooltip som forklarer labelen til inputfeltet */
+    labelTooltip?: React.ReactNode;
+    /** Forklarende tekst for knappen som åpner labelTooltip */
+    labelTooltipButtonAriaLabel?: string;
+    labelTooltipPlacement?: Placement;
+    /** Illustrerer om inputfeltet er påkrevd eller ikke */
+    required?: boolean;
+    /** ID som settes på labelen til inputfeltet */
+    labelId: string;
+    /** Varselmelding, som vil komme under form-komponenten */
+    feedback?: string;
+    /** Om inputfeltet er fylt med data. Brukes for plassering av label */
+    isFilled?: boolean;
+    /**Ekstra props som sendes til label */
+    labelProps?: { [key: string]: any };
+    /** Ekstra styling */
+    style?: React.CSSProperties;
+    /** Plasserer labelen statisk på toppen av inputfeltet */
+    disableLabelAnimation?: boolean;
+    onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+    /** Legg til et element etter feltet */
+    after?: React.ReactNode;
+    /** Legg til et element før feltet */
+    before?: React.ReactNode;
+    /** Aria-label som brukes når inputfeltet er i read-only modus */
+    ariaLabelOnReadOnly?: string;
+  };
 
 export const BaseFormControl = React.forwardRef<
   HTMLDivElement,
@@ -101,7 +114,8 @@ export const BaseFormControl = React.forwardRef<
       labelProps,
       style,
       disableLabelAnimation = false,
-      ariaAlertOnFeedback = true,
+      ariaAlertOnFeedback = 'status',
+      feedbackProps,
       ariaLabelOnReadOnly = 'Dette skjemafeltet kan bare leses',
       ...rest
     },
@@ -110,12 +124,25 @@ export const BaseFormControl = React.forwardRef<
     const contextVariant = useVariant();
     const currentVariant = variant || contextVariant || undefined;
 
-    const feedbackRole =
-      ariaAlertOnFeedback === false
-        ? undefined
-        : ariaAlertOnFeedback === 'alert'
+    const {
+      role: feedbackRoleOverride,
+      'aria-live': feedbackAriaLive,
+      ...restFeedbackProps
+    } = feedbackProps ?? {};
+
+    const defaultFeedbackRole =
+      ariaAlertOnFeedback === true || ariaAlertOnFeedback === 'alert'
         ? 'alert'
-        : 'status';
+        : ariaAlertOnFeedback === 'status'
+        ? 'status'
+        : undefined;
+
+    // role and aria-live passed by the developer win over our own props
+    const feedbackRole =
+      feedbackRoleOverride ??
+      (feedbackAriaLive !== undefined ? undefined : defaultFeedbackRole);
+    const isLiveRegion =
+      feedbackRole !== undefined || feedbackAriaLive !== undefined;
     const showFeedback = Boolean(feedback && currentVariant);
 
     return (
@@ -190,17 +217,18 @@ export const BaseFormControl = React.forwardRef<
             {children}
             {append && <div className="eds-form-control__append">{append}</div>}
           </div>
-          {feedbackRole !== undefined ? (
-            // Live region rendres alltid, slik at den finnes i DOM
-            // før feedback-teksten settes — ellers annonserer ikke
-            // skjermlesere innholdet pålitelig
-            <FeedbackText variant={currentVariant} role={feedbackRole}>
+          {(isLiveRegion || showFeedback) && (
+            // Live region-en rendres alltid, slik at den finnes i DOM før
+            // feedback-teksten settes — ellers annonserer ikke skjermlesere
+            // innholdet pålitelig
+            <FeedbackText
+              variant={currentVariant}
+              role={feedbackRole}
+              aria-live={feedbackAriaLive}
+              {...restFeedbackProps}
+            >
               {showFeedback ? feedback : undefined}
             </FeedbackText>
-          ) : (
-            showFeedback && (
-              <FeedbackText variant={currentVariant}>{feedback}</FeedbackText>
-            )
           )}
           {after}
         </div>

--- a/packages/form/src/BaseFormControl.tsx
+++ b/packages/form/src/BaseFormControl.tsx
@@ -58,12 +58,13 @@ export type BaseFormControlProps = React.HTMLAttributes<HTMLDivElement> & {
   style?: React.CSSProperties;
   /** Plasserer labelen statisk på toppen av inputfeltet */
   disableLabelAnimation?: boolean;
-  /** Setter feedback-tekstens rolle for skjermlesere.
-   * 'alert' = aria-live="assertive" (avbryter umiddelbart)
-   * 'status' = aria-live="polite" (venter til bruker er ferdig)
-   * undefined/false = ingen automatisk annonsering
-   */
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  /** Setter feedback-tekstens rolle for skjermlesere.
+   * true/'status' = aria-live="polite" (venter til brukeren er ferdig)
+   * 'alert' = aria-live="assertive" (avbryter umiddelbart)
+   * false = ingen automatisk annonsering
+   * @default true
+   */
   ariaAlertOnFeedback?: boolean | 'alert' | 'status';
   /** Legg til et element etter feltet */
   after?: React.ReactNode;
@@ -100,14 +101,22 @@ export const BaseFormControl = React.forwardRef<
       labelProps,
       style,
       disableLabelAnimation = false,
-      ariaAlertOnFeedback = false,
+      ariaAlertOnFeedback = true,
       ariaLabelOnReadOnly = 'Dette skjemafeltet kan bare leses',
       ...rest
     },
     ref,
   ) => {
     const contextVariant = useVariant();
-    const currentVariant = variant || contextVariant;
+    const currentVariant = variant || contextVariant || undefined;
+
+    const feedbackRole =
+      ariaAlertOnFeedback === false
+        ? undefined
+        : ariaAlertOnFeedback === 'alert'
+        ? 'alert'
+        : 'status';
+    const showFeedback = Boolean(feedback && currentVariant);
 
     return (
       <InputGroupContextProvider>
@@ -181,19 +190,17 @@ export const BaseFormControl = React.forwardRef<
             {children}
             {append && <div className="eds-form-control__append">{append}</div>}
           </div>
-          {feedback && currentVariant && (
-            <FeedbackText
-              variant={currentVariant}
-              role={
-                ariaAlertOnFeedback === true || ariaAlertOnFeedback === 'alert'
-                  ? 'alert'
-                  : ariaAlertOnFeedback === 'status'
-                  ? 'status'
-                  : undefined
-              }
-            >
-              {feedback}
+          {feedbackRole !== undefined ? (
+            // Live region rendres alltid, slik at den finnes i DOM
+            // før feedback-teksten settes — ellers annonserer ikke
+            // skjermlesere innholdet pålitelig
+            <FeedbackText variant={currentVariant} role={feedbackRole}>
+              {showFeedback ? feedback : undefined}
             </FeedbackText>
+          ) : (
+            showFeedback && (
+              <FeedbackText variant={currentVariant}>{feedback}</FeedbackText>
+            )
           )}
           {after}
         </div>

--- a/packages/form/src/BaseFormControl.tsx
+++ b/packages/form/src/BaseFormControl.tsx
@@ -60,8 +60,8 @@ export type BaseFormControlProps = React.HTMLAttributes<HTMLDivElement> & {
   disableLabelAnimation?: boolean;
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
   /** Setter feedback-tekstens rolle for skjermlesere.
-   * true/'status' = aria-live="polite" (venter til brukeren er ferdig)
-   * 'alert' = aria-live="assertive" (avbryter umiddelbart)
+   * true/'status' = role="status" (venter til brukeren er ferdig)
+   * 'alert' = role="alert" (avbryter umiddelbart)
    * false = ingen automatisk annonsering
    * @default true
    */

--- a/packages/form/src/FeedbackText.scss
+++ b/packages/form/src/FeedbackText.scss
@@ -10,6 +10,10 @@
     padding-left: calc(#{t.$space-medium} + #{t.$border-widths-medium});
   }
 
+  &--empty {
+    margin-top: 0;
+  }
+
   &__text {
     color: var(--components-form-feedbacktext-information-standard-text);
 

--- a/packages/form/src/FeedbackText.tsx
+++ b/packages/form/src/FeedbackText.tsx
@@ -24,33 +24,24 @@ const AlertIcon = ({
   switch (variant) {
     case 'success':
       return (
-        <ValidationSuccessFilledIcon
-          aria-label="Suksessmelding"
-          className={iconClass}
-        />
+        <ValidationSuccessFilledIcon aria-hidden="true" className={iconClass} />
       );
     case 'negative':
       return (
-        <ValidationErrorFilledIcon
-          aria-label="Feilmelding"
-          className={iconClass}
-        />
+        <ValidationErrorFilledIcon aria-hidden="true" className={iconClass} />
       );
     case 'information':
       return null;
     case 'warning':
       return (
         <ValidationExclamationFilledIcon
-          aria-label="Varselmelding"
+          aria-hidden="true"
           className={iconClass}
         />
       );
     case error:
       return (
-        <ValidationErrorFilledIcon
-          aria-label="Feilmelding"
-          className={iconClass}
-        />
+        <ValidationErrorFilledIcon aria-hidden="true" className={iconClass} />
       );
     case info:
       return null;
@@ -60,12 +51,13 @@ const AlertIcon = ({
 };
 
 export type FeedbackTextProps = {
-  /** Teksten som vises */
-  children: React.ReactNode;
+  /** Teksten som vises. Uten tekst rendres en tom (usynlig) container,
+   * slik at en aria-live-region kan eksistere i DOM før meldingen settes */
+  children?: React.ReactNode;
   /** Skjuler ikonet */
   hideIcon?: boolean;
   /** Feedbackvarianten*/
-  variant: VariantType | typeof error | typeof info;
+  variant?: VariantType | typeof error | typeof info;
   /** Ekstra klassenavn */
   className?: string;
   [key: string]: any;
@@ -77,6 +69,7 @@ export const FeedbackText = ({
   className,
   ...rest
 }: FeedbackTextProps) => {
+  const hasContent = children !== undefined && children !== null;
   return (
     <SubLabel
       className={classNames(
@@ -84,13 +77,16 @@ export const FeedbackText = ({
         {
           'eds-feedback-text--information':
             variant === info || variant === 'information',
+          'eds-feedback-text--empty': !hasContent,
         },
         className,
       )}
       {...rest}
     >
-      {!hideIcon && <AlertIcon variant={variant} />}
-      <span className="eds-feedback-text__text">{children}</span>
+      {hasContent && !hideIcon && variant && <AlertIcon variant={variant} />}
+      {hasContent && (
+        <span className="eds-feedback-text__text">{children}</span>
+      )}
     </SubLabel>
   );
 };

--- a/packages/form/src/TextArea.test.tsx
+++ b/packages/form/src/TextArea.test.tsx
@@ -22,3 +22,31 @@ test('textarea does not override default CSS resize when no resize prop is set',
   const textarea = container.querySelector('textarea');
   expect(textarea?.style.resize).toBe('');
 });
+
+describe('aria-invalid', () => {
+  test.each(['negative', 'error'] as const)(
+    'is true for %s variant',
+    variant => {
+      const { container } = render(
+        <TextArea label="testing label" variant={variant} />,
+      );
+      expect(container.querySelector('textarea')).toHaveAttribute(
+        'aria-invalid',
+        'true',
+      );
+    },
+  );
+
+  test.each(['warning', 'success', 'information', undefined] as const)(
+    'is false for %s variant',
+    variant => {
+      const { container } = render(
+        <TextArea label="testing label" variant={variant} />,
+      );
+      expect(container.querySelector('textarea')).toHaveAttribute(
+        'aria-invalid',
+        'false',
+      );
+    },
+  );
+});

--- a/packages/form/src/TextArea.tsx
+++ b/packages/form/src/TextArea.tsx
@@ -43,6 +43,13 @@ export type TextAreaProps = {
    * @default "vertical"
    */
   resize?: 'vertical' | 'none';
+  /** Setter feedback-tekstens rolle for skjermlesere.
+   * true/'status' = aria-live="polite" (venter til brukeren er ferdig)
+   * 'alert' = aria-live="assertive" (avbryter umiddelbart)
+   * false = ingen automatisk annonsering
+   * @default true
+   */
+  ariaAlertOnFeedback?: boolean | 'alert' | 'status';
 } & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
@@ -61,6 +68,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
       onChange,
       disableLabelAnimation,
       resize,
+      ariaAlertOnFeedback,
       ...rest
     },
     ref: React.Ref<HTMLTextAreaElement>,
@@ -82,6 +90,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         labelTooltipPlacement={labelTooltipPlacement}
         labelProps={{ className: 'eds-textarea__label' }}
         disableLabelAnimation={disableLabelAnimation}
+        ariaAlertOnFeedback={ariaAlertOnFeedback}
         onClick={e => {
           if (e.target === e.currentTarget) textareaRef?.current?.focus();
         }}

--- a/packages/form/src/TextArea.tsx
+++ b/packages/form/src/TextArea.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { VariantType, mergeRefs, useOnMount } from '@entur/utils';
 
 import { useVariant } from './VariantProvider';
-import { BaseFormControl } from './BaseFormControl';
+import { BaseFormControl, FeedbackAnnouncementProps } from './BaseFormControl';
 import { useInputGroupContext } from './InputGroupContext';
 import { isFilled } from './utils';
 
@@ -43,14 +43,8 @@ export type TextAreaProps = {
    * @default "vertical"
    */
   resize?: 'vertical' | 'none';
-  /** Setter feedback-tekstens rolle for skjermlesere.
-   * true/'status' = aria-live="polite" (venter til brukeren er ferdig)
-   * 'alert' = aria-live="assertive" (avbryter umiddelbart)
-   * false = ingen automatisk annonsering
-   * @default true
-   */
-  ariaAlertOnFeedback?: boolean | 'alert' | 'status';
-} & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+} & FeedbackAnnouncementProps &
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (
@@ -69,6 +63,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
       disableLabelAnimation,
       resize,
       ariaAlertOnFeedback,
+      feedbackProps,
       ...rest
     },
     ref: React.Ref<HTMLTextAreaElement>,
@@ -91,6 +86,7 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         labelProps={{ className: 'eds-textarea__label' }}
         disableLabelAnimation={disableLabelAnimation}
         ariaAlertOnFeedback={ariaAlertOnFeedback}
+        feedbackProps={feedbackProps}
         onClick={e => {
           if (e.target === e.currentTarget) textareaRef?.current?.focus();
         }}

--- a/packages/form/src/TextArea.tsx
+++ b/packages/form/src/TextArea.tsx
@@ -153,7 +153,7 @@ const TextAreaBase = React.forwardRef<HTMLTextAreaElement, TextAreaBaseProps>(
         disabled={disabled}
         onChange={handleChange}
         value={value}
-        aria-invalid={currentVariant === 'error'}
+        aria-invalid={currentVariant === 'negative' || currentVariant === error}
         style={resize ? { ...style, resize } : style}
         {...rest}
       />

--- a/packages/form/src/TextField.test.tsx
+++ b/packages/form/src/TextField.test.tsx
@@ -255,4 +255,30 @@ describe('TextField', () => {
       expect(clearButton.tabIndex).not.toBe(-1);
     });
   });
+
+  describe('aria-invalid', () => {
+    test.each(['negative', 'error'] as const)(
+      'is true for %s variant',
+      variant => {
+        render(<TextField label="Test field" variant={variant} />);
+
+        expect(screen.getByLabelText('Test field')).toHaveAttribute(
+          'aria-invalid',
+          'true',
+        );
+      },
+    );
+
+    test.each(['warning', 'success', 'information', undefined] as const)(
+      'is false for %s variant',
+      variant => {
+        render(<TextField label="Test field" variant={variant} />);
+
+        expect(screen.getByLabelText('Test field')).toHaveAttribute(
+          'aria-invalid',
+          'false',
+        );
+      },
+    );
+  });
 });

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -6,7 +6,7 @@ import { CloseSmallIcon } from '@entur/icons';
 import { Placement } from '@entur/tooltip';
 import { VariantType, mergeRefs } from '@entur/utils';
 
-import { BaseFormControl } from './BaseFormControl';
+import { BaseFormControl, FeedbackAnnouncementProps } from './BaseFormControl';
 import { useInputGroupContext } from './InputGroupContext';
 import { isFilled } from './utils';
 import { useVariant } from './VariantProvider';
@@ -63,14 +63,8 @@ export type TextFieldProps = {
    * @default "Tøm felt"
    */
   clearButtonAriaLabel?: string;
-  /** Setter feedback-tekstens rolle for skjermlesere.
-   * true/'status' = role="status" (venter til brukeren er ferdig)
-   * 'alert' = role="alert" (avbryter umiddelbart)
-   * false = ingen automatisk annonsering
-   * @default true
-   */
-  ariaAlertOnFeedback?: boolean | 'alert' | 'status';
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'label'>;
+} & FeedbackAnnouncementProps &
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'label'>;
 
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
   (
@@ -97,6 +91,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       clearButtonAriaLabel = 'Tøm felt',
       value,
       ariaAlertOnFeedback,
+      feedbackProps,
       ...rest
     },
     ref: React.Ref<HTMLInputElement>,
@@ -158,6 +153,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
         disableLabelAnimation={disableLabelAnimation}
         labelProps={labelProps}
         ariaAlertOnFeedback={ariaAlertOnFeedback}
+        feedbackProps={feedbackProps}
         onClick={e => {
           if (e.target === e.currentTarget) textFieldRef?.current?.focus();
         }}

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -64,9 +64,10 @@ export type TextFieldProps = {
    */
   clearButtonAriaLabel?: string;
   /** Setter feedback-tekstens rolle for skjermlesere.
+   * true/'status' = aria-live="polite" (venter til brukeren er ferdig)
    * 'alert' = aria-live="assertive" (avbryter umiddelbart)
-   * 'status' = aria-live="polite" (venter til bruker er ferdig)
-   * undefined/false = ingen automatisk annonsering
+   * false = ingen automatisk annonsering
+   * @default true
    */
   ariaAlertOnFeedback?: boolean | 'alert' | 'status';
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'label'>;
@@ -95,7 +96,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       onClear,
       clearButtonAriaLabel = 'Tøm felt',
       value,
-      ariaAlertOnFeedback = false,
+      ariaAlertOnFeedback,
       ...rest
     },
     ref: React.Ref<HTMLInputElement>,

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -64,8 +64,8 @@ export type TextFieldProps = {
    */
   clearButtonAriaLabel?: string;
   /** Setter feedback-tekstens rolle for skjermlesere.
-   * true/'status' = aria-live="polite" (venter til brukeren er ferdig)
-   * 'alert' = aria-live="assertive" (avbryter umiddelbart)
+   * true/'status' = role="status" (venter til brukeren er ferdig)
+   * 'alert' = role="alert" (avbryter umiddelbart)
    * false = ingen automatisk annonsering
    * @default true
    */

--- a/packages/form/src/TextField.tsx
+++ b/packages/form/src/TextField.tsx
@@ -218,7 +218,7 @@ const TextFieldBase = React.forwardRef<HTMLInputElement, TextFieldBaseProps>(
 
     return (
       <input
-        aria-invalid={currentVariant === 'error'}
+        aria-invalid={currentVariant === 'negative' || currentVariant === error}
         className="eds-form-control"
         disabled={disabled}
         readOnly={readOnly}

--- a/skills/entur-accessibility/SKILL.md
+++ b/skills/entur-accessibility/SKILL.md
@@ -41,6 +41,7 @@ These things cannot be automated by components — you must supply them:
 5. **`SkipToContent` as the first element** in every app with navigation, with `<main id="main-content">`.
 6. **Logical heading hierarchy.** Use `Heading1`–`Heading6` in order — don't skip levels for visual sizing.
 7. **`variant="negative"` and `feedback` together** on invalid form fields — error state must not rely on color alone.
+8. **`feedback` text that stands on its own.** It is announced through a live region while the status icon is `aria-hidden`, so the text is all a screen reader user gets — "Ugyldig" is not enough.
 
 ---
 

--- a/skills/entur-accessibility/references/entur-a11y-patterns.md
+++ b/skills/entur-accessibility/references/entur-a11y-patterns.md
@@ -102,6 +102,33 @@ For custom validation, use the `feedback` and `variant` props:
 
 The `feedback` prop renders inline validation text near the field, paired with visual `variant` styling.
 
+### Feedback text is announced automatically
+
+Every form component that renders `feedback` also renders it inside a live region with `role="status"`, present in the DOM from mount. Screen readers announce the message politely when it appears or changes — you do not need to add an `aria-live` region of your own. Wrapping the field in one announces the same text twice.
+
+The message text has to identify the problem on its own. The status icon is `aria-hidden`, so nothing but your text tells a screen reader user whether this is an error, a warning or a confirmation:
+
+```tsx
+// Good — the text says what is wrong
+<TextField label="Mobilnummer" variant="negative" feedback="Ugyldig format. Bruk 8 siffer." />
+
+// Bad — "Ugyldig" only reads as an error because of the red icon
+<TextField label="Mobilnummer" variant="negative" feedback="Ugyldig" />
+```
+
+Two props change the announcement. They apply to `TextField`, `TextArea`, `DateField`, `TimePicker`, `SimpleTimePicker`, `NativeDatePicker`, `NativeTimePicker`, `Dropdown`, `SearchableDropdown`, `MultiSelect` and `NativeDropdown`:
+
+| Prop                           | Effect                                                                                                                                                    |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _none_                         | `role="status"` — polite announcement. The default, and correct for nearly all validation                                                                 |
+| `ariaAlertOnFeedback`          | `true`/`'alert'` gives `role="alert"` — interrupts the screen reader immediately. Only for messages that block the user                                    |
+| `ariaAlertOnFeedback={false}`  | No live region at all. Use when something else announces the error, such as a focused error summary after submit                                          |
+| `feedbackProps`                | Passed to the feedback text. Your own `role` or `aria-live` here overrides the prop above                                                                 |
+
+Prefer the default. `role="alert"` cuts off whatever the screen reader is currently saying, including the user's own typing echo, so inline validation that fires on change or blur should stay polite.
+
+`ariaAlertOnFeedback={false}` is also the escape hatch for feedback that changes on every keystroke — a character counter rendered through `feedback` would otherwise be announced on each change.
+
 For grouping related fields:
 
 ```tsx
@@ -169,7 +196,9 @@ Contrast checker: https://linje.entur.no/universell-utforming/kontrastsjekker
 
 ## ARIA live regions
 
-For dynamic content updates (alerts, toast notifications, results):
+Form fields are already covered — `feedback` gets its own live region, so don't wrap a field in one. See [Feedback text is announced automatically](#feedback-text-is-announced-automatically).
+
+For other dynamic content updates (alerts, toast notifications, results):
 
 ```tsx
 // Use ToastProvider from @entur/alert for toast messages

--- a/skills/entur-accessibility/references/patterns-checklist.md
+++ b/skills/entur-accessibility/references/patterns-checklist.md
@@ -8,6 +8,9 @@ Component-specific checklists and code examples. The component handles interacti
 
 - [ ] Every field has a visible `label` prop — not just `placeholder`
 - [ ] Invalid fields set both `variant="negative"` and `feedback="…"` — error communicated in text, not color alone
+- [ ] `feedback` text identifies the problem on its own — the status icon is `aria-hidden`, so "Ugyldig" alone tells a screen reader user nothing
+- [ ] No hand-rolled `aria-live` region around a field — `feedback` is already announced with `role="status"`
+- [ ] `role="alert"` (`ariaAlertOnFeedback`) only for messages that block the user — it interrupts the screen reader mid-sentence
 - [ ] Related fields grouped with `Fieldset` and a descriptive `label`
 - [ ] Required fields are indicated (via `label` text or equivalent — not color alone)
 
@@ -90,7 +93,7 @@ Component-specific checklists and code examples. The component handles interacti
 ## Loading states
 
 - [ ] Use `Loader` with descriptive text for meaningful loading states — `Spinner` alone is not announced to screen readers
-- [ ] For async results appearing in the page (search results, filtered lists), wrap the region in `aria-live="polite"`
+- [ ] For async results appearing in the page (search results, filtered lists), wrap the region in `aria-live="polite"` — but not around a form field's `feedback`, which already has its own live region
 
 ```tsx
 // Good — text is announced to screen readers

--- a/skills/entur-accessibility/references/testing-guide.md
+++ b/skills/entur-accessibility/references/testing-guide.md
@@ -90,7 +90,8 @@ Screen readers convert page content to speech and braille. Test with real screen
 - Page title is descriptive
 - Images have meaningful alt text (or `alt=""` if decorative)
 - Form fields have visible, associated labels
-- Error messages are announced when they appear
+- Error messages are announced when they appear — and only once. Two announcements of the same text usually means an `aria-live` wrapper around a field that already announces its `feedback`
+- A field's error message says what is wrong without relying on the status icon, which is `aria-hidden`
 - Status updates (loading, results) use `aria-live` regions
 - Interactive elements have accessible names (especially icon-only buttons)
 

--- a/skills/entur-web-development/references/components.md
+++ b/skills/entur-web-development/references/components.md
@@ -119,6 +119,8 @@ import { TextField, TextArea, Checkbox, Radio, RadioGroup, Switch, Fieldset } fr
 />
 
 // With validation feedback
+// feedback is announced to screen readers via role="status" — no aria-live of your own.
+// Pass ariaAlertOnFeedback for role="alert", or ariaAlertOnFeedback={false} to stay silent.
 <TextField
   label="Mobilnummer"
   value={phone}

--- a/tools/design-system-scanner/catalog.json
+++ b/tools/design-system-scanner/catalog.json
@@ -2,7 +2,7 @@
   "packages": [
     {
       "packageName": "@entur/a11y",
-      "latestVersion": "0.2.108",
+      "latestVersion": "0.3.2",
       "symbols": [
         {
           "symbolName": "SkipToContent",
@@ -18,7 +18,7 @@
     },
     {
       "packageName": "@entur/alert",
-      "latestVersion": "0.18.8",
+      "latestVersion": "0.20.2",
       "symbols": [
         {
           "symbolName": "BannerAlertBox",
@@ -116,7 +116,7 @@
     },
     {
       "packageName": "@entur/button",
-      "latestVersion": "4.0.4",
+      "latestVersion": "5.0.2",
       "symbols": [
         {
           "symbolName": "Button",
@@ -241,7 +241,7 @@
     },
     {
       "packageName": "@entur/chip",
-      "latestVersion": "0.10.8",
+      "latestVersion": "0.11.2",
       "symbols": [
         {
           "symbolName": "ActionChip",
@@ -278,7 +278,7 @@
     },
     {
       "packageName": "@entur/datepicker",
-      "latestVersion": "11.5.8",
+      "latestVersion": "12.0.2",
       "symbols": [
         {
           "symbolName": "ariaLabelIfNorwegian",
@@ -289,25 +289,18 @@
           "symbolName": "Calendar",
           "symbolType": "component",
           "knownProps": [
-            "selectedDate",
-            "onChange",
-            "navigationDescription",
+            "state",
+            "calendarProps",
+            "prevButtonProps",
+            "nextButtonProps",
+            "title",
+            "calendarRef",
             "style",
             "className",
-            "onSelectedCellClick",
-            "onCellClick",
-            "minDate",
-            "maxDate",
+            "navigationDescription",
             "showWeekNumbers",
             "weekNumberHeader",
-            "showOutsideMonth",
-            "classNameForDate",
-            "ariaLabelForDate",
-            "onValidate",
-            "disabled",
-            "locale",
-            "calendarRef",
-            "forcedReturnType"
+            "renderCell"
           ]
         },
         {
@@ -358,6 +351,8 @@
             "readOnly",
             "className",
             "style",
+            "ariaAlertOnFeedback",
+            "feedbackProps",
             "prepend",
             "append",
             "labelTooltipButtonAriaLabel",
@@ -365,7 +360,6 @@
             "required",
             "labelId",
             "disableLabelAnimation",
-            "ariaAlertOnFeedback",
             "after",
             "before",
             "ariaLabelOnReadOnly"
@@ -404,6 +398,8 @@
             "navigationDescription",
             "classNameForDate",
             "ariaLabelForDate",
+            "ariaAlertOnFeedback",
+            "feedbackProps",
             "prepend",
             "append",
             "labelTooltipButtonAriaLabel",
@@ -411,7 +407,6 @@
             "required",
             "labelId",
             "disableLabelAnimation",
-            "ariaAlertOnFeedback",
             "after",
             "before",
             "ariaLabelOnReadOnly"
@@ -473,9 +468,27 @@
           "knownProps": ["variant"]
         },
         {
-          "symbolName": "shouldUseAriaAlert",
-          "symbolType": "util",
-          "knownProps": []
+          "symbolName": "RangeCalendar",
+          "symbolType": "component",
+          "knownProps": [
+            "value",
+            "onChange",
+            "navigationDescription",
+            "style",
+            "className",
+            "minDate",
+            "maxDate",
+            "showWeekNumbers",
+            "weekNumberHeader",
+            "showOutsideMonth",
+            "classNameForDate",
+            "ariaLabelForDate",
+            "onValidate",
+            "disabled",
+            "locale",
+            "calendarRef",
+            "visibleDuration"
+          ]
         },
         {
           "symbolName": "SimpleTimePicker",
@@ -498,12 +511,13 @@
             "className",
             "style",
             "labelProps",
+            "ariaAlertOnFeedback",
+            "feedbackProps",
             "labelTooltipButtonAriaLabel",
             "labelTooltipPlacement",
             "required",
             "labelId",
             "disableLabelAnimation",
-            "ariaAlertOnFeedback",
             "after",
             "before",
             "ariaLabelOnReadOnly"
@@ -543,6 +557,8 @@
             "className",
             "style",
             "labelProps",
+            "ariaAlertOnFeedback",
+            "feedbackProps",
             "prepend",
             "append",
             "labelTooltipButtonAriaLabel",
@@ -550,7 +566,6 @@
             "required",
             "labelId",
             "disableLabelAnimation",
-            "ariaAlertOnFeedback",
             "after",
             "before",
             "ariaLabelOnReadOnly"
@@ -570,7 +585,7 @@
     },
     {
       "packageName": "@entur/dropdown",
-      "latestVersion": "8.1.0",
+      "latestVersion": "9.0.2",
       "symbols": [
         {
           "symbolName": "Dropdown",
@@ -600,7 +615,9 @@
             "ariaLabelCloseList",
             "ariaLabelOpenList",
             "ariaLabelChosenSingular",
-            "ariaLabelSelectedItem"
+            "ariaLabelSelectedItem",
+            "ariaAlertOnFeedback",
+            "feedbackProps"
           ]
         },
         {
@@ -635,6 +652,8 @@
             "ariaLabelOpenList",
             "ariaLabelChosenSingular",
             "ariaLabelSelectedItem",
+            "ariaAlertOnFeedback",
+            "feedbackProps",
             "selectedItems",
             "onChange",
             "itemFilter",
@@ -669,7 +688,9 @@
             "selectedItem",
             "value",
             "variant",
-            "disableLabelAnimation"
+            "disableLabelAnimation",
+            "ariaAlertOnFeedback",
+            "feedbackProps"
           ]
         },
         {
@@ -706,6 +727,8 @@
             "ariaLabelOpenList",
             "ariaLabelChosenSingular",
             "ariaLabelSelectedItem",
+            "ariaAlertOnFeedback",
+            "feedbackProps",
             "itemFilter",
             "debounceTimeout",
             "onBlur",
@@ -718,38 +741,40 @@
     },
     {
       "packageName": "@entur/expand",
-      "latestVersion": "3.7.5",
+      "latestVersion": "4.0.2",
       "symbols": [
         {
           "symbolName": "Accordion",
           "symbolType": "component",
-          "knownProps": ["children"]
+          "knownProps": ["children", "openId", "onToggle", "defaultOpenId"]
         },
         {
           "symbolName": "AccordionItem",
           "symbolType": "component",
           "knownProps": [
             "title",
-            "children",
             "defaultOpen",
             "contentStyle",
-            "disableAnimation"
+            "disableAnimation",
+            "unmountOnClose"
           ]
         },
         {
           "symbolName": "BaseExpand",
           "symbolType": "component",
-          "knownProps": ["children", "open"]
+          "knownProps": ["children", "open", "unmountOnClose"]
         },
         {
           "symbolName": "ExpandablePanel",
           "symbolType": "component",
           "knownProps": [
             "title",
-            "children",
             "defaultOpen",
+            "open",
             "onToggle",
-            "contentStyle"
+            "contentStyle",
+            "disableAnimation",
+            "unmountOnClose"
           ]
         },
         {
@@ -757,19 +782,19 @@
           "symbolType": "component",
           "knownProps": [
             "title",
-            "children",
             "defaultOpen",
             "open",
             "onToggle",
             "contentStyle",
             "titleElement",
-            "disableAnimation"
+            "disableAnimation",
+            "unmountOnClose"
           ]
         },
         {
           "symbolName": "ExpandableTextButton",
           "symbolType": "component",
-          "knownProps": []
+          "knownProps": ["children", "open", "onToggle", "as"]
         },
         {
           "symbolName": "ExpandArrow",
@@ -785,7 +810,7 @@
     },
     {
       "packageName": "@entur/fileupload",
-      "latestVersion": "0.5.6",
+      "latestVersion": "0.6.2",
       "symbols": [
         {
           "symbolName": "FileUpload",
@@ -805,12 +830,14 @@
     },
     {
       "packageName": "@entur/form",
-      "latestVersion": "9.3.0",
+      "latestVersion": "10.0.2",
       "symbols": [
         {
           "symbolName": "BaseFormControl",
           "symbolType": "component",
           "knownProps": [
+            "ariaAlertOnFeedback",
+            "feedbackProps",
             "disabled",
             "readOnly",
             "prepend",
@@ -827,7 +854,6 @@
             "isFilled",
             "labelProps",
             "disableLabelAnimation",
-            "ariaAlertOnFeedback",
             "after",
             "before",
             "ariaLabelOnReadOnly"
@@ -1023,13 +1049,13 @@
         {
           "symbolName": "VariantProvider",
           "symbolType": "component",
-          "knownProps": ["variant"]
+          "knownProps": ["children", "variant"]
         }
       ]
     },
     {
       "packageName": "@entur/grid",
-      "latestVersion": "0.3.74",
+      "latestVersion": "0.4.2",
       "symbols": [
         {
           "symbolName": "GridContainer",
@@ -1052,7 +1078,7 @@
     },
     {
       "packageName": "@entur/layout",
-      "latestVersion": "3.5.0",
+      "latestVersion": "4.0.2",
       "symbols": [
         {
           "symbolName": "Badge",
@@ -1153,7 +1179,7 @@
     },
     {
       "packageName": "@entur/loader",
-      "latestVersion": "0.6.5",
+      "latestVersion": "0.8.2",
       "symbols": [
         {
           "symbolName": "Loader",
@@ -1189,7 +1215,7 @@
     },
     {
       "packageName": "@entur/menu",
-      "latestVersion": "6.1.3",
+      "latestVersion": "7.1.0",
       "symbols": [
         {
           "symbolName": "BreadcrumbItem",
@@ -1212,6 +1238,19 @@
             "collapsibleButtonPosition",
             "openSideMenuAriaLabel",
             "closeSideMenuAriaLabel"
+          ]
+        },
+        {
+          "symbolName": "Logo",
+          "symbolType": "component",
+          "knownProps": [
+            "productName",
+            "size",
+            "href",
+            "as",
+            "className",
+            "children",
+            "ref"
           ]
         },
         {
@@ -1328,7 +1367,7 @@
     },
     {
       "packageName": "@entur/modal",
-      "latestVersion": "1.8.8",
+      "latestVersion": "2.0.2",
       "symbols": [
         {
           "symbolName": "Drawer",
@@ -1359,9 +1398,11 @@
             "initialFocusRef",
             "open",
             "onDismiss",
+            "showCloseButton",
             "size",
             "align",
             "title",
+            "aria-label",
             "closeOnClickOutside"
           ]
         },
@@ -1378,45 +1419,67 @@
             "onDismiss",
             "children",
             "className",
-            "initialFocusRef"
+            "initialFocusRef",
+            "closeOnClickOutside"
           ]
         }
       ]
     },
     {
       "packageName": "@entur/tab",
-      "latestVersion": "0.6.5",
+      "latestVersion": "0.8.2",
       "symbols": [
         {
           "symbolName": "Tab",
           "symbolType": "component",
-          "knownProps": ["children", "disabled", "as", "removeActiveLine"]
+          "knownProps": [
+            "children",
+            "disabled",
+            "index",
+            "as",
+            "removeActiveLine",
+            "className"
+          ]
         },
         {
           "symbolName": "TabList",
           "symbolType": "component",
-          "knownProps": ["children", "as", "width"]
+          "knownProps": [
+            "children",
+            "as",
+            "width",
+            "className",
+            "aria-label",
+            "aria-labelledby"
+          ]
         },
         {
           "symbolName": "TabPanel",
           "symbolType": "component",
-          "knownProps": ["children", "as"]
+          "knownProps": ["children", "as", "index", "className"]
         },
         {
           "symbolName": "TabPanels",
           "symbolType": "component",
-          "knownProps": ["children", "as"]
+          "knownProps": ["children", "as", "keepMounted", "className"]
         },
         {
           "symbolName": "Tabs",
           "symbolType": "component",
-          "knownProps": ["children", "onChange", "defaultIndex", "index", "as"]
+          "knownProps": [
+            "children",
+            "onChange",
+            "defaultIndex",
+            "index",
+            "as",
+            "className"
+          ]
         }
       ]
     },
     {
       "packageName": "@entur/table",
-      "latestVersion": "4.10.8",
+      "latestVersion": "5.0.2",
       "symbols": [
         {
           "symbolName": "DataCell",
@@ -1517,7 +1580,7 @@
     },
     {
       "packageName": "@entur/tokens",
-      "latestVersion": "3.22.3",
+      "latestVersion": "4.0.1",
       "symbols": [
         {
           "symbolName": "borderRadiuses",
@@ -1618,7 +1681,7 @@
     },
     {
       "packageName": "@entur/tooltip",
-      "latestVersion": "5.3.8",
+      "latestVersion": "6.0.2",
       "symbols": [
         {
           "symbolName": "Popover",
@@ -1674,7 +1737,7 @@
     },
     {
       "packageName": "@entur/travel",
-      "latestVersion": "6.5.8",
+      "latestVersion": "8.0.2",
       "symbols": [
         {
           "symbolName": "LegBone",
@@ -1727,6 +1790,7 @@
             "children",
             "className",
             "alert",
+            "type",
             "transport",
             "label",
             "labelPlacement",
@@ -1737,7 +1801,7 @@
     },
     {
       "packageName": "@entur/typography",
-      "latestVersion": "2.1.5",
+      "latestVersion": "3.0.2",
       "symbols": [
         {
           "symbolName": "Blockquote",
@@ -1860,11 +1924,16 @@
     },
     {
       "packageName": "@entur/utils",
-      "latestVersion": "0.13.2",
+      "latestVersion": "0.15.0",
       "symbols": [
         {
           "symbolName": "ConditionalWrapper",
           "symbolType": "component",
+          "knownProps": []
+        },
+        {
+          "symbolName": "getActiveElement",
+          "symbolType": "util",
           "knownProps": []
         },
         {


### PR DESCRIPTION
## 💡 Hvorfor?

**Berørte komponenter:** TextField, TextArea, DateField, TimePicker, SimpleTimePicker, NativeDatePicker, NativeTimePicker, Dropdown, SearchableDropdown, MultiSelect, NativeDropdown

### Live region ved sidelast
Live regioner for feil og statusmeldinger ble rendret feil. Statusregionen ble rendret samtidig med statusmeldingen. Dette virker med noen skjermlesere (som VoiceOver) men ikke med andre da det bryter ARIA-standarden.

_"Typically, assistive technology will only convey changes to a live region, not the initial contents of a live region. To ensure content in a live region is announced, authors SHOULD create a rendered but empty live region as early as possible (such as on page load), and then modify the content of the live region when the author expects changes to be spoken or brailled."_ - https://w3c.github.io/aria/

Live region-en rendres nå tom ved sidelast og fylles når meldingen kommer.

### Default til en statusmelding (`role='status'`)
Per idag må hver utvikler som bruker tekstfelt eller dato eksplisitt si at de vil ha live annonsering med `ariaAlertOnFeedback`-proppen. Mitt noe negative syn på mine medutviklere er at de fleste ikke tenker på dette med statusmeldinger og skjermleserbrukere, og derfor ikke aktiverer ariaAlertOnFeedback. De fleste status og feilmeldinger i skjema bør annonseres live – det er såklart unntak for dette (feks å istedenfor annonsere oppsummerende feilmeldingsliste) men jeg tørr påstå at i majoriten av tilfeller bør en live annonsering ved melding/feil bli gitt.

Konvensjonen mange går etter er å bruke `role='alert'/aria-live='assertive'` for feilmeldinger og `role='status'/aria-live='polite'` for statusmeldinger. Her velger vi istedenfor å defaulte alle meldinger til role='status' og la utviklere selv sette role='alert' der de ønsker å bruke dette.

Role='status' er mer "høflig" enn alert, det avbryter ikke hva enn skjermleserbrukeren nå hører. Alert kan oppleves som forstyrrende og noe "frekt" av flere skjermleserbrukere og bør derfor i større grad kun brukes der det faktisk er viktig at brukeren hører meldingen med en gang – feks ved en log out-notifikasjon.

Fun fact: aria-live='assertive' het først aria-live='rude' [w3.org/WAI/ARIA/track/actions/331](https://www.w3.org/WAI/ARIA/track/actions/331)

### To props styrer annonseringen
`ariaAlertOnFeedback` støttet allerede `'status'` som verdi, så hele annonseringen styres av den ene proppen. Det som endrer seg er defaultverdien: fra `false` til `'status'`.

| Prop | Effekt |
| --- | --- |
| _ingen props_ | `role="status"`, live region-en finnes alltid i DOM |
| `ariaAlertOnFeedback` (default `'status'`) | `true`/`'alert'` gir `role="alert"`, `'status'` gir `role="status"`, `false` skrur av annonsering helt |
| `feedbackProps` | Sendes videre til feedback-teksten. Egen `role` eller `aria-live` her vinner over `ariaAlertOnFeedback` |

Typen `FeedbackAnnouncementProps` eksporteres fra `@entur/form` og deles av alle komponentene.

### Andre endringer å bry seg om
#### TextArea
TextArea forwardet ikke `ariaAlertOnFeedback` til BaseFormControl og fikk derfor aldri noen live-annonsering av feedback-teksten. Samme props og samme default er nå lagt til her som for TextField.

#### Datepicker og timepicker
Denne PRen var først kun for tekstfelt, men innkluderer nå også datepicker som var avhengig av kode tekstfield brukte for å rendre feilmeldinger. DateField bruker samme logikk og defaulter til `role='status'` med mindre du eksplisitt passer props for å fjerne live-annonsering eller sette alert via `ariaAlertOnFeedback="alert"`.

#### Dropdown og de native komponentene
Alle skjemakomponenter som rendrer en feedback-tekst tar nå de samme proppene: Dropdown, SearchableDropdown, MultiSelect, NativeDropdown, NativeDatePicker, NativeTimePicker og SimpleTimePicker. Uten dette ville de fått den nye defaulten uten mulighet til å skru den av. SimpleTimePicker sendte proppene inn i react-aria istedenfor til TextField.

#### Statusikoner er nå skjult
Det blir brukt ikoner for å vise hva slags status som viser, feks har warning en varseltrekant. Disse hadde en god beskrivelse via aria-label, men jeg syntes dette skaper støy for skjermleserbrukere. Istedenfor bør vi regne med at statusmeldingen er så god at man forstår hva den sier. Jeg kan såklart reverte dette, men disse ikonene er for meg kun dekorative gitt at teksten er forståbar. Særlig i lange skjema vil disse ikonene med aria-label skape støy.

#### FeedbackText tillater at du passer inn tom tekst, dette for å kunne rendre feilmeldingsregionen før feilmeldingen eksisterer

#### aria-invalid virket ikke for variant="negative"
`aria-invalid` sjekket bare den deprekerte `variant="error"`, så felt med `variant="negative"` ble aldri markert som ugyldige for skjermlesere. Rettet i TextField, TextArea, NativeDatePicker og NativeTimePicker, og lagt til i Dropdown, SearchableDropdown og MultiSelect. Dette gir skjermleseren beskjed om at feltet er ugyldig når brukeren står i det, uten å legge ekstra tekst i meldingen.

## 🔧 Hvordan?
`BaseFormControl` regner ut rollen til feedback-teksten fra `ariaAlertOnFeedback` og eventuell `role`/`aria-live` i `feedbackProps`, og rendrer live region-en så lenge en av dem gir en rolle. FeedbackText rendrer en tom live-region i stedet for `null` når feedback mangler, slik at regionen finnes i DOM allerede ved mount. Proppene videreformidles fra hver skjemakomponent, og deles som typen `FeedbackAnnouncementProps`.

Dokumentasjonssidene for Text field, Text area, Dropdown og Timepicker har fått en Tilgjengelighet-seksjon som beskriver annonseringen, og skills-referansene for tilgjengelighet og webutvikling er oppdatert med det samme.

## 🧩 Type endring

- [X] 🐞 Feilretting
- [X] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [X] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💣 Breaking changes (om aktuelt)
Ingen. `ariaAlertOnFeedback` beholder betydningen av hver enkelt verdi, og ingen konsument må endre kode. Det er kun defaultverdien som går fra `false` til `'status'`, slik at feedback-tekst annonseres uten at man setter noen props.

To ting er verdt å merke seg likevel:

1. Felt uten props annonserer nå feedback-teksten. Vil du ha stillhet, sett `ariaAlertOnFeedback={false}` – den betyr fortsatt ingen live region.
2. Alle skjemafelt rendrer nå en permanent tom `.eds-feedback-text`-node. Konsumenter med snapshot-tester eller `getByRole('status')`-spørringer kan få rød CI uten at de må endre kildekode.

Datovelgere med variant `negative` eller `warning` fikk tidligere `role="alert"` og defaulter nå til `role="status"`. Dette merkes bare av skjermleserbrukere, og `ariaAlertOnFeedback="alert"` gir den gamle oppførselen.

## ✅ Sjekkliste

- [X] Navnestandarder følges
- [X] Kode og Figma reflekterer hverandre
- [X] Dokumentasjonen er oppdatert (hvis aktuelt)
- [X] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

- [X] Testet med skjermleser
- [X] Testet i Safari og Firefox
- [X] Testet i dokumentasjonsiden
- [X] Enhetstester: presedens mellom `ariaAlertOnFeedback` og `feedbackProps` i BaseFormControl, og aria-invalid per pakke

Merk: skjermlesertestingen er gjort på den opprinnelige oppførselen (`role="status"` som default). `feedbackProps` og aria-invalid-fiksen er dekket av enhetstester, men ikke verifisert med skjermleser.
