### PR TITLE
Forbedre Kom i gang for utviklere og dokumentere skillene

### DIFF
--- a/apps/documentation/src/components/Navigations/SideNavigation/utils.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/utils.tsx
@@ -138,13 +138,16 @@ export const sortSubCategoriesForCategory = (
   return aSortOrder - bSortOrder;
 };
 
-export const sorters: { [key: string]: any } = {
-  'kom-i-gang': komIGangMenuSortOrder,
-  identitet: visuellIdentitetMenuSortOrder,
-  komponenter: componentsMenuSortOrder,
-  tokens: tokensMenuSortOrder,
-  monster: monsterMenuSortOrder,
-  ressurser: ressurserMenuSortOrder,
-};
+// Keys are normalized so both route slugs ('kom-i-gang') and titles ('Kom i gang') resolve
+export const sorters: { [key: string]: any } = Object.fromEntries(
+  Object.entries({
+    'kom-i-gang': komIGangMenuSortOrder,
+    identitet: visuellIdentitetMenuSortOrder,
+    komponenter: componentsMenuSortOrder,
+    tokens: tokensMenuSortOrder,
+    monster: monsterMenuSortOrder,
+    ressurser: ressurserMenuSortOrder,
+  }).map(([category, sortOrder]) => [normalizeString(category), sortOrder]),
+);
 
 export { getSanitizedPath };

--- a/apps/documentation/src/pages/kom-i-gang/for-utviklere/bidra-med-kode.mdx
+++ b/apps/documentation/src/pages/kom-i-gang/for-utviklere/bidra-med-kode.mdx
@@ -4,7 +4,7 @@ description: Har du funnet en bug i designsystemet? Vil du legge til en ny featu
 route: /kom-i-gang/for-utviklere/bidra-med-kode
 parent: Kom i gang
 menu: For utviklere
-order: 2
+order: 4
 ---
 
 import { graphql } from 'gatsby';

--- a/apps/documentation/src/pages/kom-i-gang/for-utviklere/css-og-stiler.mdx
+++ b/apps/documentation/src/pages/kom-i-gang/for-utviklere/css-og-stiler.mdx
@@ -1,0 +1,130 @@
+---
+title: CSS og stiler
+description: Komponentene våre kommer med separate CSS-filer som må importeres for at alt skal fungere. Her lærer du hvordan du importerer dem, hvilken rekkefølge de må ha og hva du gjør når stilene ikke fungere.
+route: /kom-i-gang/for-utviklere/css-og-stiler
+parent: Kom i gang
+menu: For utviklere
+order: 2
+---
+
+import { SEO } from '@components/seo/SEO';
+
+export const Head = ( props ) => {
+  return <SEO title={props.pageContext.frontmatter.title} description={props.pageContext.frontmatter.description} pathname={props.pageContext.frontmatter.route} />
+}
+
+
+For at komponentene skal se riktige ut, må du inkludere CSS-filene fra pakkene du bruker. Dette bør gjøres på et globalt nivå i applikasjonen din, f.eks. i `App.tsx`, `index.js`, eller en global `.css` eller `.scss`-fil.
+
+## Hvordan importere
+
+Hver pakke eksponerer stilene sine på under `/styles`. Importer dem gjerne direkte i JavaScript eller TypeScript (anbefalt for moderne prosjekter):
+
+```js
+import '@entur/button/styles';
+```
+
+Eller i en CSS-fil:
+
+```css
+@import '@entur/button/styles';
+```
+
+I en SCSS-fil bruker du `@use`:
+
+```scss
+@use '@entur/tokens/styles/base' as *;
+@use '@entur/button/styles';
+```
+
+<SmallAlertBox variant="information">
+  `/styles` er en subpath i pakkens <CodeText>exports</CodeText>, og kobles riktig gjennom bundleren din, f.eks Webpack (via sass-loader) og Vite. Importerer du gjennom <CodeText>sass</CodeText> direkte, må du oppgi full sti – <CodeText>@entur/tokens/dist/base.scss</CodeText> – eller bruke <CodeText>pkg:</CodeText>-prefiks.
+</SmallAlertBox>
+
+De gamle stiene  – som `@entur/button/dist/styles.css` – virker fortsatt, men `/styles` er den anbefalte formen.
+
+## Riktig rekkefølge
+
+For å unngå uventede stilkonflikter er det viktig å importere stilene i riktig rekkefølge. Tokens først, deretter komponentstilene:
+
+```css
+/* 1. Basetokens – alltid først (farger og fargemodus) */
+@import '@entur/tokens/styles/base';
+
+/* 2. Øvrige tokens (spacing, border-radius, fontstørrelser, breakpoints) */
+@import '@entur/tokens/styles';
+
+/* 3. Komponentstiler – i denne rekkefølgen */
+@import '@entur/a11y/styles';
+@import '@entur/grid/styles';
+@import '@entur/icons/styles';
+@import '@entur/tab/styles';
+@import '@entur/typography/styles';
+@import '@entur/typography/beta/styles';
+@import '@entur/layout/styles';
+@import '@entur/layout/beta/styles';
+@import '@entur/loader/styles';
+@import '@entur/expand/styles';
+@import '@entur/button/styles';
+@import '@entur/alert/styles';
+@import '@entur/menu/styles';
+@import '@entur/fileupload/styles';
+@import '@entur/modal/styles';
+@import '@entur/tooltip/styles';
+@import '@entur/form/styles';
+@import '@entur/chip/styles';
+@import '@entur/datepicker/styles';
+@import '@entur/travel/styles';
+@import '@entur/table/styles';
+@import '@entur/dropdown/styles';
+```
+
+Importerer du fra JavaScript eller SCSS, er det samme rekkefølge – bytt `@import` med `import` eller `@use`.
+
+Du trenger bare stilene for pakkene du faktisk bruker – men behold rekkefølgen mellom dem. Rekkefølgen er ikke tilfeldig: noen komponentstiler bygger på stiler fra pakker lenger opp i listen. `@entur/form` avhenger for eksempel av `@entur/icons` og `@entur/typography`.
+
+De øvrige token-filene (`semantic`, `data`, `transport`) importeres ved behov i filene som bruker dem – ikke globalt.
+
+## Betapakker har egne stilfiler
+
+`@entur/typography/beta` og `@entur/layout/beta` har stiler som ligger utenfor hovedstilene til pakken. Bruker du betakomponentene, må du importere `/beta/styles` i tillegg til `/styles`, slik listen over viser.
+
+## Mørk modus
+
+Komponentene følger fargemodusen til nærmeste forelder med `data-color-mode="dark"` eller `data-color-mode="light"`. Token-variablene bytter verdi automatisk, så du trenger ikke gjøre noe per komponent:
+
+```html
+<div data-color-mode="dark">
+  <!-- tokens har mørke verdier her -->
+</div>
+```
+
+Sett attributtet på `document.documentElement` hvis hele appen skal bytte. Se [dark mode](/tokens/fargetokens/dark-mode) for hele oppsettet.
+
+## Overstyring av komponentstiler
+
+Overstyring kan bryte visuell konsistens og gir vedlikeholdsgjeld når designsystemet endrer seg. Sjekk først om det finnes en variant som løser behovet – spør gjerne på [#talk-designsystem](https://entur.slack.com/archives/C899QSPB7).
+
+Er det likevel best å overskrive er dette noen råd:
+
+1. Legg en egen `className` på komponenten og bruk den som selektor. Ikke sikt på interne `.eds-*`-klasser.
+2. Sett token-variabler framfor rene verdier – komponenttokens (`--components-{pakke}-…`) først, deretter base- og semantiske tokens.
+3. Ikke bruk `!important`. Trenger du høyere spesifisitet, bygg den opp gjennom din egen selektor.
+4. Skriv en kort kommentar om hvorfor avviket finnes, så det kan spores.
+
+```css
+/* bevisst avvik – bestillingsforsiden krever korall bakgrunn */
+.booking-hero-cta {
+  --components-button-primary-standard-default: var(--shape-highlight);
+}
+```
+
+## Feilsøking
+
+**Stilene ser feil ut etter en oppgradering.** Sjekk om du har duplikate `@entur/*`-pakker i avhengighetstreet – to versjoner av samme pakke gir inkompatibel CSS og JS. `yarn dedupe --pattern "@entur"` eller `npm dedupe` rydder opp.
+
+**Komponentene er helt ustylet.** CSS-importen må ligge globalt, ikke inne i en komponentfil. Mangler stilene for én pakke, kan det også slå ut på pakker lenger ned i rekkefølgen. Hvis pakken avhenger av en annen pakken må du også ha dens stiler, eksempelvis avhenger `datepicker` av `button`.
+
+**Tailwind eller annet rammeverk overstyrer stilene våre.** Mesteparten av CSS-en vår ligger utenfor cascade layers, og ulagd CSS taper alltid mot ulagd CSS som kommer senere. Legg rammeverkets globale reset i et `@layer`, eller flytt importrekkefølgen slik at Entur-stilene kommer sist.
+
+**Komponenten avviker litt fra skissen.** Ikke legg på CSS-overstyringer med en gang – sjekk først importrekkefølgen og om skissen bruker en annen variant. Er det skissen som har divergert, si fra på #talk-designsystem.

--- a/apps/documentation/src/pages/kom-i-gang/for-utviklere/komponentbibliotek.mdx
+++ b/apps/documentation/src/pages/kom-i-gang/for-utviklere/komponentbibliotek.mdx
@@ -19,9 +19,11 @@ export const Head = ( props ) => {
 
 ## Installer pakker
 
-Designsystemet er delt opp i et knippe forskjellige pakker, som lastes ned enkelthvis fra NPM. Du kan se en komplett oversikt over tilgjengelige pakker [her](http://npmjs.org/org/entur).
+Designsystemet er delt opp i et knippe forskjellige pakker, som lastes ned enkeltvis fra NPM. Du kan se en komplett oversikt over tilgjengelige pakker [på npm](https://www.npmjs.com/org/entur).
 
-Du kan bruke `yarn` eller `npm` til å innstallere pakkene - det er opp til prosjektet ditt. Har prosjektet ditt en `yarn.lock`, bruker du `yarn add`, og har du `package-lock.json`, så bruker du `npm`.
+Alle pakkene krever React 18 eller nyere – `react` og `react-dom` er `peerDependencies`, så de installeres av prosjektet ditt.
+
+Du kan bruke `yarn` eller `npm` til å installere pakkene – det er opp til prosjektet ditt. Har prosjektet ditt en `yarn.lock`, bruker du `yarn add`, og har du `package-lock.json`, så bruker du `npm`.
 
 Velg gjerne det du bruker i prosjektet ditt i innstillingsmenyen oppe i høyre hjørne.
 
@@ -31,78 +33,30 @@ Det avhenger av hva du skal lage, men en god start kan være disse:
 
 <PackageManager></PackageManager>
 
-### Hvorfor ikke bare én pakke?
+`@entur/tokens` bør alltid være med – den inneholder farger, spacing og typografi som resten av pakkene bygger på.
 
-Når man har én pakke, har man også bare én versjon å forholde seg til - og det kan skape noen utfordringer etterhvert som designsystemet modnes.
-Ved å dele opp i flere pakker med uavhengige versjonering, kan man få oppgradert en bugfiks på knappene sine, uten at man trenger å oppgradere andre eventuelle breaking changes som har skjedd siden sist du oppdaterte avhengigheten din.
+<ExpandablePanel title="Hvorfor ikke bare én pakke?">
 
-En annen fordel er at man ikke inkluderer mer kode enn man trenger, som kan ha en positiv effekt på mengden JavaScript og CSS ved å kun ha de komponentenene og den stylingen man behøver.
+Når man har én pakke, har man også bare én versjon å forholde seg til – og det kan skape noen utfordringer etterhvert som designsystemet modnes.
+Ved å dele opp i flere pakker med uavhengig versjonering, kan man få oppgradert en bugfiks på knappene sine, uten at man trenger å oppgradere andre eventuelle breaking changes som har skjedd siden sist du oppdaterte avhengigheten din.
+
+En annen fordel er at man ikke inkluderer mer kode enn man trenger, som kan ha en positiv effekt på mengden JavaScript og CSS ved å kun ha de komponentene og den stylingen man behøver.
 
 Det er litt mer arbeid å komme i gang med nye prosjekter, men vedlikeholdet av applikasjonene blir enklere.
 
+</ExpandablePanel>
+
 ## Inkluder CSS
 
-For at komponentene skal se riktige ut, må du inkludere CSS-filene fra pakkene du bruker. Dette bør gjøres på et globalt nivå i applikasjonen din (f.eks. i `App.tsx`, `index.js`, eller en global `.scss`-fil) for å sikre at stilene er tilgjengelige i hele prosjektet.
+Komponentene har ingen innebygde stiler – CSS-en ligger i egne filer i hver pakke, og må importeres globalt i applikasjonen din. Rekkefølgen mellom pakkene betyr noe.
 
-### Hvordan importere
+Se [CSS og stiler](/kom-i-gang/for-utviklere/css-og-stiler) for hvordan du importerer, hele rekkefølgelisten og feilsøking når stilene ikke oppfører seg.
 
-Du kan importere CSS direkte i JavaScript eller TypeScript (anbefalt for moderne prosjekter):
+## Bruk komponentene
 
-```js
-import '@entur/button/dist/styles.css';
-...
-```
+Hver av pakkene kommer med sine egne universelt utformede React-komponenter, som gjør det enkelt for React-utviklere å lage komplette apper. [Du finner API-dokumentasjonen for alle komponentene her](/komponenter).
 
-Eller i en CSS/SCSS-fil:
-
-```css
-@import '@entur/button/dist/styles.css';
-```
-```scss
-@use '@entur/button/dist/styles.css' as *;
-```
-
-### Riktig rekkefølge
-
-For å unngå uventede stilkonflikter er det viktig å importere pakkene i riktig rekkefølge. Her er den anbefalte rekkefølgen for alle pakkene:
-
-```css
-@import '@entur/a11y/dist/styles.css';
-@import '@entur/grid/dist/styles.css';
-@import '@entur/icons/dist/styles.css';
-@import '@entur/tab/dist/styles.css';
-@import '@entur/typography/dist/styles.css';
-@import '@entur/typography/beta/styles';
-@import '@entur/layout/dist/styles.css';
-@import '@entur/loader/dist/styles.css';
-@import '@entur/expand/dist/styles.css';
-@import '@entur/button/dist/styles.css';
-@import '@entur/alert/dist/styles.css';
-@import '@entur/menu/dist/styles.css';
-@import '@entur/fileupload/dist/styles.css';
-@import '@entur/modal/dist/styles.css';
-@import '@entur/tooltip/dist/styles.css';
-@import '@entur/form/dist/styles.css';
-@import '@entur/chip/dist/styles.css';
-@import '@entur/datepicker/dist/styles.css';
-@import '@entur/travel/dist/styles.css';
-@import '@entur/table/dist/styles.css';
-@import '@entur/dropdown/dist/styles.css';
-```
-
-## React-komponenter
-
-Hver av pakkene kommer med sine egne universelt utformede React-komponenter, som gjør det enkelt for React-utviklere å lage komplette apper. ['Du finner API-dokumentasjonen for alle komponentene her'](/komponenter).
-
-## Typer
-
-Per i dag leveres alle pakker med komplette TypeScript-typings.
-
-Typene for alle komponentene er eksportert på toppnivå, og kan importeres for å brukes videre i egen kode.
-
-De er på formen `KomponentnavnProps`, så eksempelvis så har komponenten `Dropdown` typene eksponert via `DropdownProps`.
-
-## Exports
+### Exports
 
 Designsystemets pakker benytter seg kun av [named exports](https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export). Dette gjør at du alltid vil importere komponenter og funksjoner slik:
 
@@ -112,12 +66,37 @@ import { EnKomponent, useEnHook } from '@entur/en-pakke';
 
 Du vil med andre ord _aldri_ se default exports.
 
+### Typer
+
+Alle pakker leveres med komplette TypeScript-typer, eksportert på toppnivå sammen med komponentene.
+
+De er på formen `KomponentnavnProps`, så eksempelvis så har komponenten `Dropdown` typene eksponert via `DropdownProps`.
+
+```tsx
+import { Dropdown } from '@entur/dropdown';
+import type { DropdownProps } from '@entur/dropdown';
+```
+
+### Bytt HTML-element med `as`
+
+Mange komponenter tar en `as`-prop, slik at du kan beholde utseendet men endre elementet som rendres – nyttig for f.eks. en knapp som egentlig er en lenke:
+
+```tsx
+<PrimaryButton as="a" href="/kjop-billett">
+  Kjøp billett
+</PrimaryButton>
+```
+
+## La KI-agenten din kunne designsystemet
+
+Vi publiserer skills som gir kodeagenter som Claude Code, Copilot og Cursor kunnskap om `@entur/*`-pakkene, tokens, visuell identitet og universell utforming. Se [Skills](/kom-i-gang/for-utviklere/skills) for installasjon og bruk.
+
 ## Spørsmål?
 
 Hvis du har spørsmål, ta kontakt på #talk-designsystem på Slack. Hvis du mangler tilgang til dokumentasjon (skisser og collections) i Figma, kontakt [Sergio Haisch](mailto:sergio.haisch.timm@entur.org).
 
 ## Kom i gang med å bidra!
 
-Designsystem-teamet trenger så mye hjelp de kan få - både med å skrive dokumentasjon, lage eksempler, skrive tester, finne bugs og fikse dem.
+Designsystem-teamet trenger så mye hjelp de kan få – både med å skrive dokumentasjon, lage eksempler, skrive tester, finne bugs og fikse dem. Se [bidra med kode](/kom-i-gang/for-utviklere/bidra-med-kode) for hvordan du kommer i gang i repoet.
 
-Om du har tid til å gjøre det selv, kan du [lage et pull request](https://github.com/entur/design-system). Om du ikke har tid, kan du lage et [issue på Jira](https://enturas.atlassian.net/jira/software/c/projects/ETU/boards/173?quickFilter=1229). Om du bare lurer på noe, ta kontakt på #talk-designsystem på Slack.
+Om du ikke har tid til å gjøre det selv, kan du lage et [issue på Jira](https://enturas.atlassian.net/jira/software/c/projects/ETU/boards/173?quickFilter=1229). Om du bare lurer på noe, ta kontakt på #talk-designsystem på Slack.

--- a/apps/documentation/src/pages/kom-i-gang/for-utviklere/skills.mdx
+++ b/apps/documentation/src/pages/kom-i-gang/for-utviklere/skills.mdx
@@ -1,0 +1,123 @@
+---
+title: Skills
+description: Linje tilbyr noen skills som gir KI-kodeagenter mer kunnskap om riktig bruk av komponenter, tokens, universell utforming og lignende. Denne artiklen tar deg gjennom hvordan du installerer og bruker skillsene.
+route: /kom-i-gang/for-utviklere/skills
+parent: Kom i gang
+menu: For utviklere
+order: 3
+---
+
+import { SEO } from '@components/seo/SEO';
+import { CodeBlock } from '@components/Codeblock/CodeBlock';
+
+export const Head = ( props ) => {
+  return <SEO title={props.pageContext.frontmatter.title} description={props.pageContext.frontmatter.description} pathname={props.pageContext.frontmatter.route} />
+}
+
+
+## Hva er en skill?
+
+En skill er et instruksjonssett en KI-kodeagent laster inn når oppgaven krever det. Agenten får da info om blant annet hvilke `@entur/*`-komponenter som finnes, hvordan laste inn CSS på riktig måte, hvilke fargevariabler den skal bruke og hvilke krav universell utforming stiller.
+
+Skillene er en del av [designsystem-repoet](https://github.com/entur/design-system/tree/main/skills).
+
+## Tilgjengelige skills
+
+<Table spacing="middle">
+  <TableHead>
+    <TableRow>
+      <HeaderCell>Skill</HeaderCell>
+      <HeaderCell>Dekker</HeaderCell>
+    </TableRow>
+  </TableHead>
+  <TableBody>
+    <TableRow>
+      <DataCell><CodeText>entur-linje</CodeText></DataCell>
+      <DataCell>Inneholder informasjon om tilgjengelige skills og delegerer oppgaven til riktig sted.</DataCell>
+    </TableRow>
+    <TableRow>
+      <DataCell><CodeText>entur-web-development</CodeText></DataCell>
+      <DataCell>Installasjon og bruk av <CodeText>@entur/*</CodeText>-pakkene, CSS-rekkefølge, tokens, komponentkatalog</DataCell>
+    </TableRow>
+    <TableRow>
+      <DataCell><CodeText>entur-accessibility</CodeText></DataCell>
+      <DataCell>WCAG 2.1, universell utforming, tastaturtesting, skjermlesere, lovkrav</DataCell>
+    </TableRow>
+    <TableRow>
+      <DataCell><CodeText>entur-brand-design</CodeText></DataCell>
+      <DataCell>Farger, typografi, datavisualisering, visuell identitet, presentasjoner</DataCell>
+    </TableRow>
+    <TableRow>
+      <DataCell><CodeText>migrate-react-18</CodeText></DataCell>
+      <DataCell>Oppgradering av <CodeText>@entur/*</CodeText> til React 18-majorversjonene, steg for steg</DataCell>
+    </TableRow>
+  </TableBody>
+</Table>
+
+Du trenger bare å forholde deg til `entur-linje`. Den ser hva oppgaven handler om og laster resten selv.
+
+## Claude Code via Enturs marketplace (anbefalt)
+
+Skillene er publisert som plugin i Enturs plugin-marketplace i [entur/ai](https://github.com/entur/ai), sammen med de andre KI-verktøyene på plattformen. Kjør dette i Claude Code:
+
+```bash
+/plugin marketplace add entur/ai
+/plugin install entur-linje@entur
+```
+
+Marketplacet peker rett på `main` i design-system-repoet. Du kan kjøre følgende kommando for å hente siste versjon av skillen:
+
+```bash
+claude plugin marketplace update entur
+```
+
+Agenten skal i prinsippet bruke skills automatisk når de er relevante, men du kan også tvinge den til å bruke den med `/entur-linje`-kommandoen inne i Claude.
+
+## Gjennom AGENTS.md
+
+De fleste KI-kodeagenter leser en instruksjonsfil i prosjektet ditt – `CLAUDE.md`, `AGENTS.md`, `.cursor/rules/*.mdc` eller `.windsurfrules`, avhengig av verktøy. Legg dette inn der:
+
+<CodeBlock language="markdown" hideLineNumbers copyable>
+  {`## Designsystem\n
+Når du jobber med Entur-komponenter, profil eller universell utforming, les og følg:
+https://raw.githubusercontent.com/entur/design-system/main/skills/entur-linje/SKILL.md`}
+</CodeBlock>
+
+## Maskinlesbar dokumentasjon
+
+Dokumentasjonssiden publiserer to filer for agenter:
+
+<Table spacing="middle">
+  <TableHead>
+    <TableRow>
+      <HeaderCell>URL</HeaderCell>
+      <HeaderCell>Innhold</HeaderCell>
+    </TableRow>
+  </TableHead>
+  <TableBody>
+    <TableRow>
+      <DataCell><LinkText href="https://linje.entur.no/llms.txt">llms.txt</LinkText></DataCell>
+      <DataCell>Strukturert indeks over alle dokumentasjonssider</DataCell>
+    </TableRow>
+    <TableRow>
+      <DataCell><LinkText href="https://linje.entur.no/llms-full.txt">llms-full.txt</LinkText></DataCell>
+      <DataCell>Alt skill-innhold og hele sideindeksen i én fil</DataCell>
+    </TableRow>
+  </TableBody>
+</Table>
+
+`llms-full.txt` er den mest komplette enkeltreferansen: en agent som leser den får alle skills og alle referansefiler inline. Bruk den som alternativ eller supplement til skill-URL-en.
+
+## Fordeler
+
+Denne skillen vil hjelpe deg med å:
+
+- installere bare de `@entur/*`-pakkene som trengs, og få CSS-rekkefølgen riktig
+- bruke tokens framfor hardkodede farger og spacing, og ikke overstyre `.eds-*`-klasser
+- velge komponentvarianten som finnes, framfor å bygge en egen
+- skrive kode som oppfyller WCAG 2.1 AA, med norske feilmeldinger og riktige labels
+- migrere til nyere versjoner der det er breaking changes
+
+<SmallAlertBox variant="information">
+  Les alltid gjennom det agenten produserer. Skillene gjør den mye mer treffsikker, men de gjør den ikke ufeilbarlig – og de erstatter ikke en gjennomgang av universell utforming.
+</SmallAlertBox>

--- a/apps/documentation/src/styles/index.scss
+++ b/apps/documentation/src/styles/index.scss
@@ -100,6 +100,11 @@ body {
   }
 }
 
+// Tables in doc content have no bottom spacing of their own
+.page .eds-table {
+  margin-bottom: eds.$space-extra-large;
+}
+
 .side-nav-column {
   grid-area: sidenav;
   background: var(--components-menu-sidenavigation-standard-background);


### PR DESCRIPTION
Jira: [[ETU-75371](https://enturas.atlassian.net/browse/ETU-75371)](https://enturas.atlassian.net/browse/ETU-75371)

## 💡 Hvorfor?

`Kom i gang → For utviklere` var feil på et av de viktigste punktene for å komme i gang: importrekkefølgen for CSS.

* Token-CSS var ikke med i rekkefølgelisten, selv om `@entur/tokens/styles/base` og `/styles` skal importeres først.
* `@entur/layout/beta/styles` manglet.
* Dokumentasjonen viste bare de gamle `dist/styles.css`-stiene, selv om alle pakkene eksponerer `./styles` via `exports`.
* Rekkefølgen samsvarte heller ikke med den dokumentasjonssiden selv bruker i `apps/documentation/src/styles/index.scss`.

Skillene under `skills/` var heller ikke dokumentert. De er publisert i Enturs plugin-marketplace (`entur/ai`, plugin `entur-linje@entur`), men det sto ingenting på linje.entur.no om at de finnes eller hvordan de installeres.

## 🔧 Hvordan?

**Feil i sidemenyen.** `sorters` i `SideNavigation/utils.tsx` brukte rutesluggen `'kom-i-gang'` som nøkkel, mens oppslaget normaliserer kategorien fra URL-en til `'kom i gang'`. Dermed traff ikke oppslaget. Alle undermenyer fikk fallback-verdien 10, og rekkefølgen ble alfabetisk.

Nøklene bygges nå med `normalizeString`, slik at både slug og tittel gir treff. Rekkefølgen er dermed: Introduksjon → For designere → For utviklere.

**Ny struktur under For utviklere.** Inspirert av oppdelingen designsystemet.no bruker under «Kode», er CSS skilt ut på en egen side. Det er sannsynligvis det vanligste oppslaget på siden og bør ha en egen, lenkbar URL.

```text
Komponentbibliotek  /kom-i-gang/for-utviklere/komponentbibliotek   (uendret rute)
CSS og stiler       /kom-i-gang/for-utviklere/css                  ny
Skills              /kom-i-gang/for-utviklere/skills               ny
Bidra med kode      /kom-i-gang/for-utviklere/bidra-med-kode
```

`komponentbibliotek` beholder eksisterende rute. Den brukes allerede som kanonisk lenke fra `skills/entur-web-development/references/getting-started.md`, `llms.txt` og eksterne kilder.

**Komponentbibliotek** dekker nå installasjon og grunnleggende bruk: React 18 som peer dependency, hvilke pakker som finnes, named exports, typer og `as`-propen. Forklaringen på hvorfor vi ikke publiserer alt som én pakke er flyttet inn i et `ExpandablePanel`. Den dupliserte seksjonen om å bidra er erstattet med en lenke til `bidra-med-kode`.

**CSS og stiler** dokumenterer `/styles`-subpathen, komplett importrekkefølge med tokens først og betastilene inkludert, mørk modus, regler for overstyring og vanlige feilsituasjoner:

* duplikate `@entur/*`-pakker
* komponenter uten styling
* Tailwind og cascade layers
* avvik mellom implementasjon og skisse

SCSS-eksemplene bruker `@use` i stedet for `@import`. Dette er verifisert med Dart Sass 1.102:

* `@use` fungerer med rene CSS-filer uten deprecation-advarsel
* det er Sass sin egen `@import` som er deprecated
* ekstensjonsløs `@use 'x'` finner `x.css`

Siden presiserer også at `exports`-subpaths løses av bundleren, for eksempel webpack via `sass-loader` eller Vite, og ikke nødvendigvis av `sass`-CLI direkte.

**Skills** forklarer hva en skill er, lister de fem skillene og viser flere måter å installere eller bruke dem på:

* `/plugin marketplace add entur/ai`
* `/plugin install entur-linje@entur`
* `npx skills@latest add entur/design-system` for andre agenter
* URL-referanse i `CLAUDE.md` eller `AGENTS.md`
* `llms.txt` og `llms-full.txt`

Tittelen er «Skills», ikke «KI-agenter». Agenten er konsumenten; skillen er det vi publiserer.

Det trengs ingen endringer i `entur/ai`. Marketplacet peker på `main` i dette repoet via `git-subdir`, og de nye sidene tas automatisk med i `llms.txt` fordi `gatsby-node.js` samler alle MDX-noder med `frontmatter.route`.

## 🧩 Type endring

* [x] 🐞 Feilretting
* [ ] 🚀 Ny funksjonalitet
* [ ] 💥 Breaking change (krever kodeendringer hos brukere)
* [x] 📝 Dokumentasjonsoppdatering
* [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
* [ ] ⚡️ Ytelsesforbedring
* [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

Ikke lagt ved, siden endringene hovedsakelig gjelder tekstinnhold.

Se preview-deployen for:

* `/kom-i-gang/for-utviklere/css`
* `/kom-i-gang/for-utviklere/skills`

Sjekk også rekkefølgen i sidemenyen under «Kom i gang».

## 💬 Tilleggsnotater

Endringene er fordelt på tre commits:

1. fiks for sidemenyen
2. CSS-innhold
3. Skills-siden

Skills-siden overlapper bevisst noe med `skills/README.md`. README-en er intern og skrevet på engelsk, mens dokumentasjonssiden er forbrukerrettet og skrevet på norsk.

## ✅ Sjekkliste

* [x] Navnestandarder følges
* [ ] Kode og Figma reflekterer hverandre (ikke relevant)
* [x] Dokumentasjonen er oppdatert
* [x] Ingen ubrukte imports, varsler eller `console.log`-kall

## 🧪 Testing

* Kjørt full produksjonsbygg av dokumentasjonssiden lokalt med `SKIP_PROPS_GENERATION=1 yarn build`. Bygget er grønt, og alle fire sidene genereres.

* Verifisert i generert HTML at sidemenyen viser Introduksjon → For designere → For utviklere.

* Verifisert at «For utviklere» viser Komponentbibliotek → CSS og stiler → Skills → Bidra med kode.

* Verifisert at tabellene og `SmallAlertBox` på Skills-siden rendres.

* Verifisert at `ExpandablePanel` på Komponentbibliotek-siden er på plass.

* Verifisert at krysslenkene mellom sidene treffer riktig.

* Verifisert at alle fire sidene er med i `llms.txt` etter bygg.

* Kjørt `npx tsc --noEmit` på dokumentasjonsappen. `SideNavigation/utils.tsx` er ren.

* Verifisert CSS-påstandene mot pakkenes faktiske `exports` og Dart Sass 1.102.

* Verifisert CI-påstanden på Skills-siden mot `yarn verify:skills` i `build-test-and-deploy-preview.yml`.

* [ ] Testet med skjermleser

* [ ] Testet i Safari og Firefox

* [x] Testet i dokumentasjonssiden via bygg og inspeksjon av generert HTML, men ikke klikket gjennom manuelt i nettleser

[ETU-75371]: https://entur.atlassian.net/browse/ETU-75371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ