### PR TITLE
fix(expand): keep collapsed content unreachable on React 19

### DIFF
--- a/packages/expand/src/Accordion.test.tsx
+++ b/packages/expand/src/Accordion.test.tsx
@@ -43,6 +43,30 @@ test('renders a single accordion item', () => {
   );
 });
 
+test('makes collapsed content inert', () => {
+  const { getByRole, queryByText } = render(
+    <Accordion>
+      <AccordionItem title="Trains">
+        <button type="button">Buy ticket</button>
+      </AccordionItem>
+    </Accordion>,
+  );
+
+  const content = queryByText('Buy ticket')!.closest('.eds-base-expand');
+  expect(content).toHaveAttribute('inert');
+
+  fireEvent.click(getByRole('button', { name: 'Trains' }));
+  act(() => {
+    jest.runAllTimers();
+  });
+
+  expect(content).not.toHaveAttribute('inert');
+
+  fireEvent.click(getByRole('button', { name: 'Trains' }));
+
+  expect(content).toHaveAttribute('inert');
+});
+
 test('renders a group of accordion items that can be opened and closed', () => {
   const { getByRole, queryByText } = render(
     <Accordion>

--- a/packages/expand/src/BaseExpand.tsx
+++ b/packages/expand/src/BaseExpand.tsx
@@ -69,12 +69,15 @@ export const BaseExpand = React.forwardRef<HTMLDivElement, BaseExpandProps>(
 
     if (!mounted) return null;
 
+    // `inert` is a string on purpose: React 18 drops `inert={true}` and React 19
+    // drops `inert=""`, so only a string value renders the attribute on both.
+    // React 19 logs a dev-only warning about it — do not "fix" it to a boolean.
     return (
       <div
         ref={mergeRefs(collapseRef, ref)}
         className={`eds-base-expand${expanded ? ' eds-base-expand--open' : ''}`}
         onTransitionEnd={handleTransitionEnd}
-        {...(!expanded ? { 'aria-hidden': true, inert: '' } : {})}
+        {...(!expanded ? { 'aria-hidden': true, inert: 'true' } : {})}
       >
         <div className="eds-base-expand__inner">
           <div {...rest}>{children}</div>


### PR DESCRIPTION
Løser [ETU-75288](https://entur.atlassian.net/browse/ETU-75288)

## 💡 Hvorfor?

En konsument meldte om React-advarselen «Received an empty string for a boolean attribute `inert`». Undersøkelsen viste at det ikke bare er konsollstøy: React 19 tolker `inert` som en boolsk attributt, og fjerner den helt når verdien er tom streng. `BaseExpand` sendte `inert=""`, så på React 19 fikk kollapset innhold i `Accordion`, `ExpandablePanel` og `ExpandableText` aldri `inert` – innholdet kunne nås med både tastatur og mus selv om det var visuelt skjult.

Verifisert empirisk mot begge versjonene:

| Verdi i JSX | React 18.3.1 | React 19.2.8 |
| --- | --- | --- |
| `inert=""` (før) | `inert=""` settes, ingen advarsel | **attributtet fjernes**, advarsel |
| `inert={true}` | **attributtet fjernes**, advarsel | `inert=""` settes, ingen advarsel |
| `inert="true"` | `inert="true"` settes, ingen advarsel | `inert=""` settes, advarsel |

## 🔧 Hvordan?

Verdien er endret fra tom streng til strengen `"true"`. Det er den eneste verdien som faktisk setter attributtet på hele peerDependency-spennet (`react >=18.0.0`), og nettlesere aktiverer `inert` uavhengig av verdi.

React 19 logger fortsatt en dev-only advarsel om at strengen burde vært en boolsk verdi. Det er et bevisst valg – ingen enkeltverdi er advarselsfri på begge versjoner, og alternativet (boolsk verdi) ville brutt funksjonaliteten for alle React 18-konsumenter. Kommentar i koden forklarer hvorfor, slik at ingen «retter» den til `inert={true}` senere.

Lagt til regresjonstest i `Accordion.test.tsx` som sjekker at `inert` finnes på kollapset innhold og forsvinner når det åpnes.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

Vurderte alternativer:

- **Sette attributtet imperativt via `ref` i en effect.** Versjonsnøytralt og advarselsfritt, men koster en ekstra effect og gir et bilderammes forsinkelse ved montering. Kan være neste steg hvis advarselen blir plagsom.
- **`visibility: hidden` i CSS i stedet for `inert`.** Mest «native», men `visibility` arves og kan overstyres av konsumentens eget innhold, og det ville rørt animasjonssekvensen i en mye brukt komponent.

Repoet kjører kun React 18.3.1 i test, så CI kan ikke fange denne klassen av feil i dag. Verdt å vurdere om testoppsettet bør dekke React 19 også.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

`yarn workspace @entur/expand test` – 14 tester passerer, inkludert ny regresjonstest. Oppførselen for begge React-versjoner er verifisert med isolerte jsdom-renders mot React 18.3.1 og React 19.2.8 (matrisen over).

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden


[ETU-75288]: https://entur.atlassian.net/browse/ETU-75288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ