### PR TITLE
fix(dropdown): stop console errors when rendered inside shadow DOM

### DIFF
--- a/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx
+++ b/packages/datepicker/src/TimePicker/SimpleTimePicker.tsx
@@ -13,7 +13,7 @@ import type {
 
 import { BaseFormControlProps, TextField } from '@entur/form';
 import { ClockIcon } from '@entur/icons';
-import { VariantType, mergeRefs } from '@entur/utils';
+import { VariantType, getActiveElement, mergeRefs } from '@entur/utils';
 
 import './SimpleTimePicker.scss';
 
@@ -146,7 +146,10 @@ export const SimpleTimePicker = <TimeType extends TimeValue>({
     const selectedTimeString = getStringFromTimeValue(selectedTime);
     setInputText(selectedTimeString);
 
-    const timeFieldIsFocused = document.activeElement === timeFieldRef?.current;
+    // check the ref too, since both are null before mount
+    const timeFieldIsFocused =
+      timeFieldRef.current !== null &&
+      getActiveElement() === timeFieldRef.current;
     if (selectedTimeString === '' && !timeFieldIsFocused)
       addPlaceholderToInput();
   };

--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -17,7 +17,7 @@ import {
 
 import { BaseFormControl } from '@entur/form';
 import { space } from '@entur/tokens';
-import { VariantType, mergeRefs } from '@entur/utils';
+import { VariantType, getActiveElement, mergeRefs } from '@entur/utils';
 
 import { DropdownList } from './components/DropdownList';
 import { DropdownFieldAppendix } from './components/FieldComponents';
@@ -28,10 +28,7 @@ import {
   NormalizedDropdownItemType,
   PotentiallyAsyncDropdownItemType,
 } from './types';
-import {
-  getActiveElement,
-  useShadowDomEnvironment,
-} from './useShadowDomEnvironment';
+import { useShadowDomEnvironment } from './useShadowDomEnvironment';
 
 import './Dropdown.scss';
 
@@ -175,11 +172,8 @@ export const Dropdown = React.forwardRef(
       selectedItem,
       ...(environment && { environment }),
       stateReducer(state, { changes, type }) {
-        const root = (toggleButtonRef.current?.getRootNode() ?? document) as
-          | Document
-          | ShadowRoot;
         const toggleButtonIsFocused =
-          getActiveElement(root) === floatingRefs?.reference.current;
+          getActiveElement() === floatingRefs?.reference.current;
 
         switch (type) {
           case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowDown:

--- a/packages/dropdown/src/SearchableDropdown.tsx
+++ b/packages/dropdown/src/SearchableDropdown.tsx
@@ -23,17 +23,14 @@ import {
 
 import { BaseFormControl } from '@entur/form';
 import { space } from '@entur/tokens';
-import { mergeRefs } from '@entur/utils';
+import { getActiveElement, mergeRefs } from '@entur/utils';
 
 import { DropdownList } from './components/DropdownList';
 import { DropdownFieldAppendix } from './components/FieldComponents';
 
 import { DropdownProps } from './Dropdown';
 import { useResolvedItems } from './useResolvedItems';
-import {
-  getActiveElement,
-  useShadowDomEnvironment,
-} from './useShadowDomEnvironment';
+import { useShadowDomEnvironment } from './useShadowDomEnvironment';
 import {
   EMPTY_INPUT,
   clamp,
@@ -142,12 +139,7 @@ export const SearchableDropdown = React.forwardRef(
 
     const inputHasFocus =
       typeof document !== 'undefined' &&
-      inputRef.current ===
-        getActiveElement(
-          (inputRef.current?.getRootNode() ?? document) as
-            | Document
-            | ShadowRoot,
-        );
+      inputRef.current === getActiveElement();
 
     useEffect(() => {
       filterListItems({ inputValue });

--- a/packages/dropdown/src/SearchableDropdown.tsx
+++ b/packages/dropdown/src/SearchableDropdown.tsx
@@ -137,9 +137,9 @@ export const SearchableDropdown = React.forwardRef(
       filterListItems({ inputValue: inputValue ?? EMPTY_INPUT });
     };
 
+    // Both are null before mount and on the server, so check the ref too
     const inputHasFocus =
-      typeof document !== 'undefined' &&
-      inputRef.current === getActiveElement();
+      inputRef.current !== null && inputRef.current === getActiveElement();
 
     useEffect(() => {
       filterListItems({ inputValue });

--- a/packages/dropdown/src/tests/useShadowDomEnvironment.test.tsx
+++ b/packages/dropdown/src/tests/useShadowDomEnvironment.test.tsx
@@ -1,0 +1,107 @@
+import React, { useRef } from 'react';
+import { render, renderHook } from '@testing-library/react';
+import { useShadowDomEnvironment } from '../useShadowDomEnvironment';
+
+function createShadowDomContainer() {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const shadowRoot = host.attachShadow({ mode: 'open' });
+  const container = document.createElement('div');
+  shadowRoot.appendChild(container);
+  return { host, container };
+}
+
+let host: HTMLDivElement;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  ({ host, container } = createShadowDomContainer());
+});
+
+afterEach(() => {
+  document.body.removeChild(host);
+});
+
+describe('environment.document proxy', () => {
+  function environmentDocument() {
+    const el = document.createElement('div');
+    container.appendChild(el);
+    const ref = { current: el };
+    const { result } = renderHook(() => useShadowDomEnvironment(ref));
+    return result.current!.document;
+  }
+
+  test.each(['body', 'documentElement', 'head'] as const)(
+    'invokes the getter for %s with the real document as receiver',
+    prop => {
+      // Accessors on Document.prototype are branded: browsers throw
+      // "Illegal invocation" if the getter runs with `this` set to
+      // anything but a real Document — the proxy included. jsdom does
+      // not brand-check, so assert the receiver directly.
+      const descriptor = Object.getOwnPropertyDescriptor(
+        Document.prototype,
+        prop,
+      )!;
+      const expected = document[prop];
+      const receivers: unknown[] = [];
+      Object.defineProperty(Document.prototype, prop, {
+        ...descriptor,
+        get() {
+          receivers.push(this);
+          return descriptor.get!.call(document);
+        },
+      });
+
+      let actual;
+      try {
+        actual = environmentDocument()[prop];
+      } finally {
+        Object.defineProperty(Document.prototype, prop, descriptor);
+      }
+
+      expect(actual).toBe(expected);
+      expect(receivers.length).toBeGreaterThan(0);
+      // Compared as a boolean: printing a diff of the proxied document
+      // exhausts memory in jest's matcher utils.
+      expect(receivers.every(candidate => candidate === document)).toBe(true);
+    },
+  );
+
+  test('lets downshift append to document.body', () => {
+    const doc = environmentDocument();
+    const div = doc.createElement('div');
+    expect(() => doc.body.appendChild(div)).not.toThrow();
+    doc.body.removeChild(div);
+  });
+
+  test('activeElement is never null when focus is outside the shadow root', () => {
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+
+    expect(environmentDocument().activeElement).toBe(outside);
+
+    document.body.removeChild(outside);
+  });
+
+  test('activeElement drills into the shadow root when focus is inside', () => {
+    const inside = document.createElement('button');
+    container.appendChild(inside);
+    inside.focus();
+
+    expect(environmentDocument().activeElement).toBe(inside);
+  });
+});
+
+describe('useShadowDomEnvironment outside shadow DOM', () => {
+  test('returns undefined so downshift uses its window default', () => {
+    let environment: ReturnType<typeof useShadowDomEnvironment>;
+    function Probe() {
+      const ref = useRef<HTMLDivElement>(null);
+      environment = useShadowDomEnvironment(ref);
+      return <div ref={ref} />;
+    }
+    render(<Probe />);
+    expect(environment!).toBeUndefined();
+  });
+});

--- a/packages/dropdown/src/useShadowDomEnvironment.ts
+++ b/packages/dropdown/src/useShadowDomEnvironment.ts
@@ -1,18 +1,7 @@
 import { RefObject, useMemo } from 'react';
 import type { Environment } from 'downshift';
 
-/**
- * Returns the active element, drilling into shadow roots.
- * `document.activeElement` stops at the shadow host — this
- * follows the chain into nested shadow roots.
- */
-export function getActiveElement(root: Document | ShadowRoot): Element | null {
-  const active = root.activeElement;
-  if (active?.shadowRoot) {
-    return getActiveElement(active.shadowRoot);
-  }
-  return active;
-}
+import { getActiveElement } from '@entur/utils';
 
 /**
  * Creates a downshift `environment` that works inside shadow DOM.
@@ -41,7 +30,7 @@ function createShadowEnvironment(shadowRoot: ShadowRoot): Environment {
     document: new Proxy(document, {
       get(target, prop) {
         if (prop === 'activeElement') {
-          return getActiveElement(document);
+          return getActiveElement();
         }
         // Read with `target` as the receiver, not the proxy: accessors on
         // Document.prototype (`body`, `head`, …) are branded and throw

--- a/packages/dropdown/src/useShadowDomEnvironment.ts
+++ b/packages/dropdown/src/useShadowDomEnvironment.ts
@@ -25,8 +25,8 @@ export function getActiveElement(root: Document | ShadowRoot): Element | null {
  *
  * This adapter redirects downshift's event listeners to the shadow
  * root (where targets are not retargeted) and proxies
- * `document.activeElement` to return the shadow root's active
- * element instead.
+ * `document.activeElement` so it drills into shadow roots instead of
+ * stopping at the shadow host.
  *
  * Outside shadow DOM this returns `undefined`, letting downshift
  * use its default `window` environment.
@@ -39,11 +39,14 @@ function createShadowEnvironment(shadowRoot: ShadowRoot): Environment {
     removeEventListener: shadowRoot.removeEventListener.bind(shadowRoot),
     Node: window.Node,
     document: new Proxy(document, {
-      get(target, prop, receiver) {
+      get(target, prop) {
         if (prop === 'activeElement') {
-          return getActiveElement(shadowRoot);
+          return getActiveElement(document);
         }
-        const value = Reflect.get(target, prop, receiver);
+        // Read with `target` as the receiver, not the proxy: accessors on
+        // Document.prototype (`body`, `head`, …) are branded and throw
+        // "Illegal invocation" when invoked with anything else as `this`.
+        const value = Reflect.get(target, prop);
         return typeof value === 'function' ? value.bind(target) : value;
       },
     }),

--- a/packages/modal/src/Drawer.tsx
+++ b/packages/modal/src/Drawer.tsx
@@ -4,7 +4,7 @@ import { Contrast } from '@entur/layout';
 import { CloseIcon } from '@entur/icons';
 import { Heading3 } from '@entur/typography';
 import { IconButton } from '@entur/button';
-import { ConditionalWrapper } from '@entur/utils';
+import { ConditionalWrapper, getActiveElement } from '@entur/utils';
 import { ModalOverlay } from './ModalOverlay';
 
 import './Drawer.scss';
@@ -54,7 +54,7 @@ export const Drawer = ({
   useEffect(
     function handleFocus() {
       if (!open || overlay) return;
-      previouslyFocusedRef.current = document.activeElement;
+      previouslyFocusedRef.current = getActiveElement();
       drawerRef.current
         ?.querySelector<HTMLElement>('[data-autofocus]')
         ?.focus();

--- a/packages/tab/src/TabList.tsx
+++ b/packages/tab/src/TabList.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useContext, useRef } from 'react';
 import classNames from 'classnames';
+import { getActiveElement } from '@entur/utils';
 
 import { TabItemContext, TabsContext } from './TabsContext';
 
@@ -32,8 +33,9 @@ export const TabList = ({
     );
     if (!tabs || tabs.length === 0) return;
 
+    const focusedElement = getActiveElement();
     const currentIndex = Array.from(tabs).findIndex(
-      tab => tab === document.activeElement,
+      tab => tab === focusedElement,
     );
     if (currentIndex === -1) return;
 

--- a/packages/utils/src/getActiveElement.ssr.test.ts
+++ b/packages/utils/src/getActiveElement.ssr.test.ts
@@ -1,0 +1,10 @@
+/**
+ * @jest-environment node
+ */
+import { getActiveElement } from './getActiveElement';
+
+describe('getActiveElement without a DOM', () => {
+  test('returns null instead of throwing, so server rendering is safe', () => {
+    expect(getActiveElement()).toBeNull();
+  });
+});

--- a/packages/utils/src/getActiveElement.test.ts
+++ b/packages/utils/src/getActiveElement.test.ts
@@ -1,0 +1,53 @@
+import { getActiveElement } from './getActiveElement';
+
+let host: HTMLDivElement;
+let shadowRoot: ShadowRoot;
+
+beforeEach(() => {
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  shadowRoot = host.attachShadow({ mode: 'open' });
+});
+
+afterEach(() => {
+  document.body.removeChild(host);
+});
+
+describe('getActiveElement', () => {
+  test('returns the focused element in the light DOM', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+    button.focus();
+
+    expect(getActiveElement()).toBe(button);
+
+    document.body.removeChild(button);
+  });
+
+  test('drills into a shadow root instead of stopping at the host', () => {
+    const button = document.createElement('button');
+    shadowRoot.appendChild(button);
+    button.focus();
+
+    expect(document.activeElement).toBe(host);
+    expect(getActiveElement()).toBe(button);
+  });
+
+  test('drills into nested shadow roots', () => {
+    const innerHost = document.createElement('div');
+    shadowRoot.appendChild(innerHost);
+    const button = document.createElement('button');
+    innerHost.attachShadow({ mode: 'open' }).appendChild(button);
+    button.focus();
+
+    expect(getActiveElement()).toBe(button);
+  });
+
+  test('accepts an explicit root', () => {
+    const button = document.createElement('button');
+    shadowRoot.appendChild(button);
+    button.focus();
+
+    expect(getActiveElement(shadowRoot)).toBe(button);
+  });
+});

--- a/packages/utils/src/getActiveElement.ts
+++ b/packages/utils/src/getActiveElement.ts
@@ -1,0 +1,20 @@
+/**
+ * Returns the active element, drilling into shadow roots.
+ * `document.activeElement` stops at the shadow host — this
+ * follows the chain into nested shadow roots.
+ *
+ * Use this instead of `document.activeElement` whenever the result is
+ * compared to an element that may live inside a shadow root.
+ *
+ * Returns `null` when there is no DOM, so it is safe to call during
+ * server rendering.
+ */
+export function getActiveElement(root?: Document | ShadowRoot): Element | null {
+  const target =
+    root ?? (typeof document === 'undefined' ? undefined : document);
+  const active = target?.activeElement ?? null;
+  if (active?.shadowRoot) {
+    return getActiveElement(active.shadowRoot);
+  }
+  return active;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,5 +10,6 @@ export * from './useWindowDimensions';
 export * from './ConditionalWrapper';
 export * from './warnAboutMissingStyles';
 export * from './types/variants';
+export * from './getActiveElement';
 export * from './getNodeText';
 export * from './useControllableProp';

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["src", "types"],
-  "exclude": ["src/**/*.test.tsx", "node_modules", "dist"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "node_modules", "dist"],
   "compilerOptions": {
     "paths": {
       "@entur/*": ["../*/dist"]


### PR DESCRIPTION
## 💡 Hvorfor?

[ETU-75490](https://entur.atlassian.net/browse/ETU-75490)

Dropdown-komponentene kastet `Uncaught TypeError: Illegal invocation` i konsollen ved nesten all interaksjon (klikk, scroll, piltaster) når de rendres inne i en shadow DOM. Meldt inn fra Entur Partner, som rendrer hele sidemenyen i en shadow root. Feilen ga ingen synlige problemer for brukeren, men støyet kraftig i konsollen og gjorde det vanskeligere å oppdage reelle feil i egen applikasjon.

I tillegg logget downshift en propTypes-advarsel (`Failed prop type: Illegal invocation`) fordi `activeElement` var `null` når fokus lå utenfor shadow-roten.

## 🔧 Hvordan?

Proxyen rundt `document` i `useShadowDomEnvironment` sendte seg selv som `receiver` til `Reflect.get`. Accessorer på `Document.prototype` (`body`, `head`, `documentElement`) er brandet og kaster «Illegal invocation» når getteren kjøres med noe annet enn et ekte Document som `this`. Downshift leser `environment.document.body` når den setter a11y-status, og traff dette hver gang statusen ble oppdatert.

- `Reflect.get(target, prop)` uten `receiver`, slik at getteren kjøres på det ekte dokumentet.
- `activeElement` regnes nå ut fra `document` i stedet for shadow-roten, og borer seg ned gjennom shadow roots. Fokus inne i shadow-roten gir samme svar som før, mens fokus utenfor gir det faktiske elementet i stedet for `null`.

Selve nedboringen lå duplisert i `Dropdown` og `SearchableDropdown`, og er trukket ut som `getActiveElement` i `@entur/utils`. `packages/utils/tsconfig.json` ekskluderte bare `*.test.tsx`, så `*.test.ts` er lagt til i samme liste.

De tre øvrige stedene i designsystemet som sammenliknet med `document.activeElement` har samme feil i shadow DOM, og er tatt med her siden det er samme feilklasse og samme util:

- `TabList`: piltaster, Home og End fant aldri den fokuserte taben, så tastaturnavigasjonen sto stille.
- `Drawer`: fokus ble returnert til shadow-verten i stedet for elementet som åpnet skuffen.
- `SimpleTimePicker`: placeholderen ble skrevet inn i feltet selv om feltet hadde fokus.

`SimpleTimePicker` har fått samme ref-sjekk som `SearchableDropdown`, siden `getActiveElement()` kan returnere `null`. `useTableKeyboardNavigation` er bevisst ikke rørt.

Siden `getActiveElement` nå er offentlig API, returnerer den `null` i stedet for å kaste når det ikke finnes noe DOM. Uten det ville et kall uten argument gi `ReferenceError: document is not defined` under server-rendering. `SearchableDropdown` sjekker derfor input-refen direkte i stedet for `typeof document`, ettersom `null === null` ellers ville gi falsk fokus på server.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [x] 🚀 Ny funksjonalitet (`getActiveElement` i `@entur/utils`)
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

jsdom brand-sjekker ikke disse accessorene, så feilen kan ikke reproduseres i Jest. De nye testene sjekker derfor at getteren kalles med det ekte dokumentet som `this` – nøyaktig det nettleseren avviser.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

Verifisert i Chrome med Dropdown, SearchableDropdown og MultiSelect rendret inne i en shadow root, bygget fra `packages/dropdown/dist`:

- Før fiksen: `TypeError: Illegal invocation` fra `Reflect.get` → `getStatusDiv` → `setStatus`, samt propTypes-advarselen.
- Etter fiksen: ingen feil eller advarsler ved åpning, søk, piltaster og fokus ut av shadow-roten.

Nye enhetstester i `useShadowDomEnvironment.test.tsx` (7 stk.) og i `getActiveElement.test.ts` (4 stk., dekker fokus i lys DOM, i shadow root, i nøstede shadow roots og med eksplisitt rot). `getActiveElement.ssr.test.ts` kjører i node-miljø og dekker tilfellet uten DOM – verifisert ved å reversere fiksen, da feiler den med `ReferenceError`. Alle 78 testene i `@entur/dropdown` er grønne.

Eksisterende tester i de tre andre pakkene er grønne etter endringen: `@entur/tab` 21/21, `@entur/modal` 5/5, `@entur/datepicker` 113/113 (sistnevnte krever `TZ=UTC`, som før).

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden


[ETU-75490]: https://entur.atlassian.net/browse/ETU-75490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
