### PR TITLE
feat(tab): let Tab and TabPanel take an explicit index

### DIFF
--- a/apps/documentation/src/utils/componentProps/eds-component-props/Tab.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Tab.json
@@ -36,6 +36,21 @@
         "name": "boolean | undefined"
       }
     },
+    "index": {
+      "defaultValue": null,
+      "description": "Indeksen til taben. Settes vanligvis ut fra rekkefølgen i `TabList`, men må\nangis manuelt dersom taben ligger inne i en egen komponent",
+      "name": "index",
+      "declarations": [
+        {
+          "fileName": "packages/tab/src/Tab.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "number | undefined"
+      }
+    },
     "as": {
       "defaultValue": null,
       "description": "HTML-elementet eller React-komponenten som lager komponenten",

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TabPanel.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TabPanel.json
@@ -34,6 +34,21 @@
         "name": "\"symbol\" | \"object\" | \"div\" | \"a\" | \"abbr\" | \"address\" | \"area\" | \"article\" | \"aside\" | \"audio\" | \"b\" | \"base\" | \"bdi\" | \"bdo\" | \"big\" | \"blockquote\" | \"body\" | \"br\" | \"button\" | \"canvas\" | ... 160 more ... | undefined"
       }
     },
+    "index": {
+      "defaultValue": null,
+      "description": "Indeksen til panelet. Settes vanligvis ut fra rekkefølgen i `TabPanels`,\nmen må angis manuelt dersom panelet ligger inne i en egen komponent",
+      "name": "index",
+      "declarations": [
+        {
+          "fileName": "packages/tab/src/TabPanel.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "number | undefined"
+      }
+    },
     "className": {
       "defaultValue": null,
       "description": "",

--- a/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
@@ -468,23 +468,23 @@
     "outputs": ["ModalOverlay.json"]
   },
   "tab/src/Tab.tsx": {
-    "hash": "7ea2bd97926da0810838794c7d36f8d1",
+    "hash": "8f8ddaeb9140c4d69b2bd0496b9b7ad7",
     "outputs": ["Tab.json"]
   },
   "tab/src/TabList.tsx": {
-    "hash": "d53c459562c7e9ef5457110afd2ee4e2",
+    "hash": "11e1585f95720eceaba28b31f0786fed",
     "outputs": ["TabList.json"]
   },
   "tab/src/TabPanel.tsx": {
-    "hash": "5b3ab40dc9e1256ac88c3b8bbd080a0f",
+    "hash": "a2fa74a20bea62d832da75e34849555a",
     "outputs": ["TabPanel.json"]
   },
   "tab/src/TabPanels.tsx": {
-    "hash": "f8b81d5103c3c79ec773b34c27568cb9",
+    "hash": "ff820c25aeca3efb5831d242a484933e",
     "outputs": ["TabPanels.json"]
   },
   "tab/src/Tabs.tsx": {
-    "hash": "1d3a3a6b1d9d58f5d33fcc144443d021",
+    "hash": "9b42b5b4c5f5d79b9a9e844947e5856a",
     "outputs": ["Tabs.json"]
   },
   "table/src/DataCell.tsx": {
@@ -709,7 +709,7 @@
     "outputs": ["CalendarBase.json"]
   },
   "tab/src/TabsContext.tsx": {
-    "hash": "4b0508bbf39d74c4eb7dc35ae0907186",
+    "hash": "07c14a92c97deccf0daff99c9bf5a2e8",
     "outputs": []
   },
   "menu/src/beta/SideNavigation/SideNavigation.tsx": {

--- a/packages/tab/CHANGELOG.md
+++ b/packages/tab/CHANGELOG.md
@@ -34,6 +34,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 - **tab:** Stricter TypeScript types replace [key: string]: any.
   data-reach-\* attributes removed from DOM. Generated element IDs use new
   format.
+- **tab:** Tab and TabPanel now get their index from their position among the
+  children of TabList and TabPanels, instead of registering themselves in
+  document order. Fragments, Suspense boundaries and plain elements are
+  transparent, but a component of your own counts as one child whether it
+  renders one tab or panel, several, or none — so panels behind a wrapper
+  component share an index and open together, and a non-panel component next to
+  the panels shifts every panel after it. Render each Tab and TabPanel directly
+  from TabList and TabPanels, and put conditionals on a tab and its panel
+  together. Development builds warn when the indices cannot line up.
 
 - **tab:** require React 18, replace @reach/tabs with custom ARIA implementation
 

--- a/packages/tab/src/Tab.tsx
+++ b/packages/tab/src/Tab.tsx
@@ -1,13 +1,17 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
 
-import { TabItemContext, TabsContext } from './TabsContext';
+import { useItemIndex } from './indexedItems';
+import { TabsContext } from './TabsContext';
 
 export type TabProps = {
   /** Overskriften til taben */
   children: React.ReactNode;
   /** Om taben er disabled eller ikke */
   disabled?: boolean;
+  /** Indeksen til taben. Settes vanligvis ut fra rekkefølgen i `TabList`, men må
+   * angis manuelt dersom taben ligger inne i en egen komponent */
+  index?: number;
   /** HTML-elementet eller React-komponenten som lager komponenten */
   as?: keyof JSX.IntrinsicElements | React.ElementType;
   removeActiveLine?: boolean;
@@ -19,12 +23,12 @@ export const Tab = ({
   removeActiveLine = false,
   as,
   disabled = false,
+  index,
   children,
   ...rest
 }: TabProps) => {
-  const { selectedIndex, onSelect } = useContext(TabsContext);
-  const itemContext = useContext(TabItemContext);
-  const tabIndex = itemContext?.tabIndex ?? 0;
+  const { selectedIndex, onSelect, tabsId } = useContext(TabsContext);
+  const { index: tabIndex } = useItemIndex('tab', index);
   const isSelected = selectedIndex === tabIndex;
   const Element: React.ElementType = as || 'button';
 
@@ -32,9 +36,9 @@ export const Tab = ({
     <Element
       role="tab"
       type={as ? undefined : 'button'}
-      id={itemContext?.tabId}
+      id={`${tabsId}-tab-${tabIndex}`}
       aria-selected={isSelected}
-      aria-controls={isSelected ? itemContext?.panelId : undefined}
+      aria-controls={isSelected ? `${tabsId}-panel-${tabIndex}` : undefined}
       tabIndex={isSelected ? 0 : -1}
       disabled={disabled || undefined}
       aria-disabled={disabled || undefined}

--- a/packages/tab/src/TabList.tsx
+++ b/packages/tab/src/TabList.tsx
@@ -2,7 +2,8 @@ import React, { useCallback, useContext, useRef } from 'react';
 import classNames from 'classnames';
 import { getActiveElement } from '@entur/utils';
 
-import { TabItemContext, TabsContext } from './TabsContext';
+import { useIndexedChildren } from './indexedItems';
+import { TabsContext } from './TabsContext';
 
 export type TabListProps = {
   /** Tab-komponenter */
@@ -24,42 +25,34 @@ export const TabList = ({
   children,
   ...rest
 }: TabListProps) => {
-  const { tabsId } = useContext(TabsContext);
+  const { reportIndices } = useContext(TabsContext);
   const tabListRef = useRef<HTMLElement>(null);
 
+  const items = useIndexedChildren('tab', children, {
+    onIndices: indices => reportIndices('tab', indices),
+  });
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    const tabs = tabListRef.current?.querySelectorAll<HTMLElement>(
-      '[role="tab"]:not([disabled]):not([aria-disabled="true"])',
+    const tabs = Array.from(
+      tabListRef.current?.querySelectorAll<HTMLElement>(
+        '[role="tab"]:not([disabled]):not([aria-disabled="true"])',
+      ) ?? [],
     );
-    if (!tabs || tabs.length === 0) return;
-
     const focusedElement = getActiveElement();
-    const currentIndex = Array.from(tabs).findIndex(
-      tab => tab === focusedElement,
-    );
-    if (currentIndex === -1) return;
+    const current = tabs.findIndex(tab => tab === focusedElement);
+    if (current === -1) return;
 
-    let nextIndex: number | undefined;
-    switch (e.key) {
-      case 'ArrowRight':
-        nextIndex = (currentIndex + 1) % tabs.length;
-        break;
-      case 'ArrowLeft':
-        nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
-        break;
-      case 'Home':
-        nextIndex = 0;
-        break;
-      case 'End':
-        nextIndex = tabs.length - 1;
-        break;
-    }
+    const next = {
+      ArrowRight: (current + 1) % tabs.length,
+      ArrowLeft: (current - 1 + tabs.length) % tabs.length,
+      Home: 0,
+      End: tabs.length - 1,
+    }[e.key];
+    if (next === undefined) return;
 
-    if (nextIndex !== undefined) {
-      e.preventDefault();
-      tabs[nextIndex].focus();
-      tabs[nextIndex].click();
-    }
+    e.preventDefault();
+    tabs[next].focus();
+    tabs[next].click();
   }, []);
 
   const Element: React.ElementType = as || 'div';
@@ -78,17 +71,7 @@ export const TabList = ({
         handleKeyDown(e);
       }}
     >
-      {React.Children.map(children, (child, idx) => (
-        <TabItemContext.Provider
-          value={{
-            tabIndex: idx,
-            tabId: `${tabsId}-tab-${idx}`,
-            panelId: `${tabsId}-panel-${idx}`,
-          }}
-        >
-          {child}
-        </TabItemContext.Provider>
-      ))}
+      {items}
     </Element>
   );
 };

--- a/packages/tab/src/TabPanel.tsx
+++ b/packages/tab/src/TabPanel.tsx
@@ -1,26 +1,29 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
 
-import { TabPanelItemContext, TabsContext } from './TabsContext';
+import { useItemIndex } from './indexedItems';
+import { TabsContext } from './TabsContext';
 
 export type TabPanelProps = {
   /** Innholdet i tab-panelet */
   children?: React.ReactNode;
   /** HTML-elementet eller React-komponenten som lager komponenten */
   as?: keyof JSX.IntrinsicElements | React.ElementType;
+  /** Indeksen til panelet. Settes vanligvis ut fra rekkefølgen i `TabPanels`,
+   * men må angis manuelt dersom panelet ligger inne i en egen komponent */
+  index?: number;
   className?: string;
 } & Omit<React.ComponentPropsWithoutRef<'div'>, 'children'>;
 
 export const TabPanel = ({
   className,
   as,
+  index,
   children,
   ...rest
 }: TabPanelProps) => {
-  const { selectedIndex } = useContext(TabsContext);
-  const itemContext = useContext(TabPanelItemContext);
-  const tabIndex = itemContext?.tabIndex ?? 0;
-  const keepMounted = itemContext?.keepMounted ?? false;
+  const { selectedIndex, tabsId } = useContext(TabsContext);
+  const { index: tabIndex, keepMounted } = useItemIndex('panel', index);
 
   const isSelected = selectedIndex === tabIndex;
   const isHiddenButMounted = keepMounted && !isSelected;
@@ -32,8 +35,8 @@ export const TabPanel = ({
   return (
     <Element
       role="tabpanel"
-      id={itemContext?.panelId}
-      aria-labelledby={itemContext?.tabId}
+      id={`${tabsId}-panel-${tabIndex}`}
+      aria-labelledby={`${tabsId}-tab-${tabIndex}`}
       tabIndex={isSelected ? 0 : -1}
       hidden={isHiddenButMounted || undefined}
       className={classNames('eds-tab-panel', className)}

--- a/packages/tab/src/TabPanels.tsx
+++ b/packages/tab/src/TabPanels.tsx
@@ -1,7 +1,8 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
 
-import { TabPanelItemContext, TabsContext } from './TabsContext';
+import { useIndexedChildren } from './indexedItems';
+import { TabsContext } from './TabsContext';
 
 export type TabPanelsProps = {
   /** Tab-panelene */
@@ -20,24 +21,19 @@ export const TabPanels = ({
   children,
   ...rest
 }: TabPanelsProps) => {
-  const { tabsId } = useContext(TabsContext);
+  const { selectedIndex, reportIndices } = useContext(TabsContext);
+
+  const items = useIndexedChildren('panel', children, {
+    selectedIndex,
+    keepMounted,
+    onIndices: indices => reportIndices('panel', indices),
+  });
 
   const Element: React.ElementType = as || 'div';
 
   return (
     <Element className={classNames('eds-tab-panels', className)} {...rest}>
-      {React.Children.map(children, (child, idx) => (
-        <TabPanelItemContext.Provider
-          value={{
-            tabIndex: idx,
-            tabId: `${tabsId}-tab-${idx}`,
-            panelId: `${tabsId}-panel-${idx}`,
-            keepMounted,
-          }}
-        >
-          {child}
-        </TabPanelItemContext.Provider>
-      ))}
+      {items}
     </Element>
   );
 };

--- a/packages/tab/src/Tabs.tsx
+++ b/packages/tab/src/Tabs.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useId, useState } from 'react';
 import classNames from 'classnames';
 
+import { useUnreachablePanelWarning } from './indexedItems';
 import { TabsContext } from './TabsContext';
 
 export type TabsProps = {
@@ -30,6 +31,7 @@ export const Tabs = ({
   const isControlled = index !== undefined;
   const selectedIndex = isControlled ? index : internalIndex;
   const tabsId = useId();
+  const reportIndices = useUnreachablePanelWarning();
 
   const onSelect = useCallback(
     (i: number) => {
@@ -44,7 +46,9 @@ export const Tabs = ({
   const Element: React.ElementType = as || 'div';
 
   return (
-    <TabsContext.Provider value={{ selectedIndex, onSelect, tabsId }}>
+    <TabsContext.Provider
+      value={{ selectedIndex, onSelect, tabsId, reportIndices }}
+    >
       <Element className={classNames('eds-tabs', className)} {...rest}>
         {children}
       </Element>

--- a/packages/tab/src/TabsContext.tsx
+++ b/packages/tab/src/TabsContext.tsx
@@ -1,33 +1,18 @@
 import React from 'react';
 
+import { ItemKind } from './indexedItems';
+
 export type TabsContextValue = {
   selectedIndex: number;
   onSelect: (index: number) => void;
   tabsId: string;
+  /** Lets Tabs compare the indices the tabs and the panels ended up with */
+  reportIndices: (kind: ItemKind, indices: number[]) => void;
 };
 
 export const TabsContext = React.createContext<TabsContextValue>({
   selectedIndex: 0,
   onSelect: () => undefined,
   tabsId: '',
+  reportIndices: () => undefined,
 });
-
-export type TabItemContextValue = {
-  tabIndex: number;
-  tabId: string;
-  panelId: string;
-};
-
-export const TabItemContext = React.createContext<TabItemContextValue | null>(
-  null,
-);
-
-export type TabPanelItemContextValue = {
-  tabIndex: number;
-  tabId: string;
-  panelId: string;
-  keepMounted: boolean;
-};
-
-export const TabPanelItemContext =
-  React.createContext<TabPanelItemContextValue | null>(null);

--- a/packages/tab/src/index.test.tsx
+++ b/packages/tab/src/index.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode, Suspense } from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '.';
 
@@ -323,6 +324,460 @@ test('keepMounted keeps all panels in DOM', () => {
   expect(panels).toHaveLength(2);
   expect(panels[1]).toHaveAttribute('hidden');
   expect(panels[0]).not.toHaveAttribute('hidden');
+});
+
+describe('panels nested in markup', () => {
+  test('tabs and panels inside fragments get their own index', () => {
+    const { getAllByRole, getByText, queryByText } = render(
+      <Tabs>
+        <TabList>
+          <>
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+            <Tab>Tab 3</Tab>
+          </>
+        </TabList>
+        <TabPanels>
+          <>
+            <TabPanel>Panel 1</TabPanel>
+            <TabPanel>Panel 2</TabPanel>
+            <TabPanel>Panel 3</TabPanel>
+          </>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(getByText('Panel 1')).toBeInTheDocument();
+    expect(queryByText('Panel 2')).not.toBeInTheDocument();
+    expect(queryByText('Panel 3')).not.toBeInTheDocument();
+
+    fireEvent.click(getAllByRole('tab')[2]);
+
+    expect(getByText('Panel 3')).toBeInTheDocument();
+    expect(queryByText('Panel 1')).not.toBeInTheDocument();
+  });
+
+  test('tabs and panels inside wrapper elements get their own index', () => {
+    const { getAllByRole, getByText, queryByText } = render(
+      <Tabs>
+        <TabList>
+          <div>
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+            <Tab>Tab 3</Tab>
+          </div>
+        </TabList>
+        <TabPanels>
+          <div>
+            <TabPanel>Panel 1</TabPanel>
+            <TabPanel>Panel 2</TabPanel>
+            <TabPanel>Panel 3</TabPanel>
+          </div>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(getByText('Panel 1')).toBeInTheDocument();
+    expect(queryByText('Panel 2')).not.toBeInTheDocument();
+
+    fireEvent.click(getAllByRole('tab')[1]);
+
+    expect(getByText('Panel 2')).toBeInTheDocument();
+    expect(queryByText('Panel 1')).not.toBeInTheDocument();
+  });
+
+  test('panels nested several levels deep get their own index', () => {
+    const { getAllByRole, getByText, queryByText } = render(
+      <Tabs>
+        <TabList>
+          <div>
+            <>
+              <Tab>Tab 1</Tab>
+              <span>
+                <Tab>Tab 2</Tab>
+              </span>
+            </>
+          </div>
+        </TabList>
+        <TabPanels>
+          <div>
+            <>
+              <TabPanel>Panel 1</TabPanel>
+              <div>
+                <TabPanel>Panel 2</TabPanel>
+              </div>
+            </>
+          </div>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    const tabs = getAllByRole('tab');
+    expect(getByText('Panel 1')).toBeInTheDocument();
+    expect(queryByText('Panel 2')).not.toBeInTheDocument();
+
+    fireEvent.click(tabs[1]);
+
+    expect(getByText('Panel 2')).toBeInTheDocument();
+    expect(queryByText('Panel 1')).not.toBeInTheDocument();
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('tabs and panels inside a Suspense boundary get their own index', () => {
+    const { getAllByRole, getByText, queryByText } = render(
+      <Tabs>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+        <TabPanels>
+          <Suspense fallback={<span>Loading</span>}>
+            <TabPanel>Panel 1</TabPanel>
+            <TabPanel>Panel 2</TabPanel>
+          </Suspense>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(getByText('Panel 1')).toBeInTheDocument();
+    expect(queryByText('Panel 2')).not.toBeInTheDocument();
+
+    fireEvent.click(getAllByRole('tab')[1]);
+
+    expect(getByText('Panel 2')).toBeInTheDocument();
+    expect(queryByText('Panel 1')).not.toBeInTheDocument();
+  });
+
+  test('content that is not a tab or a panel does not consume an index', () => {
+    const showFirstPanel = false;
+    const { getAllByRole, getByText } = render(
+      <Tabs>
+        <TabList>
+          <span>Not a tab</span>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+        <TabPanels>
+          <hr />
+          {showFirstPanel && <TabPanel>Hidden panel</TabPanel>}
+          <TabPanel>Panel 1</TabPanel>
+          <TabPanel>Panel 2</TabPanel>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(getByText('Panel 1')).toBeInTheDocument();
+
+    fireEvent.click(getAllByRole('tab')[1]);
+    expect(getByText('Panel 2')).toBeInTheDocument();
+  });
+});
+
+describe('explicit index prop', () => {
+  // Stands in for a consumer component that renders one panel, which TabPanels
+  // cannot look inside — the only way in is the index prop
+  const OwnPanel = ({ index, label }: { index: number; label: string }) => (
+    <TabPanel index={index}>{label}</TabPanel>
+  );
+
+  test('a panel inside a component gets the index it is given', () => {
+    const { getAllByRole, getByText, queryByText } = render(
+      <Tabs>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+          <Tab>Tab 3</Tab>
+        </TabList>
+        <TabPanels>
+          <div>
+            <OwnPanel index={0} label="Panel 1" />
+            <OwnPanel index={1} label="Panel 2" />
+            <OwnPanel index={2} label="Panel 3" />
+          </div>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(getByText('Panel 1')).toBeInTheDocument();
+
+    fireEvent.click(getAllByRole('tab')[2]);
+
+    expect(getByText('Panel 3')).toBeInTheDocument();
+    expect(queryByText('Panel 1')).not.toBeInTheDocument();
+  });
+
+  test('the index prop wins over the index TabPanels handed out', () => {
+    const { getAllByRole, getByText, queryByText } = render(
+      <Tabs>
+        <TabList>
+          <Tab index={1}>Tab 1</Tab>
+          <Tab index={0}>Tab 2</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel index={1}>Panel 1</TabPanel>
+          <TabPanel index={0}>Panel 2</TabPanel>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    // Index 0 is selected, which is the second tab and the second panel
+    expect(getByText('Panel 2')).toBeInTheDocument();
+    expect(queryByText('Panel 1')).not.toBeInTheDocument();
+    expect(getAllByRole('tab')[1]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.click(getAllByRole('tab')[0]);
+    expect(getByText('Panel 1')).toBeInTheDocument();
+  });
+
+  test('aria-controls and aria-labelledby follow the given index', () => {
+    const { getAllByRole } = render(
+      <Tabs>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+        <TabPanels>
+          <div>
+            <OwnPanel index={0} label="Panel 1" />
+            <OwnPanel index={1} label="Panel 2" />
+          </div>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    const tab = getAllByRole('tab')[1];
+    fireEvent.click(tab);
+
+    const panel = getAllByRole('tabpanel')[0];
+    expect(panel.id).toBe(tab.getAttribute('aria-controls'));
+    expect(panel).toHaveAttribute('aria-labelledby', tab.id);
+  });
+});
+
+describe('development warnings', () => {
+  let consoleError: jest.SpyInstance;
+  let consoleWarn: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    consoleWarn.mockRestore();
+  });
+
+  test('warns when a TabPanel is rendered without TabPanels', () => {
+    const { getByText } = render(
+      <Tabs>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+        <TabPanel>Panel 1</TabPanel>
+        <TabPanel>Panel 2</TabPanel>
+      </Tabs>,
+    );
+
+    // Both panels fall back to index 0 and render at the same time
+    expect(getByText('Panel 1')).toBeInTheDocument();
+    expect(getByText('Panel 2')).toBeInTheDocument();
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('<TabPanel> was rendered outside of <TabPanels>'),
+    );
+  });
+
+  test('warns when a Tab is rendered without TabList', () => {
+    render(
+      <Tabs>
+        <Tab>Tab 1</Tab>
+        <TabPanels>
+          <TabPanel>Panel 1</TabPanel>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('<Tab> was rendered outside of <TabList>'),
+    );
+  });
+
+  test('warns when the selected index has no panel but later ones do', () => {
+    // Only a warning: a panel that is still loading looks the same from here
+    const Header = () => <h2>Heading</h2>;
+
+    render(
+      <Tabs>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+        <TabPanels>
+          <div>
+            <Header />
+            <TabPanel>Panel 1</TabPanel>
+            <TabPanel>Panel 2</TabPanel>
+          </div>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('No <TabPanel> got index 0'),
+    );
+    // The last panel ended up at index 2, which no tab can reach
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('No <Tab> got index 2'),
+    );
+  });
+
+  test('warns about a panel no tab can reach', () => {
+    const showSecondTab = false;
+
+    render(
+      <Tabs>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          {showSecondTab && <Tab>Tab 2</Tab>}
+        </TabList>
+        <TabPanels>
+          <TabPanel>Panel 1</TabPanel>
+          <TabPanel>Panel 2</TabPanel>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('No <Tab> got index 1'),
+    );
+  });
+
+  test('a tab with no panel of its own does not warn', () => {
+    render(
+      <Tabs>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Panel 1</TabPanel>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  test('warns when several panels resolve to the same index', () => {
+    const TwoPanels = () => (
+      <>
+        <TabPanel>Panel 1</TabPanel>
+        <TabPanel>Panel 2</TabPanel>
+      </>
+    );
+
+    render(
+      <Tabs>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+        <TabPanels>
+          <TwoPanels />
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Several <TabPanel> components got the same index (0)',
+      ),
+    );
+  });
+
+  test('does not warn for supported markup', () => {
+    render(
+      <Tabs>
+        <TabList>
+          <>
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+          </>
+        </TabList>
+        <TabPanels>
+          <div>
+            <TabPanel>Panel 1</TabPanel>
+            <TabPanel>Panel 2</TabPanel>
+          </div>
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  test('an index prop on each panel silences the shared-index error', () => {
+    const TwoPanels = () => (
+      <>
+        <TabPanel index={0}>Panel 1</TabPanel>
+        <TabPanel index={1}>Panel 2</TabPanel>
+      </>
+    );
+
+    render(
+      <Tabs>
+        <TabList>
+          <Tab>Tab 1</Tab>
+          <Tab>Tab 2</Tab>
+        </TabList>
+        <TabPanels>
+          <TwoPanels />
+        </TabPanels>
+      </Tabs>,
+    );
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  test('a panel with an index prop outside TabPanels does not warn', () => {
+    render(
+      <Tabs>
+        <TabList>
+          <Tab index={0}>Tab 1</Tab>
+        </TabList>
+        <TabPanel index={0}>Panel 1</TabPanel>
+      </Tabs>,
+    );
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  test('does not warn in StrictMode, where effects run twice', () => {
+    render(
+      <StrictMode>
+        <Tabs>
+          <TabList>
+            <Tab>Tab 1</Tab>
+            <Tab>Tab 2</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>Panel 1</TabPanel>
+            <TabPanel>Panel 2</TabPanel>
+          </TabPanels>
+        </Tabs>
+      </StrictMode>,
+    );
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
 });
 
 test('TabList accepts aria-label', () => {

--- a/packages/tab/src/indexedItems.ts
+++ b/packages/tab/src/indexedItems.ts
@@ -1,0 +1,198 @@
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
+
+const isDev = () => process.env.NODE_ENV !== 'production';
+
+export type ItemKind = 'tab' | 'panel';
+
+const NAMES = {
+  tab: { child: 'Tab', parent: 'TabList', self: 'tab', sibling: 'panel' },
+  panel: {
+    child: 'TabPanel',
+    parent: 'TabPanels',
+    self: 'panel',
+    sibling: 'tab',
+  },
+} as const;
+
+type ItemContextValue = {
+  index: number;
+  register: (index: number) => () => void;
+  keepMounted: boolean;
+};
+
+const ItemContexts = {
+  tab: React.createContext<ItemContextValue | null>(null),
+  panel: React.createContext<ItemContextValue | null>(null),
+};
+
+/** Logs each distinct message once, so a later problem is not swallowed */
+export function useWarnOnce() {
+  const reported = useRef(new Set<string>());
+
+  return useCallback((level: 'warn' | 'error', message: string) => {
+    if (!isDev() || reported.current.has(message)) return;
+    reported.current.add(message);
+    console[level](message);
+  }, []);
+}
+
+/**
+ * Settles on the index for a Tab or TabPanel — an explicit index prop wins over
+ * the one the parent handed out — and reports it back to the parent, which uses
+ * it to spot markup where the indices cannot line up.
+ */
+export function useItemIndex(kind: ItemKind, explicitIndex?: number) {
+  const { child, parent } = NAMES[kind];
+  const item = useContext(ItemContexts[kind]);
+  const register = item?.register;
+  const index = explicitIndex ?? item?.index ?? 0;
+  const warn = useWarnOnce();
+
+  useEffect(() => register?.(index), [register, index]);
+
+  useEffect(() => {
+    if (explicitIndex === undefined && !register)
+      warn(
+        'warn',
+        `<${child}> was rendered outside of <${parent}>, so it falls back to index 0. Render it from <${parent}>, or give it an index prop.`,
+      );
+  }, [explicitIndex, register, child, parent, warn]);
+
+  return { index, keepMounted: item?.keepMounted ?? false };
+}
+
+/**
+ * Hands out an index to every child that could be a Tab or a TabPanel, and
+ * warns when the indices cannot line up.
+ *
+ * Fragments, Suspense boundaries and plain HTML elements are transparent: they
+ * take up no index themselves, but their children do, which keeps the indices
+ * right when tabs or panels sit nested in markup. We cannot look inside a
+ * component, so each one takes up a single index — a component that renders a
+ * tab or a panel needs an explicit index prop.
+ */
+export function useIndexedChildren(
+  kind: ItemKind,
+  children: React.ReactNode,
+  options: {
+    selectedIndex?: number;
+    keepMounted?: boolean;
+    /** Lets Tabs compare the indices the tabs and the panels ended up with */
+    onIndices?: (indices: number[]) => void;
+  } = {},
+): React.ReactNode {
+  const { selectedIndex, keepMounted = false, onIndices } = options;
+  const counts = useRef(new Map<number, number>());
+  const warn = useWarnOnce();
+
+  const register = useCallback((index: number) => {
+    counts.current.set(index, (counts.current.get(index) ?? 0) + 1);
+
+    return () => {
+      const left = (counts.current.get(index) ?? 0) - 1;
+      if (left > 0) counts.current.set(index, left);
+      else counts.current.delete(index);
+    };
+  }, []);
+
+  // Runs after the children have registered themselves
+  useEffect(() => {
+    if (!isDev()) return;
+
+    const used = Array.from(counts.current.keys());
+    const shared = used.filter(index => (counts.current.get(index) ?? 0) > 1);
+    onIndices?.(used);
+
+    if (shared.length) warn('error', sharedIndexMessage(kind, shared));
+    // An unused index after the last child is fine: that tab has no panel
+    else if (
+      selectedIndex !== undefined &&
+      !counts.current.has(selectedIndex) &&
+      selectedIndex < Math.max(...used)
+    )
+      warn('warn', missingIndexMessage(kind, selectedIndex));
+  });
+
+  let next = 0;
+  const walk = (nodes: React.ReactNode): React.ReactNode =>
+    React.Children.map(nodes, child => {
+      // Text, numbers, null and booleans can never be tabs or panels
+      if (!React.isValidElement(child)) return child;
+
+      const isTransparent =
+        child.type === React.Fragment ||
+        child.type === React.Suspense ||
+        typeof child.type === 'string';
+
+      if (!isTransparent)
+        return React.createElement(
+          ItemContexts[kind].Provider,
+          { value: { index: next++, register, keepMounted } },
+          child,
+        );
+
+      const { children: nested } = child.props as {
+        children?: React.ReactNode;
+      };
+      return nested === undefined
+        ? child
+        : React.cloneElement(child, undefined, walk(nested));
+    });
+
+  return walk(children);
+}
+
+function sharedIndexMessage(kind: ItemKind, shared: number[]) {
+  const { child, parent, self, sibling } = NAMES[kind];
+
+  return `Several <${child}> components got the same index (${shared.join(
+    ', ',
+  )}), so they belong to the same ${sibling} and change together.
+
+<${parent}> numbers its children in the order they appear, and it cannot see inside your own components. A wrapper such as <ErrorBoundary> therefore counts as one child, and every <${child}> inside it gets that same index.
+
+Fix it in one of two ways:
+  1. Put each <${child}> directly inside <${parent}>, and move wrappers such as ErrorBoundary or Suspense inside the ${self}.
+  2. Set the index yourself: <${child} index={0} />, <${child} index={1} /> and so on. Needed when the ${self} lives inside a component of your own.
+
+Fragments, Suspense and plain HTML elements take no index of their own, so nesting ${self}s in those is fine.`;
+}
+
+function missingIndexMessage(kind: ItemKind, selectedIndex: number) {
+  const { child, parent, self, sibling } = NAMES[kind];
+
+  return `No <${child}> got index ${selectedIndex}, so that ${sibling} shows nothing while later indices are in use.
+
+<${parent}> numbers its children in the order they appear, and a component it cannot see inside takes up one index whether or not it renders a ${self}. Give the ${self} an explicit index prop if it lives inside a component of your own.
+
+If the ${self} loads lazily, it sorts itself out once loading finishes.`;
+}
+
+/** Warns about panels no tab can reach, which neither parent can see on its own */
+export function useUnreachablePanelWarning() {
+  const seen = useRef<{ tab?: number[]; panel?: number[] }>({});
+  const warn = useWarnOnce();
+
+  const reportIndices = useCallback((kind: ItemKind, indices: number[]) => {
+    seen.current[kind] = indices;
+  }, []);
+
+  useEffect(() => {
+    const { tab, panel } = seen.current;
+    if (!isDev() || !tab || !panel) return;
+
+    const unreachable = panel.filter(index => !tab.includes(index));
+    if (!unreachable.length) return;
+
+    warn(
+      'error',
+      `No <Tab> got index ${unreachable.join(
+        ', ',
+      )}, so that panel can never be shown.
+
+There are more panels than tabs, or a tab is rendered conditionally while its panel is not. Render the tab and the panel under the same condition, or drop the panel.`,
+    );
+  });
+
+  return reportIndices;
+}

--- a/skills/entur-web-development/references/components.md
+++ b/skills/entur-web-development/references/components.md
@@ -329,6 +329,29 @@ import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@entur/tab';
 </Tabs>
 ```
 
+### Tabs: keep the tabs and panels in the markup
+
+`TabList` and `TabPanels` number their children by position, and the panel at position _n_ belongs to the tab at position _n_. Render both directly, one `TabList` and one `TabPanels` per `Tabs`, and build them from the same data so they cannot drift apart:
+
+```tsx
+<Tabs>
+  <TabList>
+    {views.map(view => (
+      <Tab key={view.id}>{view.title}</Tab>
+    ))}
+  </TabList>
+  <TabPanels>
+    {views.map(view => (
+      <TabPanel key={view.id}>{view.content}</TabPanel>
+    ))}
+  </TabPanels>
+</Tabs>
+```
+
+Fragments, `Suspense` boundaries and plain elements are transparent, so nesting tabs or panels inside them is fine. A component of your own is not: it counts as one child whether it renders one panel, several, or none at all. So don't put a wrapper component, a heading component, or a component-per-panel inside `TabPanels` — and put conditionals on the tab and its panel together, never on just one.
+
+When a panel genuinely has to live inside a component of your own, pass the position explicitly with the `index` prop on `Tab` and `TabPanel`; it wins over the inherited one. In development the components log a warning or error when the indices cannot line up.
+
 ---
 
 ## Travel-specific

--- a/skills/migrate-react-18/SKILL.md
+++ b/skills/migrate-react-18/SKILL.md
@@ -107,6 +107,8 @@ Fix any remaining type errors or test failures. Common issues:
 - **Type errors from stricter props** — `@entur/tab` components no longer accept arbitrary props. Remove unknown props.
 - **Test failures from ID changes** — Tab/panel IDs now use `useId()` format. Don't match specific ID strings; use `aria-controls`/`aria-labelledby` to find linked elements.
 - **All panels render under the first tab** — panels hidden behind a component of your own (an error boundary, a data wrapper, or a component per panel) share one index. Render each panel from `<TabPanels>`, or pass each one an explicit `index` prop. `@entur/tab` logs an error in development when this happens.
+- **Panels are off by one** — a component of your own inside `<TabPanels>` takes an index even when it renders no panel, so a heading or layout component shifts every panel after it. Move it out of `<TabPanels>`, or inline it as plain markup.
+- **A tab shows the wrong panel** — a `<Tab>` and its `<TabPanel>` sit under different conditions, so a falsy conditional shifts every later index on one side only. Silent when the conditional is mid-list; merely logged when it's last. Put both behind the same condition.
 - **Test failures from batched updates** — React 18 batches all state updates. Wrap assertions that depend on intermediate states in `act()` or use `waitFor`.
 - **Double renders in dev** — `<StrictMode>` now mounts, unmounts, and re-mounts components. This is expected; fix missing `useEffect` cleanups it reveals.
 

--- a/skills/migrate-react-18/SKILL.md
+++ b/skills/migrate-react-18/SKILL.md
@@ -72,14 +72,14 @@ Load **[references/breaking-changes.md](references/breaking-changes.md)** and wo
 
 The reference covers:
 
-| Package                      | Key changes                                                               |
-| ---------------------------- | ------------------------------------------------------------------------- |
-| ESM `exports` (all packages) | Deep `dist/` imports break; built files renamed to `.mjs`/`.cjs`          |
-| `@entur/modal`               | `onDismiss` required, `<div>` → `<dialog>`, `data-reach-*` selectors gone |
-| `@entur/tab`                 | `data-reach-*` selectors gone, stricter types, ID format changed          |
-| `@entur/expand`              | Content stays in DOM when collapsed; `unmountOnClose` opt-out             |
-| `@entur/layout` (beta)       | `LayoutProvider` removed; responsive base key `s` → `base`                |
-| `@entur/utils`               | `useRandomId` deprecated → use React `useId()`                            |
+| Package                      | Key changes                                                                                             |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------- |
+| ESM `exports` (all packages) | Deep `dist/` imports break; built files renamed to `.mjs`/`.cjs`                                        |
+| `@entur/modal`               | `onDismiss` required, `<div>` → `<dialog>`, `data-reach-*` selectors gone                               |
+| `@entur/tab`                 | `data-reach-*` selectors gone, stricter types, ID format changed, tab/panel index comes from the markup |
+| `@entur/expand`              | Content stays in DOM when collapsed; `unmountOnClose` opt-out                                           |
+| `@entur/layout` (beta)       | `LayoutProvider` removed; responsive base key `s` → `base`                                              |
+| `@entur/utils`               | `useRandomId` deprecated → use React `useId()`                                                          |
 
 For each applicable section: grep for the affected patterns, fix them, and confirm no instances remain.
 
@@ -106,6 +106,7 @@ Fix any remaining type errors or test failures. Common issues:
 
 - **Type errors from stricter props** — `@entur/tab` components no longer accept arbitrary props. Remove unknown props.
 - **Test failures from ID changes** — Tab/panel IDs now use `useId()` format. Don't match specific ID strings; use `aria-controls`/`aria-labelledby` to find linked elements.
+- **All panels render under the first tab** — panels hidden behind a component of your own (an error boundary, a data wrapper, or a component per panel) share one index. Render each panel from `<TabPanels>`, or pass each one an explicit `index` prop. `@entur/tab` logs an error in development when this happens.
 - **Test failures from batched updates** — React 18 batches all state updates. Wrap assertions that depend on intermediate states in `act()` or use `waitFor`.
 - **Double renders in dev** — `<StrictMode>` now mounts, unmounts, and re-mounts components. This is expected; fix missing `useEffect` cleanups it reveals.
 

--- a/skills/migrate-react-18/references/behavioral-changes.md
+++ b/skills/migrate-react-18/references/behavioral-changes.md
@@ -59,6 +59,19 @@ Tab and panel IDs now use React's `useId()` format (e.g. `:r1:`) instead of Reac
 - Browser devtools will show the new ID format in the DOM
 - Deep links or URL fragments pointing to specific tab panel IDs will stop working
 
+### Development warnings for tab and panel markup
+
+`@entur/tab` logs in development — never in production — when the markup cannot produce usable indices:
+
+- `console.warn` when a `Tab` renders outside `TabList` or a `TabPanel` outside `TabPanels`, with no `index` prop to fall back on
+- `console.error` when several tabs or panels share an index — usually panels hidden behind a component of your own
+- `console.warn` when the selected tab has no panel while later indices are in use. A panel that is still loading looks the same from the outside, so this one is a hint, not a verdict
+
+**What you'll notice:**
+
+- New console output in dev builds if the markup hits one of those cases; the message says what to change
+- Tests that fail on unexpected console output need the markup fixed, not the assertion relaxed
+
 ---
 
 ## @entur/expand

--- a/skills/migrate-react-18/references/breaking-changes.md
+++ b/skills/migrate-react-18/references/breaking-changes.md
@@ -165,7 +165,96 @@ const panel = document.getElementById(tab.getAttribute('aria-controls')!);
 
 Keeps all panels in the DOM with `hidden` attribute instead of unmounting inactive ones. No action required unless you want this behavior.
 
-**Search patterns:** `data-reach-tab`, `data-reach-tabs`, hardcoded tab/panel IDs in tests.
+### `Tab` and `TabPanel` get their index from the markup
+
+`TabList` and `TabPanels` hand out one index per child, and the child at index _n_ belongs to the tab at index _n_. Under `@reach/tabs` every tab and panel registered itself and got its index from the document order, so it did not matter how deeply it was nested.
+
+Fragments, `Suspense` boundaries and wrapper elements are supported — they consume no index of their own:
+
+```tsx
+// ✅ Both work
+<TabPanels>
+  <>
+    <TabPanel>One</TabPanel>
+    <TabPanel>Two</TabPanel>
+  </>
+</TabPanels>
+
+<TabPanels>
+  <div className="my-layout">
+    <TabPanel>One</TabPanel>
+    <TabPanel>Two</TabPanel>
+  </div>
+</TabPanels>
+```
+
+Your own components are opaque — `TabPanels` cannot look inside them, so each one gets a single index. Several panels behind one component therefore share that index and open and close together:
+
+```tsx
+// ❌ Both panels get index 0 and render at the same time
+const MyPanels = () => (
+  <>
+    <TabPanel>One</TabPanel>
+    <TabPanel>Two</TabPanel>
+  </>
+);
+
+<TabPanels>
+  <MyPanels />
+</TabPanels>;
+
+// ✅ Render the panels from TabPanels
+<TabPanels>
+  <TabPanel>One</TabPanel>
+  <TabPanel>Two</TabPanel>
+</TabPanels>;
+```
+
+### Panels behind a wrapper component
+
+A component of your own between `TabPanels` and the panels — an error boundary, a data or layout wrapper — hides them, so all of them inherit that component's single index. Either lift the wrapper out of `TabPanels`, or give each panel an explicit `index`:
+
+```tsx
+// ❌ Every panel below the wrapper gets index 0
+<TabPanels>
+  <Wrapper>
+    <FirstPanel />
+    <SecondPanel />
+  </Wrapper>
+</TabPanels>
+
+// ✅ Lift the wrapper out — TabPanels sees the panel components again
+<Wrapper>
+  <TabPanels>
+    <FirstPanel />
+    <SecondPanel />
+  </TabPanels>
+</Wrapper>
+
+// ✅ Or place each panel yourself; index wins over the inherited one
+const Wrapper = ({ children }: { children?: any }) => <div>{children}</div>;
+const FirstPanel = ({ index }: { index?: number }) => (
+  <TabPanel index={index}>…</TabPanel>
+);
+const SecondPanel = ({ index }: { index?: number }) => (
+  <TabPanel index={index}>…</TabPanel>
+);
+
+<TabPanels>
+  <Wrapper>
+    <FirstPanel index={0} />
+    <SecondPanel index={1} />
+  </Wrapper>
+</TabPanels>;
+```
+
+Lifting the wrapper out relies on each component rendering a single `TabPanel`; `index` works regardless. Note that a `Suspense` boundary needs neither — it is transparent like a fragment.
+
+`TabPanel` otherwise needs a `TabPanels` parent, and `Tab` a `TabList` parent — outside them, with no `index` prop, they fall back to index 0 and log a `console.warn` in development.
+
+`TabList` and `TabPanels` also report unusable indices in development: a `console.error` when several children share an index, and a `console.warn` when the selected tab has no panel while later indices are in use (which is also what a panel that is still loading looks like).
+
+**Search patterns:** `data-reach-tab`, `data-reach-tabs`, hardcoded tab/panel IDs in tests, components that return more than one `<Tab>` or `<TabPanel>`, `<TabPanels>` whose children are components of your own.
 
 ---
 

--- a/skills/migrate-react-18/references/breaking-changes.md
+++ b/skills/migrate-react-18/references/breaking-changes.md
@@ -250,11 +250,95 @@ const SecondPanel = ({ index }: { index?: number }) => (
 
 Lifting the wrapper out relies on each component rendering a single `TabPanel`; `index` works regardless. Note that a `Suspense` boundary needs neither — it is transparent like a fragment.
 
-`TabPanel` otherwise needs a `TabPanels` parent, and `Tab` a `TabList` parent — outside them, with no `index` prop, they fall back to index 0 and log a `console.warn` in development.
+### A component that is not a panel still takes an index
 
-`TabList` and `TabPanels` also report unusable indices in development: a `console.error` when several children share an index, and a `console.warn` when the selected tab has no panel while later indices are in use (which is also what a panel that is still loading looks like).
+This one is easy to miss, because the markup looks harmless and worked before. Any component of your own counts as one child whether or not it renders a panel, so a heading or a layout component next to the panels shifts every panel after it by one:
 
-**Search patterns:** `data-reach-tab`, `data-reach-tabs`, hardcoded tab/panel IDs in tests, components that return more than one `<Tab>` or `<TabPanel>`, `<TabPanels>` whose children are components of your own.
+```tsx
+// ❌ Heading takes index 0, so the panels end up at 1 and 2.
+// Tab 1 shows nothing, tab 2 shows the first panel.
+<TabPanels>
+  <Heading />
+  <TabPanel>One</TabPanel>
+  <TabPanel>Two</TabPanel>
+</TabPanels>
+
+// ✅ Move it out of TabPanels
+<Heading />
+<TabPanels>
+  <TabPanel>One</TabPanel>
+  <TabPanel>Two</TabPanel>
+</TabPanels>
+
+// ✅ Or inline the markup, since plain elements are transparent
+<TabPanels>
+  <h2>A heading</h2>
+  <TabPanel>One</TabPanel>
+  <TabPanel>Two</TabPanel>
+</TabPanels>
+```
+
+Plain elements, strings, `null` and `false` never take an index, so conditional children are safe as long as they are not components of your own.
+
+### Render a tab and its panel under the same condition
+
+Under `@reach/tabs` both sides re-registered on every render, so a condition on one side alone still left the pairing intact. The index now comes from the position, so a falsy conditional shifts every later index **on its own side only** — and the two sides stop agreeing from that point on.
+
+The damage depends on where the conditional sits. In the middle of a list it silently pairs a tab with the wrong panel:
+
+```tsx
+// ❌ With `show` false, tabs number A=0, C=1 — but panels number A=0, B=1, C=2.
+// Clicking tab C shows Panel B.
+<TabList>
+  <Tab>A</Tab>
+  {show && <Tab>B</Tab>}
+  <Tab>C</Tab>
+</TabList>
+<TabPanels>
+  <TabPanel>Panel A</TabPanel>
+  <TabPanel>Panel B</TabPanel>
+  <TabPanel>Panel C</TabPanel>
+</TabPanels>
+
+// ✅ Same condition on both sides — indices stay in step
+<TabList>
+  <Tab>A</Tab>
+  {show && <Tab>B</Tab>}
+  <Tab>C</Tab>
+</TabList>
+<TabPanels>
+  <TabPanel>Panel A</TabPanel>
+  {show && <TabPanel>Panel B</TabPanel>}
+  <TabPanel>Panel C</TabPanel>
+</TabPanels>
+```
+
+At the **end** of a list, a one-sided conditional is harmless in practice: the orphaned panel is simply unreachable, and an unselected panel renders nothing anyway. It still logs a `console.error`, so fix it, but nothing is visibly wrong. A trailing tab with no panel is allowed outright and does not warn.
+
+So it isn't the counts that matter, it's the positions. Putting both sides under the same condition is the rule worth following, because it holds wherever the conditional sits.
+
+### One `TabList` and one `TabPanels` per `Tabs`
+
+Each container numbers its own children from 0 and knows nothing about the other, so a second one restarts at 0 — two tabs end up selected at once, two panels show at once, and the generated ids collide. Nothing warns about this, since neither container can see the duplicate.
+
+```tsx
+// ❌ Both lists produce indices 0 and 1
+<Tabs>
+  <TabList>…</TabList>
+  <TabList>…</TabList>
+  <TabPanels>…</TabPanels>
+</Tabs>
+```
+
+Use one of each, and give each group of tabs its own `Tabs` if you need two.
+
+### Development warnings
+
+`TabPanel` needs a `TabPanels` parent, and `Tab` a `TabList` parent — outside them, with no `index` prop, they fall back to index 0 and log a `console.warn` in development.
+
+`TabList` and `TabPanels` also report unusable indices in development: a `console.error` when several children share an index, and a `console.warn` when the selected tab has no panel while later indices are in use (which is also what a panel that is still loading looks like). `Tabs` logs a `console.error` for a panel no tab can reach.
+
+**Search patterns:** `data-reach-tab`, `data-reach-tabs`, hardcoded tab/panel IDs in tests, components that return more than one `<Tab>` or `<TabPanel>`, `<TabPanels>` whose children are components of your own, non-panel components inside `<TabPanels>`, conditionals on only one of `<Tab>`/`<TabPanel>`, more than one `<TabList>` or `<TabPanels>` inside a `<Tabs>`.
 
 ---
 


### PR DESCRIPTION
## 💡 Hvorfor?

[ETU-75596](https://entur.atlassian.net/browse/ETU-75596). Entur Partner meldte at en `<Tabs>` med tre tab-er viste innholdet i alle panelene stablet under den første taben, og ingenting under de to andre, etter oppgradering til `@entur/tab` 0.8.0.

Årsaken er at `TabPanels` delte ut indekser med `React.Children.map` over sine direkte barn, og `TabPanel` falt tilbake til indeks 0 uten kontekst. Ligger flere paneler i samme barn – i et fragment, i et wrapper-element eller bak en egen komponent – fikk alle indeks 0, og de ble derfor vist samtidig mens de andre tab-ene ble tomme. `TabList` og `Tab` hadde samme svakhet.

Dette er en regresjon fra 0.8.0, der `@reach/tabs` ble byttet ut med en nativ ARIA-implementasjon. Under `@reach/tabs` registrerte hver tab og hvert panel seg selv og fikk indeksen fra rekkefølgen i DOM, så det hadde ingenting å si hvor dypt de lå i markupen. Endringen var breaking, men helt stille: ingen advarsel, ingen typefeil, bare feil resultat.

## 🔧 Hvordan?

`TabList` og `TabPanels` deler ut indekser ved å gå gjennom fragmenter, `Suspense`-grenser og vanlige HTML-elementer på vei nedover. Slike containere forbruker ingen indeks selv, mens barna deres gjør det. Innhold som ikke kan være en tab eller et panel – tekst, tall, `null`, `false` – forbruker heller ingen indeks.

Egne komponenter kan ikke inspiseres, og får derfor én indeks hver. Det er nettopp formen Partner har: panelene ligger bak en `ErrorBoundary`, og da hjelper ingen strukturell gjennomgang. Derfor tar `Tab` og `TabPanel` nå imot en `index`-prop som overstyrer indeksen forelderen deler ut, og som virker uansett hvordan panelet er pakket inn:

```tsx
<TabPanels>
  <ErrorBoundary fallback={<ErrorMessage />}>
    <Suspense fallback={<Loader />}>
      <UserRolesTabPanel index={0} />
      <UserPermissionsTabPanel index={1} />
      <AuditLogTabPanel index={2} />
    </Suspense>
  </ErrorBoundary>
</TabPanels>
```

`@reach/tabs` hadde forøvrig den samme utveien: `Tab` tok imot en `index`-prop som ble sendt rett videre til `useDescendant`.

`id`, `aria-controls` og `aria-labelledby` bygges nå i `Tab` og `TabPanel` ut fra indeksen de faktisk endte på, ikke i `TabList` og `TabPanels`. Uten det ville ARIA-koblingen pekt på partneren til indeksen forelderen delte ut. ID-formatet er uendret.

Hele indeks-håndteringen ligger i én modul, `indexedItems.ts`: gjennomgangen av markupen, de to item-kontekstene, registreringen barna gjør av indeksen sin, og advarslene. `TabsContext` er tilsvarende mindre, og tastaturnavigasjonen i `TabList` er skrevet om fra en `switch` til et oppslag fra tast til indeks. `getActiveElement` fra `ETU-75490` er beholdt.

Selvregistrering med indeks fra rekkefølgen i DOM (slik `@reach/tabs` gjorde) ble vurdert og forkastet: `TabPanel` returnerer `null` når det ikke er valgt, så et umontert panel har ingen DOM-node å sammenligne, samtidig som det trenger indeksen for å avgjøre om det skal montere. Den veien krever at alle paneler alltid ligger i DOM – altså å reversere dagens `keepMounted={false}`-standard – og indeksen ville først vært kjent etter en layout-effekt. Kilden til `@reach/tabs` bekrefter kostnaden: den kommenterer selv at `useDescendant` alltid returnerer `-1` på første render, og bærer en egen «ready»-ref for å håndtere det.

Advarslene i utviklingsmodus:

- `console.warn` når `Tab` ligger utenfor `TabList` eller `TabPanel` utenfor `TabPanels` og ikke har fått en `index`-prop å falle tilbake på. Mildeste varianten med vilje: `Tab` gjenbrukt som styling utenfor en tab-liste er en tenkelig og legitim bruk, og en `console.error` ville gjort testoppsett hos konsumenter røde uten at appen deres feiler.
- `console.error` når flere barn deler indeks. Det er alltid en feil – panelene åpnes og lukkes samtidig, og ID-ene kolliderer. Meldingen beskriver først hva man ser, peker på wrappere som `ErrorBoundary` som vanligste årsak, og gir begge utveier: flytte wrapperen inn i panelet, eller sette `index` selv.
- `console.warn` når den valgte taben ikke har noe panel mens senere indekser er i bruk. Denne var først en `console.error`, men et panel som fortsatt laster (`React.lazy` bak en `Suspense`) ser helt likt ut fra forelderens side. Verifisert: den gamle varianten ga en falsk feilmelding under lasting. Nå er den formulert som et hint, med lasting nevnt.
- `console.error` fra `Tabs` når et panel har en indeks ingen tab kan nå. `TabList` og `TabPanels` ser bare sine egne barn, så denne sammenligner indeksene de to endte på. Den fanger både flere paneler enn tab-er, og en tab som rendres betinget mens panelet ikke gjør det. Motsatt retning – en tab uten eget panel – er et legitimt mønster og sier ingenting.

Hver distinkte melding logges én gang per komponentinstans, så et problem som oppstår senere blir ikke slukt av det første.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [x] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [x] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

Indeksene endrer seg for markup som blandet paneler med annet innhold: lå det et dekorativt element blant panelene, forbrukte det tidligere en indeks. Nå gjør det ikke det, og panelene får de indeksene tab-ene faktisk peker på. Det er den samme feilen som fikses, sett fra en annen kant.

Det gjelder også `{visKanskje && <TabPanel />}`, som i 0.8.x forbrukte en indeks selv når betingelsen var falsk. Det er verifisert mot kilden at `@reach/tabs` ikke gjorde det: `useDescendant` teller bare det som faktisk rendres. Nummereringen her er altså den samme som før 0.8.0, og 0.8.x er unntaket. Konsekvensen – en betinget tab med et ubetinget panel – er tilfellet den nye `console.error`-en om uoppnåelige paneler fanger.

Risikoen for konsumenter er vurdert og testet. Verifisert uendret: paneler som direkte barn (normaltilfellet), `ref` og `key` på wrapper-elementer (samme DOM-node etter ny render, altså ingen remount), HTML-elementer med tekstbarn som `<option>`, og ID-formatet på tab-er og paneler. Kontekstene eksporteres ikke fra `index.tsx`, så det er ingen typeendring for konsumenter. Det som faktisk kan merkes er ny konsoll-logging ved markup som ikke var støttet – konsumenter som feiler testene sine på `console.error` vil se rødt der de før fikk feil panel i stillhet.

Partner har to veier, begge verifisert: flytte `ErrorBoundary` og `Suspense` inn i hvert `TabPanel` – da er panelene direkte barn igjen, og ingen `index` er nødvendig – eller sende inn `index` på panel-komponentene sine. Den første er anbefalt: en error boundary som har fanget en feil blir stående i feiltilstand, så rundt hele settet tar den med seg `TabList` også, og brukeren kan ikke bytte fane. Inne i panelet nullstilles den av seg selv når panelet avmonteres ved fanebytte.

`REACT-18-MIGRATION.md` finnes ikke lenger – den ble fjernet i `a59e450ec` til fordel for `migrate-react-18`-skillen, så migreringsnotatene er oppdatert der i stedet. Migrering-siden i Sanity er oppdatert som utkast og venter på publisering.

`migrate-react-18` dekker nå også tre former som var stille brudd i 0.8.x, og som alle fungerte under `@reach/tabs`: en egen komponent inne i `TabPanels` som forbruker en indeks selv om den ikke rendrer et panel, en betingelse på bare én av `Tab` og `TabPanel`, og mer enn én `TabList` eller `TabPanels` i samme `Tabs` – den siste nummererer fra 0 i hver container og advarer ikke om noe, siden ingen av dem ser den andre. Symptomene er lagt inn i feilsøkingslisten i skillen, formulert slik man møter dem: paneler forskjøvet med én, og en tab som ikke viser noe.

`entur-web-development`-skillen omtalte ikke dette i det hele tatt – den viste et flatt `Tabs`-eksempel uten et ord om at indeksen kommer fra markupen. Den har nå et avsnitt om å bygge begge sider fra samme data, hva som er gjennomsiktig og hva som ikke er det, og `index` som utvei.

`packages/tab/CHANGELOG.md` er rettet: 0.8.0-oppføringen listet dype importer, strengere typer, `data-reach-*` og ID-formatet under breaking changes, men ikke selve indeksendringen. Den er lagt til der endringen faktisk kom, siden det er seksjonen konsumenter leser ved oppgradering. Lerna prepender nye oppføringer og skriver bare headeren om, så manuelle rettelser i eldre seksjoner overlever neste publisering.

Prop-tabellene på dokumentasjonssiden er regenerert, slik at `index` er dokumentert på `Tab` og `TabPanel`.

Grenen er rebaset på `main`, så endringene i `TabList` fra `ETU-75490-dropdown-shadow-dom-illegal-invocation` (PR #446) ligger under.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

Atten nye tester i `packages/tab/src/index.test.tsx` (21 → 39) dekker fragment, wrapper-element, `Suspense`, flere nivåer nesting, innhold som ikke er tab eller panel, `index`-propen alene og i konflikt med forelderens indeks, ARIA-koblingen ved eksplisitt indeks, alle advarslene, paneler ingen tab kan nå, at gyldig markup ikke advarer, at en tab uten eget panel ikke advarer, og at `StrictMode` ikke gir falske advarsler når effektene kjører dobbelt.

Nestings-testene ble verifisert mot den gamle indeksfordelingen og feilet alle der. Partner-formen ble reprodusert med en egen `ErrorBoundary` rundt `Suspense`: før viste tab 1 alle tre panelene og tab 2 og 3 ingenting, etter viser hver tab sitt eget panel med riktig ARIA-kobling.

`@entur/tab` er grønn (39/39), og hele monorepoet er grønt (22 prosjekter). `tsc --noEmit` er ren, `yarn lint packages/tab` gir 0 feil, Prettier er fornøyd, og `yarn build:package tab` går gjennom. `yarn verify:skills` er ren etter dokumentasjonsendringene.

Formene i denne PR-en er også prøvd manuelt i lekerommet, med et oppsett som dekker gyldige kombinasjoner, de som skal advare, og en del rare varianter (to `TabList`-er, `React.memo` rundt et panel, `index` utenfor rekkevidde, panel som laster med `React.lazy`). Alt oppførte seg som beskrevet over. Oppsettet er lokalt og ikke committet.

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden

[ETU-75596]: https://entur.atlassian.net/browse/ETU-75596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

