### PR TITLE
fix(datepicker): treat undefined value as empty instead of crashing

### DIFF
--- a/packages/datepicker/src/DatePicker/Calendar.tsx
+++ b/packages/datepicker/src/DatePicker/Calendar.tsx
@@ -112,7 +112,8 @@ export const Calendar = <DateType extends DateValue>({
 };
 
 const _Calendar = <DateType extends DateValue>({
-  selectedDate,
+  // normalize undefined to null so the calendar stays controlled and empty
+  selectedDate = null,
   onChange,
   minDate,
   maxDate,

--- a/packages/datepicker/src/DatePicker/DateField.tsx
+++ b/packages/datepicker/src/DatePicker/DateField.tsx
@@ -138,7 +138,8 @@ export type DateFieldProps<DateType extends DateValue> =
   BaseDateFieldProps<DateType> & ExtendedDateFieldProps<DateType>;
 
 export const DateField = <DateType extends DateValue>({
-  selectedDate,
+  // normalize undefined to null so the field stays controlled and empty
+  selectedDate = null,
   onChange,
   label,
   locale: customLocale,

--- a/packages/datepicker/src/DatePicker/DatePicker.tsx
+++ b/packages/datepicker/src/DatePicker/DatePicker.tsx
@@ -93,7 +93,8 @@ export type DatePickerProps<DateType extends DateValue> = Omit<
   ExtendedDateFieldProps<DateType>;
 
 export const DatePicker = <DateType extends DateValue>({
-  selectedDate,
+  // normalize undefined to null so the picker stays controlled and empty
+  selectedDate = null,
   locale,
   disabled,
   readOnly,

--- a/packages/datepicker/src/DatePicker/RangeCalendar.tsx
+++ b/packages/datepicker/src/DatePicker/RangeCalendar.tsx
@@ -107,7 +107,8 @@ export const RangeCalendar = <DateType extends DateValue>({
 };
 
 const _RangeCalendar = <DateType extends DateValue>({
-  value,
+  // normalize undefined to null so the calendar stays controlled and empty
+  value = null,
   onChange,
   minDate,
   maxDate,

--- a/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx
@@ -31,6 +31,7 @@ type ExtendedSimpleTimePickerProps<TimeType extends TimeValue> = Omit<
   AriaTimeFieldProps<TimeType>,
   | keyof BaseSimpleTimePickerProps<TimeType>
   | 'value'
+  | 'defaultValue'
   | 'hideTimeZone'
   | 'placeholder'
   | 'minValue'

--- a/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx
@@ -105,7 +105,8 @@ export const SimpleTimePicker = <TimeType extends TimeValue>({
   padding = 'default',
   prepend,
   readOnly,
-  selectedTime,
+  // normalize undefined to null so the picker stays controlled and empty
+  selectedTime = null,
   showSeconds,
   style,
   variant,

--- a/packages/datepicker/src/TimePicker/TimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/TimePicker.tsx
@@ -35,6 +35,7 @@ type ExtendedTimePickerProps<TimeType extends TimeValue> = Omit<
   AriaTimeFieldProps<TimeType>,
   | keyof BaseTimePickerProps<TimeValue>
   | 'value'
+  | 'defaultValue'
   | 'hideTimeZone'
   | 'placeholder'
   | 'minValue'

--- a/packages/datepicker/src/TimePicker/TimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/TimePicker.tsx
@@ -112,7 +112,8 @@ export type TimePickerProps<TimeType extends TimeValue> =
   BaseTimePickerProps<TimeType> & ExtendedTimePickerProps<TimeType>;
 
 export const TimePicker = <TimeType extends TimeValue>({
-  selectedTime,
+  // normalize undefined to null so the picker stays controlled and empty
+  selectedTime = null,
   onChange,
   disabled,
   readOnly,

--- a/packages/datepicker/src/shared/utils.ts
+++ b/packages/datepicker/src/shared/utils.ts
@@ -65,7 +65,7 @@ export function nativeDateToDateValue(
   timeZone?: string,
   offset?: number,
 ) {
-  if (date === null) return null;
+  if (date == null) return null;
 
   if (noTimeOnlyDate)
     return new CalendarDate(
@@ -91,7 +91,7 @@ export function nativeDateToTimeValue(
   timeZone?: string,
   offset?: number,
 ) {
-  if (date === null) return null;
+  if (date == null) return null;
 
   if (noDateOnlyTime)
     return new Time(
@@ -114,7 +114,7 @@ export function timeOrDateValueToNativeDate(
   value: TimeValue | DateValue | null,
   timeZoneForCalendarDateTime?: string,
 ) {
-  if (value === null) return null;
+  if (value == null) return null;
 
   // type is Time
   if (!('day' in value)) {
@@ -175,7 +175,7 @@ export const convertValueToType = ({
   type: 'CalendarDate' | 'CalendarDateTime' | 'ZonedDateTime' | 'Time';
   timezone?: string;
 }) => {
-  if (value === null) return null;
+  if (value == null) return null;
   switch (type) {
     case 'CalendarDate':
       if (!('day' in value)) return today(timezone);
@@ -223,7 +223,7 @@ export const focusSegment = (
 
 /** Based on code from https://stackoverflow.com/questions/6117814/get-week-of-year-in-javascript-like-in-php */
 export function getWeekNumberForDate(date: DateValue | null) {
-  if (date === null) return -1;
+  if (date == null) return -1;
   const calendarDate = convertValueToType({
     value: date,
     type: 'CalendarDate',
@@ -262,10 +262,10 @@ export function handleOnChange<DateType extends DateValue>({
         value,
         type: forcedReturnType ?? 'ZonedDateTime',
         timezone:
-          (value !== null && 'timeZone' in value
+          (value != null && 'timeZone' in value
             ? (value.timeZone as string)
             : undefined) ??
-          (selectedDate !== null && 'timeZone' in selectedDate
+          (selectedDate != null && 'timeZone' in selectedDate
             ? (selectedDate.timeZone as string)
             : undefined),
       }) as MappedDateValue<typeof forcedReturnType> | null,

--- a/packages/datepicker/src/tests/UndefinedValue.test.tsx
+++ b/packages/datepicker/src/tests/UndefinedValue.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CalendarDate } from '@internationalized/date';
+import { Calendar, DateField, DatePicker, RangeCalendar } from '../DatePicker';
+import { SimpleTimePicker, TimePicker } from '../TimePicker';
+import { handleOnChange } from '../shared/utils';
+
+describe('undefined value props', () => {
+  test('shared handleOnChange with undefined selectedDate', () => {
+    const spy = jest.fn();
+    expect(() =>
+      handleOnChange({
+        value: new CalendarDate(2026, 8, 4),
+        selectedDate: undefined as any,
+        forcedReturnType: undefined,
+        onChange: spy,
+      }),
+    ).not.toThrow();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test.each([
+    ['TimePicker', TimePicker],
+    ['SimpleTimePicker', SimpleTimePicker],
+  ])('%s renders with undefined selectedTime', (_name, Component: any) => {
+    expect(() =>
+      render(
+        <Component
+          label="test"
+          selectedTime={undefined as any}
+          onChange={jest.fn()}
+          locale="en-GB"
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  test.each([
+    ['DatePicker', DatePicker],
+    ['DateField', DateField],
+    ['Calendar', Calendar],
+  ])('%s renders with undefined selectedDate', (_name, Component: any) => {
+    expect(() =>
+      render(
+        <Component
+          label="test"
+          selectedDate={undefined as any}
+          onChange={jest.fn()}
+          locale="en-GB"
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  test('DateField with undefined selectedDate fires onChange on full date', async () => {
+    const spy = jest.fn();
+    render(
+      <DateField
+        label="test"
+        selectedDate={undefined as any}
+        onChange={spy}
+        locale="en-GB"
+      />,
+    );
+    await userEvent.click(screen.getByRole('spinbutton', { name: /day/ }));
+    await userEvent.keyboard('04082026');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('TimePicker with undefined selectedTime fires onChange on typing', async () => {
+    const spy = jest.fn();
+    render(
+      <TimePicker
+        label="test"
+        selectedTime={undefined as any}
+        onChange={spy}
+        locale="en-GB"
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole('spinbutton', { name: 'hour, test' }),
+    );
+    await userEvent.keyboard('1230');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('RangeCalendar renders with undefined value', () => {
+    expect(() =>
+      render(
+        <RangeCalendar
+          value={undefined as any}
+          onChange={jest.fn()}
+          locale="en-GB"
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  test('RangeCalendar with undefined value stays controlled', async () => {
+    const spy = jest.fn();
+    render(
+      <RangeCalendar value={undefined as any} onChange={spy} locale="en-GB" />,
+    );
+    const dates = screen.getAllByRole('button', { name: /\d/ });
+    await userEvent.click(dates[5]);
+    await userEvent.click(dates[8]);
+    expect(spy).toHaveBeenCalled();
+    // controlled: nothing is selected until the consumer passes a value back
+    expect(document.querySelectorAll('[aria-selected="true"]')).toHaveLength(0);
+  });
+});

--- a/packages/datepicker/src/tests/UndefinedValue.test.tsx
+++ b/packages/datepicker/src/tests/UndefinedValue.test.tsx
@@ -53,6 +53,7 @@ describe('undefined value props', () => {
   });
 
   test('DateField with undefined selectedDate fires onChange on full date', async () => {
+    const user = userEvent.setup();
     const spy = jest.fn();
     render(
       <DateField
@@ -62,12 +63,13 @@ describe('undefined value props', () => {
         locale="en-GB"
       />,
     );
-    await userEvent.click(screen.getByRole('spinbutton', { name: /day/ }));
-    await userEvent.keyboard('04082026');
+    await user.click(screen.getByRole('spinbutton', { name: /day/ }));
+    await user.keyboard('04082026');
     expect(spy).toHaveBeenCalled();
   });
 
   test('TimePicker with undefined selectedTime fires onChange on typing', async () => {
+    const user = userEvent.setup();
     const spy = jest.fn();
     render(
       <TimePicker
@@ -77,10 +79,8 @@ describe('undefined value props', () => {
         locale="en-GB"
       />,
     );
-    await userEvent.click(
-      screen.getByRole('spinbutton', { name: 'hour, test' }),
-    );
-    await userEvent.keyboard('1230');
+    await user.click(screen.getByRole('spinbutton', { name: 'hour, test' }));
+    await user.keyboard('1230');
     expect(spy).toHaveBeenCalled();
   });
 
@@ -97,13 +97,14 @@ describe('undefined value props', () => {
   });
 
   test('RangeCalendar with undefined value stays controlled', async () => {
+    const user = userEvent.setup();
     const spy = jest.fn();
     render(
       <RangeCalendar value={undefined as any} onChange={spy} locale="en-GB" />,
     );
     const dates = screen.getAllByRole('button', { name: /\d/ });
-    await userEvent.click(dates[5]);
-    await userEvent.click(dates[8]);
+    await user.click(dates[5]);
+    await user.click(dates[8]);
     expect(spy).toHaveBeenCalled();
     // controlled: nothing is selected until the consumer passes a value back
     expect(document.querySelectorAll('[aria-selected="true"]')).toHaveLength(0);


### PR DESCRIPTION
## 💡 Hvorfor?

[ETU-75329](https://entur.atlassian.net/browse/ETU-75329)

Velgerne i `@entur/datepicker` krasjet hvis de fikk `undefined` som valgt verdi i stedet for `null`:

```
TypeError: Cannot use 'in' operator to search for 'timeZone' in undefined
```

Feilen skjedde under render, så på React 18 kunne hele siden avmonteres – ikke bare komponenten. Et team traff dette i praksis (gruppereise-skjemaet på om.entur.no) etter oppgradering til react-hook-form ≥ 7.73.1, der et felt under et `null`-objekt nå gir `undefined` der det før ga `null`.

Sjekkene i koden var strengt `!== null`. Siden `undefined !== null` er sant, gikk kontrollflyten videre til `'timeZone' in undefined`, som kaster.

## 🔧 Hvordan?

`undefined` blir nå normalisert til `null` helt i prop-grensen, via default-verdi i destrukturering:

```diff
-export const TimePicker = <TimeType extends TimeValue>({ selectedTime, ... })
+export const TimePicker = <TimeType extends TimeValue>({ selectedTime = null, ... })
```

Gjort i `TimePicker`, `SimpleTimePicker`, `DatePicker`, `DateField`, `Calendar` og `RangeCalendar`. Resten av komponentkroppene er urørt, siden `null` allerede håndteres riktig overalt.

I `shared/utils.ts` er `=== null` byttet til `== null`. Disse funksjonene er eksportert og kalles direkte av konsumenter, så de har ingen prop-grense å normalisere i.

Valget av normalisering, framfor bare å utvide sjekken slik det ble foreslått: `useControlledState` i react-stately tolker `value === undefined` som *ukontrollert*. Hadde vi bare utvidet sjekken, ville `undefined` nådd react-aria og gjort feltet ukontrollert – konsumentens state slutter å være kilden til sannhet, og man får en advarsel når verdien senere blir satt. Normalisering holder feltet kontrollert.

En sidegevinst: `RangeCalendar` krasjet ikke på `undefined`, men gled stille over i ukontrollert modus og beholdt sitt eget valg. Den oppfører seg nå likt de andre.

Andre commit fjerner `defaultValue` fra prop-typene til `TimePicker` og `SimpleTimePicker`. Propen lakk gjennom fra react-aria og har aldri hatt effekt, siden velgerne alltid er kontrollerte. Holdt utenfor changeloggen med vilje, siden det ikke er en funksjonell endring.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [x] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

Konsumenter trenger ikke lenger `selectedTime={value ?? null}` på kallstedet. Workaroundet er fortsatt trygt å ha stående.

Alle velgerne er nå bevisst **kun kontrollerte**. Støtte for ukontrollert bruk er en egen oppgave: da bør den lande under DS-navngivning (`defaultSelectedTime` / `defaultSelectedDate`) med egen intern state, ikke ved å la `undefined` bety «ukontrollert». Ellers kommer denne feilklassen tilbake som stille state-desync i stedet for en krasj.

Merk at `defaultValue`-fjerningen i teorien kan gi kompileringsfeil hos noen som sender propen i dag, men den har aldri gjort noe.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre <!-- ingen visuelle endringer -->
- [ ] Dokumentasjonen er oppdatert (hvis aktuelt) <!-- ingen dokumenterte props er endret -->
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

Ny testfil `src/tests/UndefinedValue.test.tsx` med 10 tester: render med `undefined` for alle seks komponentene, `onChange` med `undefined` for `TimePicker` og `DateField`, `shared/utils.ts handleOnChange` direkte, samt en test som slår fast at `RangeCalendar` forblir kontrollert.

- `yarn test:package datepicker` – 113/113 grønne
- `yarn build:package datepicker` – ok
- `npx oxlint packages/datepicker` – 0 feil, 6 varsler som alle finnes på `main` fra før

Reproduksjonen er verifisert på `main` før fiksen: `TimePicker` kastet under render, `SimpleTimePicker` i mount-effekten, og `DatePicker` / `DateField` / `Calendar` ved første `onChange`.

- [ ] Testet med skjermleser <!-- ingen endring i markup eller a11y-flate -->
- [ ] Testet i Safari og Firefox <!-- ingen visuelle endringer; dekket av tester -->
- [ ] Testet i dokumentasjonsiden


[ETU-75329]: https://entur.atlassian.net/browse/ETU-75329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ