### PR TITLE
fix(website): use the beta SideNavigation in the docs site

### DIFF
--- a/apps/code-playground/src/components.ts
+++ b/apps/code-playground/src/components.ts
@@ -16,8 +16,8 @@ export * from '@entur/layout';
 export * from '@entur/layout/beta';
 export * from '@entur/loader';
 export * from '@entur/menu';
-// Namespaced: exports a SideNavigation that would otherwise clash with the stable one
-export * as MenuBeta from '@entur/menu/beta';
+// Aliased: exports a SideNavigation that would otherwise clash with the stable one
+export { SideNavigation as SideNavigationBeta } from '@entur/menu/beta';
 export * from '@entur/modal';
 export * from '@entur/tab';
 export * from '@entur/table';

--- a/apps/code-playground/src/components.ts
+++ b/apps/code-playground/src/components.ts
@@ -16,6 +16,8 @@ export * from '@entur/layout';
 export * from '@entur/layout/beta';
 export * from '@entur/loader';
 export * from '@entur/menu';
+// Namespaced: exports a SideNavigation that would otherwise clash with the stable one
+export * as MenuBeta from '@entur/menu/beta';
 export * from '@entur/modal';
 export * from '@entur/tab';
 export * from '@entur/table';

--- a/apps/code-playground/src/index.scss
+++ b/apps/code-playground/src/index.scss
@@ -16,6 +16,7 @@
 @import '@entur/button/dist/styles.css';
 @import '@entur/alert/dist/styles.css';
 @import '@entur/menu/dist/styles.css';
+@import '@entur/menu/beta/styles';
 @import '@entur/fileupload/dist/styles.css';
 @import '@entur/modal/dist/styles.css';
 @import '@entur/tooltip/dist/styles.css';

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.scss
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.scss
@@ -30,6 +30,8 @@
   // backgrounds still run to the edge of the sidebar.
   &__menu {
     --eds-side-navigation-padding-inline-start: #{eds.$space-extra-large2};
+
+    margin-bottom: 2rem;
   }
 
   &-wrapper {
@@ -90,27 +92,6 @@
 
     .eds-drawer__close-button {
       z-index: 10;
-    }
-  }
-
-  &__searchbar__button {
-    display: flex;
-    align-items: center;
-    max-width: 13rem;
-    margin-left: eds.$space-extra-large2;
-    margin-top: 1rem;
-
-    kbd {
-      display: inline-block;
-      margin-left: auto;
-    }
-  }
-
-  @media screen and (max-width: map.get(variables.$breakpoints, 'tablet')) {
-    .searchbar__button {
-      span {
-        display: none;
-      }
     }
   }
 }

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.scss
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.scss
@@ -25,8 +25,11 @@
     padding: eds.$space-extra-large2 eds.$space-extra-large2 0 eds.$space-extra-large2;
   }
 
-  &__group {
-    margin-top: 1rem;
+  // Line the labels up with the top bar logo, which sits on the top bar's
+  // padding-inline. Set as padding rather than a margin so hover and active
+  // backgrounds still run to the edge of the sidebar.
+  &__menu {
+    --eds-side-navigation-padding-inline-start: #{eds.$space-extra-large2};
   }
 
   &-wrapper {
@@ -94,7 +97,7 @@
     display: flex;
     align-items: center;
     max-width: 13rem;
-    margin-left: 2rem;
+    margin-left: eds.$space-extra-large2;
     margin-top: 1rem;
 
     kbd {

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Link } from 'gatsby';
 import classNames from 'classnames';
-import {
-  SideNavigation as EnturSideNavigation,
-  SideNavigationGroup,
-  SideNavigationItem,
-} from '@entur/menu';
+import { SideNavigation as EnturSideNavigation } from '@entur/menu/beta';
 
 import { SecondaryButton } from '@entur/button';
 import { SearchIcon } from '@entur/icons';
@@ -25,7 +21,6 @@ import {
 import { useSearch } from '../../Search/SearchContext';
 
 import './SideNavigation.scss';
-import { Flex } from '@entur/layout/beta';
 
 type SideNavigationProps = {
   mobile?: boolean;
@@ -87,17 +82,16 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
     const { item } = props;
     const path = item.path || getSanitizedPath(item) || '';
     return (
-      <SideNavigationItem
+      <EnturSideNavigation.Item
         key={item.id}
         as={Link}
         to={path}
         active={isActive(path, currentLocation)}
         onClick={onClickMenuItem}
+        badge={item.tag ? <ArticleTag tag={item.tag} /> : undefined}
       >
-        <Flex justify="space-between">
-          {item.title} {item.tag && <ArticleTag tag={item.tag} />}
-        </Flex>
-      </SideNavigationItem>
+        {item.title}
+      </EnturSideNavigation.Item>
     );
   };
 
@@ -111,18 +105,16 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
           openSearch();
         }}
       />
-      <EnturSideNavigation style={{ marginTop: mobile ? '0rem' : '1.5rem' }}>
+      <EnturSideNavigation
+        className="side-navigation__menu"
+        style={{ marginTop: mobile ? '0rem' : '1.5rem' }}
+      >
         {sortedGrouped.map(([subcategory, subcategoryMenuItems]) => (
-          <SideNavigationGroup
-            key={subcategory}
-            defaultOpen={true}
-            title={subcategory}
-            className="side-navigation__group"
-          >
+          <EnturSideNavigation.Group key={subcategory} title={subcategory}>
             {subcategoryMenuItems.map(item => (
               <MenuItem key={item.id} item={item} />
             ))}
-          </SideNavigationGroup>
+          </EnturSideNavigation.Group>
         ))}
         {ungrouped.map(item => (
           <MenuItem key={item.id} item={item} />

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
@@ -8,6 +8,7 @@ import { ArticleTag } from '../../Common/ArticleTag';
 import {
   MenuItem,
   getSanitizedPath,
+  groupSubcategoryFor,
   isActive,
   menuItemComparator,
   normalizeString,
@@ -42,7 +43,7 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
     menuItems
       .filter(item => normalizeString(item.category) === currentCategory)
       .forEach(item => {
-        const { subcategory } = item;
+        const subcategory = groupSubcategoryFor(item);
         const subcategoryLowercase = subcategory?.toLowerCase();
         if (subcategoryLowercase) {
           if (!grouped[subcategoryLowercase])

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
@@ -3,9 +3,6 @@ import { Link } from 'gatsby';
 import classNames from 'classnames';
 import { SideNavigation as EnturSideNavigation } from '@entur/menu/beta';
 
-import { SecondaryButton } from '@entur/button';
-import { SearchIcon } from '@entur/icons';
-import { Badge } from '@entur/layout';
 import { ArticleTag } from '../../Common/ArticleTag';
 
 import {
@@ -18,12 +15,9 @@ import {
   sortSubCategoriesForCategory,
 } from './utils';
 
-import { useSearch } from '../../Search/SearchContext';
-
 import './SideNavigation.scss';
 
 type SideNavigationProps = {
-  mobile?: boolean;
   menuItems: MenuItem[];
   className?: string;
   onClickMenuItem?: () => void;
@@ -31,14 +25,11 @@ type SideNavigationProps = {
 };
 
 const SideNavigation: React.FC<SideNavigationProps> = ({
-  mobile = false,
   menuItems,
   className,
   onClickMenuItem,
   currentLocation,
 }) => {
-  const { openSearch } = useSearch();
-
   const currentPathSegments = removeLeadingAndTrailingSlash(
     currentLocation.pathname,
   )?.split('/');
@@ -99,16 +90,7 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
 
   return (
     <div className={classNames('side-navigation-wrapper', className)}>
-      <SearchBar
-        onOpenSearch={() => {
-          onClickMenuItem?.();
-          openSearch();
-        }}
-      />
-      <EnturSideNavigation
-        className="side-navigation__menu"
-        style={{ marginTop: mobile ? '0rem' : '1.5rem' }}
-      >
+      <EnturSideNavigation className="side-navigation__menu">
         {sortedGrouped.map(([subcategory, subcategoryMenuItems]) => (
           <EnturSideNavigation.Group key={subcategory} title={subcategory}>
             {subcategoryMenuItems.map(item => (
@@ -121,39 +103,6 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
         ))}
       </EnturSideNavigation>
     </div>
-  );
-};
-
-type SearchBarProps = {
-  /** Callback to open the search modal */
-  onOpenSearch: () => void;
-  /** Ekstra klassenavn */
-  className?: string;
-};
-
-const SearchBar: React.FC<SearchBarProps> = ({ onOpenSearch }) => {
-  return (
-    <SecondaryButton
-      aria-label="Søk i dokumentasjon"
-      className="side-navigation__searchbar__button"
-      onClick={onOpenSearch}
-      width="fluid"
-    >
-      <SearchIcon aria-hidden="true" />
-      <span>Søk …</span>
-      <Badge
-        as="kbd"
-        variant="neutral"
-        type="status"
-        style={{
-          width: '5ch',
-          minWidth: 'unset',
-          paddingInline: '0.25rem',
-        }}
-      >
-        ⌘ k
-      </Badge>
-    </SecondaryButton>
   );
 };
 

--- a/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/SideNavigation.tsx
@@ -18,6 +18,10 @@ import {
 
 import './SideNavigation.scss';
 
+// useLayoutEffect would warn during Gatsby's server render, where it never runs
+const useIsomorphicLayoutEffect =
+  typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
+
 type SideNavigationProps = {
   menuItems: MenuItem[];
   className?: string;
@@ -31,10 +35,32 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
   onClickMenuItem,
   currentLocation,
 }) => {
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+
   const currentPathSegments = removeLeadingAndTrailingSlash(
     currentLocation.pathname,
   )?.split('/');
   const currentCategory = normalizeString(currentPathSegments?.[0]) ?? '';
+
+  // The menu is long enough that the current page is often below the fold.
+  // Centre it in the sidebar when it is out of view, before the first paint.
+  // Only the sidebar scrolls — scrollIntoView would move the page as well.
+  useIsomorphicLayoutEffect(() => {
+    const wrapper = wrapperRef.current;
+    const activeItem = wrapper?.querySelector('[aria-current="page"]');
+    if (!wrapper || !activeItem) return;
+
+    const wrapperBox = wrapper.getBoundingClientRect();
+    const itemBox = activeItem.getBoundingClientRect();
+    const isInView =
+      itemBox.top >= wrapperBox.top && itemBox.bottom <= wrapperBox.bottom;
+    if (isInView) return;
+
+    wrapper.scrollTop +=
+      itemBox.top -
+      wrapperBox.top -
+      (wrapper.clientHeight - itemBox.height) / 2;
+  }, [currentLocation.pathname]);
 
   // Filter, group, and sort menu items
   const processedMenuItems = React.useMemo(() => {
@@ -90,7 +116,10 @@ const SideNavigation: React.FC<SideNavigationProps> = ({
   const { sortedGrouped, ungrouped } = processedMenuItems;
 
   return (
-    <div className={classNames('side-navigation-wrapper', className)}>
+    <div
+      className={classNames('side-navigation-wrapper', className)}
+      ref={wrapperRef}
+    >
       <EnturSideNavigation className="side-navigation__menu">
         {sortedGrouped.map(([subcategory, subcategoryMenuItems]) => (
           <EnturSideNavigation.Group key={subcategory} title={subcategory}>

--- a/apps/documentation/src/components/Navigations/SideNavigation/utils.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/utils.tsx
@@ -80,16 +80,26 @@ export function menuItemComparator(a: MenuItem, b: MenuItem) {
   return 0;
 }
 
+// Under Komponenter every component lives in one flat, alphabetical group.
+// Only the landing page and the resource pages keep a section of their own.
+const KOMPONENTER_MERGED_GROUP = 'Komponenter';
+const KOMPONENTER_STANDALONE_SUBCATEGORIES = ['oversikt', 'ressurser'];
+
+export const groupSubcategoryFor = (item: MenuItem): string | undefined => {
+  if (normalizeString(item.category) !== 'komponenter') return item.subcategory;
+  if (!item.subcategory) return item.subcategory;
+  return KOMPONENTER_STANDALONE_SUBCATEGORIES.includes(
+    normalizeString(item.subcategory),
+  )
+    ? item.subcategory
+    : KOMPONENTER_MERGED_GROUP;
+};
+
 // Menu-items sort orders
 export const componentsMenuSortOrder = {
   oversikt: 1,
   ressurser: 2,
-  knapper: 3,
-  skjemaelementer: 4,
-  navigasjon: 5,
-  'layout & flater': 6,
-  feedback: 7,
-  reise: 8,
+  komponenter: 3,
 } as any;
 
 export const komIGangMenuSortOrder = {

--- a/apps/documentation/src/components/Navigations/SideNavigation/utils.tsx
+++ b/apps/documentation/src/components/Navigations/SideNavigation/utils.tsx
@@ -81,9 +81,9 @@ export function menuItemComparator(a: MenuItem, b: MenuItem) {
 }
 
 // Under Komponenter every component lives in one flat, alphabetical group.
-// Only the landing page and the resource pages keep a section of their own.
+// Only these subcategories keep a section of their own.
 const KOMPONENTER_MERGED_GROUP = 'Komponenter';
-const KOMPONENTER_STANDALONE_SUBCATEGORIES = ['oversikt', 'ressurser'];
+const KOMPONENTER_STANDALONE_SUBCATEGORIES = ['oversikt', 'ressurser', 'maler'];
 
 export const groupSubcategoryFor = (item: MenuItem): string | undefined => {
   if (normalizeString(item.category) !== 'komponenter') return item.subcategory;
@@ -100,6 +100,7 @@ export const componentsMenuSortOrder = {
   oversikt: 1,
   ressurser: 2,
   komponenter: 3,
+  maler: 4,
 } as any;
 
 export const komIGangMenuSortOrder = {

--- a/apps/documentation/src/components/Playground/packages-scope.ts
+++ b/apps/documentation/src/components/Playground/packages-scope.ts
@@ -13,6 +13,7 @@ import * as layout from '@entur/layout';
 import * as layoutBeta from '@entur/layout/beta';
 import * as loader from '@entur/loader';
 import * as menu from '@entur/menu';
+import * as menuBeta from '@entur/menu/beta';
 import * as modal from '@entur/modal';
 import * as tab from '@entur/tab';
 import * as table from '@entur/table';
@@ -39,6 +40,9 @@ export const packages = {
   ...layoutBeta,
   ...loader,
   ...menu,
+  // Namespaced: @entur/menu/beta exports a SideNavigation that would otherwise
+  // shadow the stable one used by the existing examples.
+  MenuBeta: menuBeta,
   ...modal,
   ...tab,
   ...table,

--- a/apps/documentation/src/components/Playground/packages-scope.ts
+++ b/apps/documentation/src/components/Playground/packages-scope.ts
@@ -40,9 +40,9 @@ export const packages = {
   ...layoutBeta,
   ...loader,
   ...menu,
-  // Namespaced: @entur/menu/beta exports a SideNavigation that would otherwise
+  // Aliased: @entur/menu/beta exports a SideNavigation that would otherwise
   // shadow the stable one used by the existing examples.
-  MenuBeta: menuBeta,
+  SideNavigationBeta: menuBeta.SideNavigation,
   ...modal,
   ...tab,
   ...table,

--- a/apps/documentation/src/components/Search/Search.tsx
+++ b/apps/documentation/src/components/Search/Search.tsx
@@ -178,16 +178,9 @@ export const Search = () => {
         onClick={openSearch}
         size="small"
       >
-        <SearchIcon aria-hidden="true" /> Søk …
+        <SearchIcon aria-hidden="true" /> Søk
         <Badge as="kbd" variant="neutral" type="status">
-          <span
-            style={{
-              marginRight: '0.25rem',
-            }}
-          >
-            ⌘
-          </span>
-          k
+          ⌘+k
         </Badge>
       </SecondaryButton>
       <IconButton className="searchmodal__button--small" onClick={openSearch}>

--- a/apps/documentation/src/pages/kom-i-gang/for-utviklere/css-og-stiler.mdx
+++ b/apps/documentation/src/pages/kom-i-gang/for-utviklere/css-og-stiler.mdx
@@ -68,6 +68,7 @@ For å unngå uventede stilkonflikter er det viktig å importere stilene i rikti
 @import '@entur/button/styles';
 @import '@entur/alert/styles';
 @import '@entur/menu/styles';
+@import '@entur/menu/beta/styles';
 @import '@entur/fileupload/styles';
 @import '@entur/modal/styles';
 @import '@entur/tooltip/styles';
@@ -87,7 +88,7 @@ De øvrige token-filene (`semantic`, `data`, `transport`) importeres ved behov i
 
 ## Betapakker har egne stilfiler
 
-`@entur/typography/beta` og `@entur/layout/beta` har stiler som ligger utenfor hovedstilene til pakken. Bruker du betakomponentene, må du importere `/beta/styles` i tillegg til `/styles`, slik listen over viser.
+`@entur/typography/beta`, `@entur/layout/beta` og `@entur/menu/beta` har stiler som ligger utenfor hovedstilene til pakken. Bruker du betakomponentene, må du importere `/beta/styles` i tillegg til `/styles`, slik listen over viser.
 
 ## Mørk modus
 

--- a/apps/documentation/src/pages/komponenter/ressurser/grid.mdx
+++ b/apps/documentation/src/pages/komponenter/ressurser/grid.mdx
@@ -3,7 +3,7 @@ title: Grid
 description: Grid hjelper deg og plassere elementer med jevn rytme, og forenkler responsivitet på forskjellige flater.
 route: /komponenter/ressurser/grid
 parent: Komponenter
-menu: Ressurser
+menu: Layout & Flater
 npmPackage: grid
 tags: grid
 ---

--- a/apps/documentation/src/styles/index.scss
+++ b/apps/documentation/src/styles/index.scss
@@ -108,7 +108,6 @@ body {
 
 .side-nav-column {
   grid-area: sidenav;
-  background: var(--components-menu-sidenavigation-standard-background);
 }
 
 .toc-aside {

--- a/apps/documentation/src/styles/index.scss
+++ b/apps/documentation/src/styles/index.scss
@@ -19,6 +19,7 @@
 @import '@entur/button/dist/styles.css';
 @import '@entur/alert/dist/styles.css';
 @import '@entur/menu/dist/styles.css';
+@import '@entur/menu/beta/styles';
 @import '@entur/fileupload/dist/styles.css';
 @import '@entur/modal/dist/styles.css';
 @import '@entur/tooltip/dist/styles.css';

--- a/apps/documentation/src/utils/componentProps/eds-component-props/Calendar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/Calendar.json
@@ -5,7 +5,9 @@
   "methods": [],
   "props": {
     "selectedDate": {
-      "defaultValue": null,
+      "defaultValue": {
+        "value": null
+      },
       "description": "",
       "name": "selectedDate",
       "declarations": [
@@ -14,7 +16,7 @@
           "name": "TypeLiteral"
         }
       ],
-      "required": true,
+      "required": false,
       "type": {
         "name": "DateValue | null"
       }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DateField.json
@@ -5,7 +5,9 @@
   "methods": [],
   "props": {
     "selectedDate": {
-      "defaultValue": null,
+      "defaultValue": {
+        "value": null
+      },
       "description": "Den valgte tiden. Tid i '@internationalized/date'-pakkens format",
       "name": "selectedDate",
       "declarations": [
@@ -14,7 +16,7 @@
           "name": "TypeLiteral"
         }
       ],
-      "required": true,
+      "required": false,
       "type": {
         "name": "DateValue | null"
       }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/DatePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/DatePicker.json
@@ -5,7 +5,9 @@
   "methods": [],
   "props": {
     "selectedDate": {
-      "defaultValue": null,
+      "defaultValue": {
+        "value": null
+      },
       "description": "Den valgte tiden. Tid i '@internationalized/date'-pakkens format",
       "name": "selectedDate",
       "declarations": [
@@ -14,7 +16,7 @@
           "name": "TypeLiteral"
         }
       ],
-      "required": true,
+      "required": false,
       "type": {
         "name": "DateValue | null"
       }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendar.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/RangeCalendar.json
@@ -5,7 +5,9 @@
   "methods": [],
   "props": {
     "value": {
-      "defaultValue": null,
+      "defaultValue": {
+        "value": null
+      },
       "description": "Det valgte datoperioden. Null hvis ingen periode er valgt.",
       "name": "value",
       "declarations": [
@@ -14,7 +16,7 @@
           "name": "TypeLiteral"
         }
       ],
-      "required": true,
+      "required": false,
       "type": {
         "name": "RangeValue<MappedDateValue<DateType>> | null"
       }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.ExpandableItem.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.ExpandableItem.json
@@ -1,0 +1,166 @@
+{
+  "tags": {},
+  "description": "",
+  "displayName": "SideNavigationBeta.ExpandableItem",
+  "methods": [],
+  "props": {
+    "icon": {
+      "defaultValue": null,
+      "description": "Ikon som vises til venstre for etiketten",
+      "name": "icon",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "badge": {
+      "defaultValue": null,
+      "description": "Innhold som vises til høyre for etiketten, typisk en StatusBadge",
+      "name": "badge",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "alert": {
+      "defaultValue": null,
+      "description": "Viser en varselprikk ytterst til høyre",
+      "name": "alert",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "alertLabel": {
+      "defaultValue": {
+        "value": "'Varsel'"
+      },
+      "description": "Tekst som leses opp for varselprikken",
+      "name": "alertLabel",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "title": {
+      "defaultValue": null,
+      "description": "Etiketten til det ekspanderbare elementet",
+      "name": "title",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationExpandableItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "active": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Marker elementet som gjeldende side",
+      "name": "active",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationExpandableItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "disabled": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Deaktiver elementet",
+      "name": "disabled",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationExpandableItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "open": {
+      "defaultValue": null,
+      "description": "Om undermenyen er åpen. Gjør komponenten kontrollert",
+      "name": "open",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationExpandableItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "defaultOpen": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Om undermenyen er åpen ved første render. Kun relevant når komponenten\nikke er kontrollert",
+      "name": "defaultOpen",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationExpandableItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "onOpenChange": {
+      "defaultValue": null,
+      "description": "Kalles med den nye tilstanden når undermenyen åpnes eller lukkes",
+      "name": "onOpenChange",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationExpandableItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "((open: boolean) => void) | undefined"
+      }
+    }
+  }
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.Group.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.Group.json
@@ -1,0 +1,23 @@
+{
+  "tags": {},
+  "description": "",
+  "displayName": "SideNavigationBeta.Group",
+  "methods": [],
+  "props": {
+    "title": {
+      "defaultValue": null,
+      "description": "Overskriften til gruppen",
+      "name": "title",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationGroup.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": true,
+      "type": {
+        "name": "ReactNode"
+      }
+    }
+  }
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.Item.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.Item.json
@@ -1,0 +1,149 @@
+{
+  "tags": {},
+  "description": "",
+  "displayName": "SideNavigationBeta.Item",
+  "methods": [],
+  "props": {
+    "icon": {
+      "defaultValue": null,
+      "description": "Ikon som vises til venstre for etiketten",
+      "name": "icon",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "badge": {
+      "defaultValue": null,
+      "description": "Innhold som vises til høyre for etiketten, typisk en StatusBadge",
+      "name": "badge",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "alert": {
+      "defaultValue": null,
+      "description": "Viser en varselprikk ytterst til høyre",
+      "name": "alert",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "alertLabel": {
+      "defaultValue": {
+        "value": "'Varsel'"
+      },
+      "description": "Tekst som leses opp for varselprikken",
+      "name": "alertLabel",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "active": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Marker elementet som gjeldende side",
+      "name": "active",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "disabled": {
+      "defaultValue": {
+        "value": false
+      },
+      "description": "Deaktiver elementet. Rendres da som en deaktivert knapp",
+      "name": "disabled",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "className": {
+      "defaultValue": null,
+      "description": "Ekstra klassenavn",
+      "name": "className",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    },
+    "as": {
+      "defaultValue": null,
+      "description": "An override of the default HTML tag.\nCan also be another React component.",
+      "name": "as",
+      "declarations": [
+        {
+          "fileName": "node_modules/@entur/utils/dist/PolymorphicComponent.d.ts",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ElementType<any, keyof IntrinsicElements> | undefined"
+      }
+    },
+    "ref": {
+      "defaultValue": null,
+      "description": "",
+      "name": "ref",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItem.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "Ref<Element> | undefined"
+      }
+    }
+  }
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.ItemContent.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.ItemContent.json
@@ -1,0 +1,70 @@
+{
+  "tags": {},
+  "description": "Delt radinnhold for menyelementer og ekspanderbare menyelementer.",
+  "displayName": "SideNavigationBeta.ItemContent",
+  "methods": [],
+  "props": {
+    "icon": {
+      "defaultValue": null,
+      "description": "Ikon som vises til venstre for etiketten",
+      "name": "icon",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "badge": {
+      "defaultValue": null,
+      "description": "Innhold som vises til høyre for etiketten, typisk en StatusBadge",
+      "name": "badge",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "ReactNode"
+      }
+    },
+    "alert": {
+      "defaultValue": null,
+      "description": "Viser en varselprikk ytterst til høyre",
+      "name": "alert",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "boolean | undefined"
+      }
+    },
+    "alertLabel": {
+      "defaultValue": {
+        "value": "Varsel"
+      },
+      "description": "Tekst som leses opp for varselprikken",
+      "name": "alertLabel",
+      "declarations": [
+        {
+          "fileName": "packages/menu/src/beta/SideNavigation/SideNavigationItemContent.tsx",
+          "name": "TypeLiteral"
+        }
+      ],
+      "required": false,
+      "type": {
+        "name": "string | undefined"
+      }
+    }
+  }
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SideNavigationBeta.json
@@ -1,0 +1,7 @@
+{
+  "tags": {},
+  "description": "",
+  "displayName": "SideNavigationBeta",
+  "methods": [],
+  "props": {}
+}

--- a/apps/documentation/src/utils/componentProps/eds-component-props/SimpleTimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/SimpleTimePicker.json
@@ -5,7 +5,9 @@
   "methods": [],
   "props": {
     "selectedTime": {
-      "defaultValue": null,
+      "defaultValue": {
+        "value": null
+      },
       "description": "Den valgte tiden. Tid i '@internationalized/date'-pakkens format",
       "name": "selectedTime",
       "declarations": [
@@ -14,7 +16,7 @@
           "name": "TypeLiteral"
         }
       ],
-      "required": true,
+      "required": false,
       "type": {
         "name": "TimeValue | null"
       }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/TimePicker.json
@@ -5,7 +5,9 @@
   "methods": [],
   "props": {
     "selectedTime": {
-      "defaultValue": null,
+      "defaultValue": {
+        "value": null
+      },
       "description": "Den valgte tiden. Tid i '@internationalized/date'-pakkens format",
       "name": "selectedTime",
       "declarations": [
@@ -14,7 +16,7 @@
           "name": "TypeLiteral"
         }
       ],
-      "required": true,
+      "required": false,
       "type": {
         "name": "TimeValue | null"
       }

--- a/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
+++ b/apps/documentation/src/utils/componentProps/eds-component-props/_hashes.json
@@ -112,7 +112,7 @@
     "outputs": ["TagChip.json"]
   },
   "datepicker/src/DatePicker/Calendar.tsx": {
-    "hash": "157fa7b13ad14b272e336f9be6f1ca69",
+    "hash": "727b22f82c4c4b6271cda0fde4ca399d",
     "outputs": ["Calendar.json"]
   },
   "datepicker/src/DatePicker/CalendarCell.tsx": {
@@ -124,11 +124,11 @@
     "outputs": ["CalendarGrid.json"]
   },
   "datepicker/src/DatePicker/DateField.tsx": {
-    "hash": "c7a0e2c9674e686b784167e2c0980ce1",
+    "hash": "b5edbb48e99c4974b0bce7579d7459da",
     "outputs": ["DateField.json"]
   },
   "datepicker/src/DatePicker/DatePicker.tsx": {
-    "hash": "6c2dec68f8edc170674b1d376b54c0c9",
+    "hash": "c03a1b0ff1716015a0618b632378f6dd",
     "outputs": ["DatePicker.json"]
   },
   "datepicker/src/DatePicker/NativeDatePicker.tsx": {
@@ -140,11 +140,11 @@
     "outputs": ["NativeTimePicker.json"]
   },
   "datepicker/src/TimePicker/SimpleTimePicker.tsx": {
-    "hash": "0edee77520d8663af9102beeb2aa3cd3",
+    "hash": "43a8b19441ebaf35db4f9bb4d253615e",
     "outputs": ["SimpleTimePicker.json"]
   },
   "datepicker/src/TimePicker/TimePicker.tsx": {
-    "hash": "9a6f2f1de49a3eecb792780c2872bd6e",
+    "hash": "3e90394d60396488cf4c4c73ca96d9b6",
     "outputs": ["TimePicker.json"]
   },
   "datepicker/src/TimePicker/TimePickerArrowButton.tsx": {
@@ -196,7 +196,7 @@
     "outputs": ["AccordionItem.json"]
   },
   "expand/src/BaseExpand.tsx": {
-    "hash": "9827301324ff04a0113c9077600bcd4b",
+    "hash": "7d9f895edec123f4f4e84d2718a2dd71",
     "outputs": ["BaseExpand.json"]
   },
   "expand/src/BaseExpandablePanel.tsx": {
@@ -693,7 +693,7 @@
     "outputs": ["Logo.json"]
   },
   "datepicker/src/DatePicker/RangeCalendar.tsx": {
-    "hash": "ae778ccac6d80dcc8f47aec4595c7401",
+    "hash": "37d71e60202548caa477f60ab820e18e",
     "outputs": ["RangeCalendar.json"]
   },
   "datepicker/src/DatePicker/RangeCalendarCell.tsx": {
@@ -711,5 +711,25 @@
   "tab/src/TabsContext.tsx": {
     "hash": "4b0508bbf39d74c4eb7dc35ae0907186",
     "outputs": []
+  },
+  "menu/src/beta/SideNavigation/SideNavigation.tsx": {
+    "hash": "fdf22f55d0b67b59b298ca3592919ee7",
+    "outputs": ["SideNavigationBeta.json"]
+  },
+  "menu/src/beta/SideNavigation/SideNavigationExpandableItem.tsx": {
+    "hash": "846bcf1ab7d734e6fddc745c8e055b8a",
+    "outputs": ["SideNavigationBeta.ExpandableItem.json"]
+  },
+  "menu/src/beta/SideNavigation/SideNavigationGroup.tsx": {
+    "hash": "3b1754c5d86674683a7873f67b7f60b5",
+    "outputs": ["SideNavigationBeta.Group.json"]
+  },
+  "menu/src/beta/SideNavigation/SideNavigationItem.tsx": {
+    "hash": "0fe3822a9b5476137297aae5c97cc585",
+    "outputs": ["SideNavigationBeta.Item.json"]
+  },
+  "menu/src/beta/SideNavigation/SideNavigationItemContent.tsx": {
+    "hash": "b51ed3bad83aa205e495d7f7c06f03d7",
+    "outputs": ["SideNavigationBeta.ItemContent.json"]
   }
 }


### PR DESCRIPTION
## 💡 Hvorfor?

Denne bygger på #451, som legger til `SideNavigation` i `@entur/menu/beta`. Her ligger alt som gjelder dokumentasjonssiden og playroom: å laste betapakken, generere prop-tabeller, og å ta i bruk komponenten i vår egen sidemeny slik at vi dogfooder den.

Delt ut i egen PR for at #451 skal stå igjen som ren pakkeendring.

## 🔧 Hvordan?

**Oppsett** – `@entur/menu/beta` lastes i `apps/documentation/src/styles/index.scss` og i playroom, og er dokumentert i `css-og-stiler.mdx`. I Playground-scopet heter komponenten `SideNavigationBeta`, siden `SideNavigation` ellers ville skygge for den stabile. Fem nye prop-tabeller er generert med `SideNavigationBeta`-prefiks – generatoren navngir filene etter `displayName`, så uten prefikset ville de overskrevet tabellene til den stabile komponenten.

**Dogfooding** – sidemenyen på dokumentasjonssiden bruker nå betakomponenten. Den setter `--eds-side-navigation-padding-inline-start` til `$space-extra-large2`, som er samme verdi som topplinjas `padding-inline`, slik at etikettene står på linje med logoen oppe til venstre. Bakgrunnen bak sidemenykolonnen er droppet, siden komponenten maler sin egen.

**Søk** – sidemenyen hadde en søkeknapp som duplikerte den i topplinja. Den er fjernet, så topplinja er eneste inngang til søk.

En commit (`fix(website): regenerate stale datepicker prop tables`) er ikke relatert – det er drift generatoren plukket opp. Ligger for seg selv og kan droppes.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [x] 📝 Dokumentasjonsoppdatering

## 🖼️ Skjermbilder

<!-- Legg ved hvis det hjelper å forstå endringen -->

## 💬 Tilleggsnotater

Må merges etter #451 – uten den finnes ikke `@entur/menu/beta`.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

`oxlint` gir 0 feil og ingen ubrukte symboler i filene som er rørt. `tsc` på dokumentasjonsappen viser bare feil som fantes fra før.

Innrykket er målt i nettleser: med standardverdien 16/16/40 px for etikett, gruppeoverskrift og underelement, med overstyringen 40/40/64 px – mens radboksen fortsatt starter på 0 og er like bred, slik at hover- og aktiv-bakgrunnen går helt ut til kanten.

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden
