### PR TITLE
fix(dropdown): stop the render loop that crashed selection in automated tests

### DIFF
--- a/packages/dropdown/src/Dropdown.tsx
+++ b/packages/dropdown/src/Dropdown.tsx
@@ -28,6 +28,7 @@ import {
   NormalizedDropdownItemType,
   PotentiallyAsyncDropdownItemType,
 } from './types';
+import { useFloatingRef } from './useFloatingRef';
 import { useShadowDomEnvironment } from './useShadowDomEnvironment';
 
 import './Dropdown.scss';
@@ -213,6 +214,9 @@ export const Dropdown = React.forwardRef(
     // Update to use latest refs from floating-ui
     floatingRefs = refs;
 
+    const setFloatingMenu = useFloatingRef(refs.setFloating);
+    const setFloatingReference = useFloatingRef(refs.setReference);
+
     // Update floating-ui position on scroll etc. Floating-ui's autoupdate is usually used inside
     // the useFloating hook but this requires the floating element to be conditionally rendered.
     // Downshift doesn't work correctly when conditionally rendered since props and refs aren't correctly
@@ -236,7 +240,7 @@ export const Dropdown = React.forwardRef(
       isFilled,
     });
     const toggleButtonProps = getToggleButtonProps({
-      ref: mergeRefs(ref, refs.setReference, toggleButtonRef),
+      ref: mergeRefs(ref, setFloatingReference, toggleButtonRef),
       'aria-disabled': disabled,
       'aria-label': disabled ? 'Disabled dropdown' : '',
       disabled: disabled,
@@ -258,7 +262,7 @@ export const Dropdown = React.forwardRef(
     });
     const menuProps = getMenuProps({
       refKey: 'innerRef',
-      ref: refs.setFloating,
+      ref: setFloatingMenu,
       style: listStyle,
     });
 

--- a/packages/dropdown/src/MultiSelect.tsx
+++ b/packages/dropdown/src/MultiSelect.tsx
@@ -50,6 +50,7 @@ import {
 } from './utils';
 
 import { NormalizedDropdownItemType } from './types';
+import { useFloatingRef } from './useFloatingRef';
 import { useShadowDomEnvironment } from './useShadowDomEnvironment';
 
 import './Dropdown.scss';
@@ -410,6 +411,8 @@ export const MultiSelect = React.forwardRef(
       ],
     });
 
+    const setFloatingMenu = useFloatingRef(refs.setFloating);
+
     // Update floating-ui position on scroll etc. Floating-ui's autoupdate is usually used inside
     // the useFloating hook but this requires the floating element to be conditionally rendered.
     // Downshift doesn't work correctly when conditionally rendered since props and refs aren't correctly
@@ -466,7 +469,7 @@ export const MultiSelect = React.forwardRef(
     const menuProps = getMenuProps({
       'aria-multiselectable': true,
       refKey: 'innerRef',
-      ref: refs.setFloating,
+      ref: setFloatingMenu,
       style: listStyle,
     });
     const toggleButtonProps = getToggleButtonProps({
@@ -495,6 +498,8 @@ export const MultiSelect = React.forwardRef(
         }}
         onKeyDown={onKeyDown}
         readOnly={readOnly}
+        // A plain ref, not one downshift rebuilds every render, so it can go
+        // straight to floating-ui. useFloatingRef covers the refs that can't.
         ref={refs.setReference}
         style={style}
         variant={variant}

--- a/packages/dropdown/src/SearchableDropdown.tsx
+++ b/packages/dropdown/src/SearchableDropdown.tsx
@@ -30,6 +30,7 @@ import { DropdownFieldAppendix } from './components/FieldComponents';
 
 import { DropdownProps } from './Dropdown';
 import { useResolvedItems } from './useResolvedItems';
+import { useFloatingRef } from './useFloatingRef';
 import { useShadowDomEnvironment } from './useShadowDomEnvironment';
 import {
   EMPTY_INPUT,
@@ -279,6 +280,8 @@ export const SearchableDropdown = React.forwardRef(
       ],
     });
 
+    const setFloatingMenu = useFloatingRef(refs.setFloating);
+
     // Update floating-ui position on scroll etc. Floating-ui's autoupdate is usually used inside
     // the useFloating hook but this requires the floating element to be conditionally rendered.
     // Downshift doesn't work correctly when conditionally rendered since props and refs aren't correctly
@@ -299,7 +302,7 @@ export const SearchableDropdown = React.forwardRef(
     });
     const menuProps = getMenuProps({
       refKey: 'innerRef',
-      ref: refs.setFloating,
+      ref: setFloatingMenu,
       style: listStyle,
     });
     const inputProps = getInputProps({
@@ -350,6 +353,8 @@ export const SearchableDropdown = React.forwardRef(
         onKeyDown={onKeyDown}
         prepend={prepend}
         readOnly={readOnly}
+        // A plain ref, not one downshift rebuilds every render, so it can go
+        // straight to floating-ui. useFloatingRef covers the refs that can't.
         ref={refs.setReference}
         style={style}
         tabIndex={disabled || readOnly ? -1 : undefined}

--- a/packages/dropdown/src/tests/floatingChurn.test.tsx
+++ b/packages/dropdown/src/tests/floatingChurn.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+/**
+ * The infinite render loop needs real layout and cannot be reproduced in
+ * jsdom, but its precondition can: floating-ui's element setters must never
+ * be called with null. Every detach sets floating-ui state, and a state
+ * change triggers the render that causes the next detach.
+ *
+ * These tests fail if a component stops routing a setter through
+ * useFloatingRef — the hook's own tests would still pass in that case.
+ */
+
+// The `mock` name prefix is what lets the jest.mock factory close over this
+const mockCalls: { floating: unknown[]; reference: unknown[] } = {
+  floating: [],
+  reference: [],
+};
+
+jest.mock('@floating-ui/react-dom', () => {
+  const actual = jest.requireActual('@floating-ui/react-dom');
+  const ReactActual = jest.requireActual('react');
+  return {
+    ...actual,
+    useFloating: (options: any) => {
+      const result = actual.useFloating(options);
+      const { setFloating: realFloating, setReference: realReference } =
+        result.refs;
+      // Stable, since floating-ui's own setters are — so the probe cannot
+      // cause the churn it measures
+      const setFloating = ReactActual.useCallback(
+        (node: unknown) => {
+          mockCalls.floating.push(node);
+          realFloating(node);
+        },
+        [realFloating],
+      );
+      const setReference = ReactActual.useCallback(
+        (node: unknown) => {
+          mockCalls.reference.push(node);
+          realReference(node);
+        },
+        [realReference],
+      );
+      return {
+        ...result,
+        refs: { ...result.refs, setFloating, setReference },
+      };
+    },
+  };
+});
+
+import { Dropdown, MultiSelect, SearchableDropdown } from '..';
+
+const items = ['Oslo', 'Bergen', 'Stavanger'];
+
+// Count instead of asserting on the arrays: a failing matcher would print
+// every DOM node it collected.
+const detaches = (calls: unknown[]) => calls.filter(node => node === null);
+
+describe('floating-ui element setters are never detached on re-render', () => {
+  beforeEach(() => {
+    mockCalls.floating = [];
+    mockCalls.reference = [];
+  });
+
+  test('MultiSelect', () => {
+    const { rerender } = render(
+      <MultiSelect label="a" items={items} selectedItems={[]} />,
+    );
+    rerender(<MultiSelect label="b" items={items} selectedItems={[]} />);
+    rerender(<MultiSelect label="c" items={items} selectedItems={[]} />);
+
+    expect(mockCalls.floating.length).toBeGreaterThan(0);
+    expect(mockCalls.reference.length).toBeGreaterThan(0);
+    expect(detaches(mockCalls.floating)).toHaveLength(0);
+    expect(detaches(mockCalls.reference)).toHaveLength(0);
+  });
+
+  test('SearchableDropdown', () => {
+    const { rerender } = render(
+      <SearchableDropdown label="a" items={items} selectedItem={null} />,
+    );
+    rerender(
+      <SearchableDropdown label="b" items={items} selectedItem={null} />,
+    );
+    rerender(
+      <SearchableDropdown label="c" items={items} selectedItem={null} />,
+    );
+
+    expect(mockCalls.floating.length).toBeGreaterThan(0);
+    expect(mockCalls.reference.length).toBeGreaterThan(0);
+    expect(detaches(mockCalls.floating)).toHaveLength(0);
+    expect(detaches(mockCalls.reference)).toHaveLength(0);
+  });
+
+  test('Dropdown', () => {
+    const { rerender } = render(
+      <Dropdown label="a" items={items} selectedItem={null} />,
+    );
+    rerender(<Dropdown label="b" items={items} selectedItem={null} />);
+    rerender(<Dropdown label="c" items={items} selectedItem={null} />);
+
+    expect(mockCalls.floating.length).toBeGreaterThan(0);
+    expect(mockCalls.reference.length).toBeGreaterThan(0);
+    expect(detaches(mockCalls.floating)).toHaveLength(0);
+    expect(detaches(mockCalls.reference)).toHaveLength(0);
+  });
+});

--- a/packages/dropdown/src/tests/useFloatingRef.test.tsx
+++ b/packages/dropdown/src/tests/useFloatingRef.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useFloatingRef } from '../useFloatingRef';
+
+type FloatingRef = (node: HTMLElement | null) => void;
+
+/**
+ * The render loop this guards against needs real layout, so it cannot be
+ * reproduced in jsdom. These tests pin the two properties that break the
+ * cycle: the wrapper never forwards React's detach call, and it keeps a
+ * stable identity so it does not trigger detaches of its own.
+ */
+describe('useFloatingRef', () => {
+  const setFloating = jest.fn();
+  let wrappers: FloatingRef[] = [];
+
+  function Probe({ setElement = setFloating }: { setElement?: FloatingRef }) {
+    const setFloatingMenu = useFloatingRef(setElement);
+    wrappers.push(setFloatingMenu);
+    return <ul ref={setFloatingMenu} />;
+  }
+
+  beforeEach(() => {
+    setFloating.mockClear();
+    wrappers = [];
+  });
+
+  test('forwards the element when the ref is attached', () => {
+    const { container } = render(<Probe />);
+
+    expect(setFloating).toHaveBeenCalledTimes(1);
+    expect(setFloating).toHaveBeenCalledWith(container.querySelector('ul'));
+  });
+
+  test('never forwards null, so floating-ui does not set state on detach', () => {
+    render(<Probe />);
+    setFloating.mockClear();
+
+    wrappers[0](null);
+
+    expect(setFloating).not.toHaveBeenCalled();
+  });
+
+  test('keeps one identity even when the setter changes every render', () => {
+    // A setter with a fresh identity per render is what the hook has to
+    // absorb: hold `setElement` in the dep array instead and every render
+    // returns a new callback, which is the detach React reacts to.
+    const { rerender } = render(
+      <Probe setElement={node => setFloating(node)} />,
+    );
+    rerender(<Probe setElement={node => setFloating(node)} />);
+    rerender(<Probe setElement={node => setFloating(node)} />);
+
+    expect(wrappers).toHaveLength(3);
+    expect(new Set(wrappers).size).toBe(1);
+  });
+
+  test('forwards to the newest setter, so a stable identity is not a stale one', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+
+    const { container, rerender } = render(<Probe setElement={first} />);
+    rerender(<Probe setElement={second} />);
+
+    const menu = container.querySelector('ul') as HTMLElement;
+    first.mockClear();
+    wrappers[wrappers.length - 1](menu);
+
+    expect(second).toHaveBeenCalledWith(menu);
+    expect(first).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dropdown/src/useFloatingRef.ts
+++ b/packages/dropdown/src/useFloatingRef.ts
@@ -1,0 +1,41 @@
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+/**
+ * Wraps floating-ui's `setReference` / `setFloating` in a stable ref callback
+ * that ignores detach calls, so the menu cannot get stuck in a render loop.
+ *
+ * The loop, step by step:
+ *
+ * 1. downshift's prop getters build a new ref callback on every render.
+ * 2. When a callback ref changes identity, React detaches the old one
+ *    (`ref(null)`) and attaches the new one (`ref(node)`).
+ * 3. `setReference` and `setFloating` are state setters, so those two calls
+ *    trigger two renders — which build a new ref callback again.
+ *
+ * While the menu is open that never settles and React throws
+ * "Maximum update depth exceeded".
+ *
+ * Skipping the `null` call breaks the loop: floating-ui's own identity check
+ * then bails on the re-attach, so no state is set and no render follows.
+ * Skipping it is safe because these elements stay mounted and are hidden with
+ * `display: none` — a detach here never means the element is gone.
+ *
+ * The returned callback keeps one identity for the component's lifetime, so it
+ * cannot become the churn it prevents. `setElement` is read through a ref to
+ * keep that true even when a caller passes a new function each render; the
+ * trade-off is that a new `setElement` takes effect on the next attach rather
+ * than immediately.
+ */
+export function useFloatingRef<ElementType extends HTMLElement>(
+  setElement: (node: ElementType | null) => void,
+): (node: ElementType | null) => void {
+  const latestSetElement = useRef(setElement);
+
+  useLayoutEffect(() => {
+    latestSetElement.current = setElement;
+  }, [setElement]);
+
+  return useCallback((node: ElementType | null) => {
+    if (node !== null) latestSetElement.current(node);
+  }, []);
+}


### PR DESCRIPTION
## 💡 Hvorfor?

[ETU-75550](https://entur.atlassian.net/browse/ETU-75550)

Å velge et element kunne kaste `Uncaught Error: Maximum update depth exceeded`, slik at valget aldri ble registrert og hele React-treet komponenten står i, døde. Feilen slår inn når musepekeren treffer elementet og klikker med én gang – altså slik Playwright, Cypress og Selenium klikker. E2E-tester hos konsumenter som bruker disse komponentene kræsjer derfor.

Manuell klikking treffer den normalt ikke, fordi pekeren hviler over elementet før man trykker, og tastaturvalg har aldri vært påvirket. Den underliggende løkka er likevel reell, og lå bare én timing-endring unna å dukke opp andre steder.

Gjelder MultiSelect, Dropdown og SearchableDropdown. Feilen finnes også i publisert `@entur/dropdown` 9.0.1.

## 🔧 Hvordan?

`setReference` og `setFloating` fra floating-ui er state-settere. Vi sender dem videre til downshift sine prop-gettere og til `mergeRefs`, og begge setter dem sammen til en ny callback for hver render. React svarer på en endret callback-ref med å koble fra (`ref(null)`) og koble til igjen (`ref(node)`) hver render, så hver render setter floating-ui-state to ganger – som gir en ny render. Når lista er åpen, roer det seg aldri, og React gir opp.

- Ny `useFloatingRef` pakker inn setterne slik at `null` ikke sendes videre. Da bailer floating-ui sin egen identitetssjekk når ref-en kobles til igjen, og løkka brytes.
- Tatt i bruk for listeref-en i alle tre komponentene, og for referanseref-en i Dropdown (som gikk gjennom `mergeRefs`).

Ingenting er avhengig av frakoblingen: listeelementet rendres aldri betinget, det skjules med `display: none`.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

Løkka krever ekte layout og kan ikke reproduseres i jsdom, men forutsetningen for den kan det: frakoblingen er ren React-avstemming. Testene låser derfor at floating-ui sine settere aldri får `null`, både i wrapperen isolert og i alle tre komponentene. Selve kræsjet er verifisert i nettleser.

Feilen ble innført 23. september 2025, i commit `86c8dbf81` – som i sin tur fikset en annen «Maximum update depth»-feil i MultiSelect.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

Verifisert i Playwright mot code-playground med 40 elementer i lista:

- Før fiksen: raskt klikk på et element i MultiSelect og i Dropdown kræsjet React-treet. Stack: `dispatchSetState` ← `floating-ui.react-dom.mjs` ← `downshift.esm.js` (`handleRefs`) / `mergeRefs` ← `safelyDetachRef`.
- Etter fiksen: MultiSelect, Dropdown og SearchableDropdown velger som forventet, ingen nye feil i konsollet.
- Tastaturnavigering scroller fortsatt markert element inn i bildet (`scrollTop` 0 → 1304 gjennom lista), så downshift sin egen menyref er upåvirket.

De nye komponenttestene er verifisert ved å reversere fiksen: med alle tre komponentene tilbakestilt feiler alle tre testene, og med kun `mergeRefs`-linja i Dropdown tilbakestilt feiler bare Dropdown-testen. De dekker altså begge halvdelene av fiksen hver for seg.

Alle 77 testene i `@entur/dropdown` er grønne.

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden


[ETU-75550]: https://entur.atlassian.net/browse/ETU-75550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ