### PR TITLE
fix(expand/expandable text): add 4px spacing between title and chevron

### DIFF
--- a/packages/expand/src/ExpandableText.scss
+++ b/packages/expand/src/ExpandableText.scss
@@ -12,6 +12,7 @@
   font-size: inherit;
   display: flex;
   align-items: center;
+  gap: t.$space-extra-small2;
 
   :where(.eds-contrast) & {
     color: var(--components-expand-expandabletext-contrast-text);


### PR DESCRIPTION
## 💡 Hvorfor?

Tittelen og chevron-ikonet i `ExpandableText` sto tett inntil hverandre uten mellomrom. Det gjorde trigger-knappen vanskelig å lese, og ikonet så ut som en del av teksten. I Figma (Expandable Text, Button-frame) er avstanden 4px, så koden avvek fra designet.

Jira: [ETU-75282](https://entur.atlassian.net/browse/ETU-75282)
Figma: https://www.figma.com/design/L7FmiKATOnjdhW2TUn0eri/Entur-UI-Library?node-id=12023-202966

## 🔧 Hvordan?

Lagt til `gap: t.$space-extra-small2` (0.25rem / 4px) på flex-containeren `.eds-expandable-text__trigger`, slik at avstanden settes med spacing-token og samsvarer med Figma.

Sjekket også tilsvarende trigger-mønstre i `@entur/expand`: `BaseExpandablePanel` legger ikonet i en egen grid-kolonne (`grid-template-columns: auto 2rem`) med høyrejustert `__icon-container`, så ikonet ligger aldri inntil tittelen der. Ingen endring nødvendig utenfor `ExpandableText`.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

<!-- Legg ved hvis det hjelper å forstå endringen -->
<img width="526" height="244" alt="ETU-75282-expandable-text-gap" src="https://github.com/user-attachments/assets/ed5639f9-87cd-4701-b9d6-fc8488ac3c2f" />


## 💬 Tilleggsnotater

Klassen `.eds-expandable-text__arrow` er beholdt som den er – avstanden løses på containeren med `gap`, så ikonet trenger ingen egen styling.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

Kjørt `yarn test packages/expand` (13 tester, alle grønne) og `yarn build:package expand` – verifisert at `gap:0.25rem` kommer med i kompilert `packages/expand/dist/styles.css`.

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden


[ETU-75282]: https://entur.atlassian.net/browse/ETU-75282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ