### PR TITLE
fix(skills): correct CSS layer guidance for typography and Tailwind preflight

### DIFF
--- a/skills/entur-web-development/references/css-layers.md
+++ b/skills/entur-web-development/references/css-layers.md
@@ -4,15 +4,18 @@ If your app uses [cascade layers](https://developer.mozilla.org/en-US/docs/Web/C
 
 ## What Entur ships
 
-| Package                        | Layer status                                                                                                                            |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `@entur/typography`            | Self-layered — places its styles in `core.reset`, `core.base` and `components.primitives`, and carries the shared `@layer` declarations |
-| every other `@entur/*` package | Unlayered plain CSS                                                                                                                     |
+| Package                        | Layer status                                                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `@entur/typography`            | Partly layered — only its reset (modern-normalize + `box-sizing`) sits in `core.reset`. Everything else is unlayered plain CSS |
+| every other `@entur/*` package | Unlayered plain CSS                                                                                                            |
 
-Two consequences to design around:
+Verify against the version you ship: `grep -c '@layer' node_modules/@entur/typography/dist/styles.css` returns 1 — the single `core.reset` block, ~4 kB of 27 kB. The remaining ~23 kB (headings, `.eds-paragraph`, `.eds-preformatted-text`, `.eds-link`, list styles) is unlayered, and there is no `@layer` order declaration in any `@entur/*` stylesheet.
+
+Three consequences to design around:
 
 1. **Unlayered CSS beats every layer**, regardless of declaration order. Untouched, `@entur/button` outranks anything you put in an `app` layer.
-2. **You can move that CSS into a layer yourself** with `layer()` on the import — those files have no internal `@layer`, so wrapping them is safe and gives you full control. `@entur/typography` is the exception: it self-layers, so never wrap it.
+2. **You can move that CSS into a layer yourself** with `layer()` on the import — those files have no internal `@layer`, so wrapping them is safe and gives you full control. `@entur/typography` is the exception: it has an internal `@layer`, so never wrap it.
+3. **You cannot beat typography's unlayered rules from a layer.** An override of `.eds-paragraph` or `.eds-preformatted-text` placed in `app` loses to typography's own unlayered rule, no matter how high `app` sits. Override those unlayered, with equal-or-higher specificity (see rule 3 below).
 
 ## Recipe: put everything in the layer order
 
@@ -29,7 +32,7 @@ Declare the order first, import Entur's component CSS into `components.primitive
 @import '@entur/tokens/dist/base.css' layer(core.tokens);
 @import '@entur/tokens/dist/styles.css' layer(core.tokens);
 
-/* 3. Typography self-layers — import it bare, never with layer() */
+/* 3. Typography has an internal @layer — import it bare, never with layer() */
 @import '@entur/typography/dist/styles.css';
 
 /* 4. Component packages into components.primitives */
@@ -45,7 +48,7 @@ Declare the order first, import Entur's component CSS into `components.primitive
 }
 ```
 
-With that in place a single class in `app` overrides component styling, because `app` is the highest layer and nothing is left unlayered.
+With that in place a single class in `app` overrides component styling, because `app` is the highest layer and every wrapped package is inside it. Typography's unlayered bulk is the one exception — see consequence 3 above.
 
 To pull the declarations from source instead of pasting them, in SCSS:
 
@@ -54,6 +57,8 @@ To pull the declarations from source instead of pasting them, in SCSS:
 ```
 
 That resolves to `dist/layers.scss`, so it works from Sass only — a plain-CSS `@import` cannot read it. The block in step 1 is that file's content; keep the two in sync.
+
+Keep the token imports in step 2 even if the app appears to work without them: most component packages inline the base and semantic token declarations into their own `styles.css`, so dropping `base.css` fails silently for as long as one of those packages is imported — and breaks the moment the import list changes. Importing them explicitly also keeps every token declaration in `core.tokens`, below anything you override in a higher layer.
 
 ## Layer order
 
@@ -71,22 +76,22 @@ Where to put your own CSS:
 | Overrides of an `@entur/*` component                    | `components.overrides`                                       |
 | Utility classes                                         | `utilities`                                                  |
 | Page and app-level styles                               | `app`                                                        |
+| Overrides of an `@entur/typography` style               | nothing — keep it unlayered, see rule 3                      |
 
 ## Rules
 
-1. **Declare the order first, before any import.** Re-declaring existing names does not reorder them, and new names in a later declaration are appended at the end — they cannot be inserted between existing layers. `@entur/typography` also declares the order, so whichever declaration the browser sees first wins: make it yours.
+1. **Declare the order first, before any import.** Re-declaring existing names does not reorder them, and new names in a later declaration are appended at the end — they cannot be inserted between existing layers. No `@entur/*` package declares the order for you, so the declaration in step 1 of the recipe is the one that governs: keep it as the first CSS statement in the app.
 
-2. **Never wrap a self-layering file in `layer()`.** `@import './file.css' layer(X)` nests that file's own `@layer` declarations under `X`, so `core.reset` becomes `X.core.reset` — a different layer. This applies to `@entur/typography/dist/styles.css` only; every other `@entur/*` stylesheet is safe to wrap.
+2. **Never wrap a file that contains its own `@layer` in `layer()`.** `@import './file.css' layer(X)` nests that file's `@layer` blocks under `X`, so `core.reset` becomes `X.core.reset` — a different layer. This applies to `@entur/typography/dist/styles.css` only; every other `@entur/*` stylesheet is safe to wrap.
 
-3. **If you skip the `layer()` wrapping, override unlayered.** Component CSS left unlayered can only be beaten by unlayered CSS of equal-or-higher specificity — use the scoped `className` anchor pattern in the "Component overrides" section of `getting-started.md`. Reach for the component's own props and tokens before either approach.
+3. **Unlayered CSS is beaten only by unlayered CSS.** That covers both component CSS you chose not to wrap and everything `@entur/typography` ships outside `core.reset`. Beat it with unlayered CSS of equal-or-higher specificity — use the scoped `className` anchor pattern in the "Component overrides" section of `getting-started.md`. Reach for the component's own props and tokens before either approach.
 
 ## Tailwind CSS v4
 
-`@import "tailwindcss"` emits its own `@layer theme`, `base`, `components` and `utilities`. Those names collide with Entur's, and Tailwind's `base` layer holds preflight — a global reset that flattens component styling if it outranks it. Split the import so each part lands in the right Entur layer:
+`@import "tailwindcss"` emits its own `@layer theme`, `base`, `components` and `utilities`. Those names collide with Entur's, and Tailwind's `base` layer holds preflight — a global reset that flattens component styling if it outranks it. Split the import so each part lands in the right Entur layer, and skip preflight:
 
 ```css
 /* tailwind.css */
-@import 'tailwindcss/preflight' layer(core.reset);
 @import 'tailwindcss/utilities' layer(utilities);
 
 @theme {
@@ -100,9 +105,21 @@ Where to put your own CSS:
 @import './tailwind.css';
 ```
 
-Preflight lands below everything Entur ships, and utilities land in `utilities`.
+Utilities land in `utilities`, and Entur's own reset is the only reset in play.
 
-For a Tailwind utility to actually override an Entur component, that component's CSS must sit in a layer below `utilities` — so use the `layer(components.primitives)` imports from the recipe above. Without them the component's unlayered rules outrank `utilities`, and `className="p-4"` silently does nothing.
+**Skip preflight when `@entur/typography` is installed.** Typography's `core.reset` block already ships modern-normalize plus `box-sizing: border-box`, so preflight is a second reset over the same ground. It is not merely redundant: preflight sets `svg { vertical-align: middle }`, and `.eds-icon` only sets `display: inline` — no `vertical-align` of its own. Icons rendered with `inline` get `.eds-icon--inline { position: relative; top: 0.2em }`, an offset calibrated for a baseline-aligned svg. Centre the svg first and the nudge becomes a second correction: the `BreadcrumbItem` separator lands ~4px below the breadcrumb text. Layer order does not help — no EDS rule opposes preflight's declaration, so it wins wherever it sits.
+
+If you must keep preflight (a large existing Tailwind codebase depending on its normalization), neutralize that one rule in `third-party.overrides` or higher:
+
+```css
+@layer third-party.overrides {
+  svg.eds-icon {
+    vertical-align: baseline;
+  }
+}
+```
+
+For a Tailwind utility to actually override an Entur component, that component's CSS must sit in a layer below `utilities` — so use the `layer(components.primitives)` imports from the recipe above. Without them the component's unlayered rules outrank `utilities`, and `className="p-4"` silently does nothing. Typography's unlayered rules outrank `utilities` too, so a `text-*` or `leading-*` utility on an `.eds-paragraph` needs an unlayered override instead.
 
 ## Micro frontends
 

--- a/skills/entur-web-development/references/css-layers.md
+++ b/skills/entur-web-development/references/css-layers.md
@@ -4,18 +4,20 @@ If your app uses [cascade layers](https://developer.mozilla.org/en-US/docs/Web/C
 
 ## What Entur ships
 
-| Package                        | Layer status                                                                                                                   |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| `@entur/typography`            | Partly layered — only its reset (modern-normalize + `box-sizing`) sits in `core.reset`. Everything else is unlayered plain CSS |
-| every other `@entur/*` package | Unlayered plain CSS                                                                                                            |
+| Stylesheet                                              | Layer status                                                                                                                                                        |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@entur/typography/beta/styles`                         | Fully layered — `core.reset`, `core.base` and `components.primitives`, and it carries the shared `@layer` order declarations. Only token blocks sit outside a layer |
+| `@entur/typography/dist/styles.css` (the stable import) | Partly layered — only its reset (modern-normalize + `box-sizing`) sits in `core.reset`. Every style rule after that is unlayered, and it declares no order          |
+| `@entur/utils/styles/layers`                            | The order declarations on their own, nothing else. Sass-only, opt-in                                                                                                |
+| every other `@entur/*` stylesheet                       | Unlayered plain CSS                                                                                                                                                 |
 
-Verify against the version you ship: `grep -c '@layer' node_modules/@entur/typography/dist/styles.css` returns 1 — the single `core.reset` block, ~4 kB of 27 kB. The remaining ~23 kB (headings, `.eds-paragraph`, `.eds-preformatted-text`, `.eds-link`, list styles) is unlayered, and there is no `@layer` order declaration in any `@entur/*` stylesheet.
+The two typography stylesheets behave differently, so check which one your app imports. `grep -c '@layer' node_modules/@entur/typography/dist/styles.css` returns 1 — the single `core.reset` block, ~4 kB of 27 kB; the remaining ~23 kB (headings, `.eds-paragraph`, `.eds-preformatted-text`, `.eds-link`, list styles) is unlayered. The same grep against `dist/beta/styles/index.css` returns 8: the four order declarations plus four layered blocks.
 
 Three consequences to design around:
 
 1. **Unlayered CSS beats every layer**, regardless of declaration order. Untouched, `@entur/button` outranks anything you put in an `app` layer.
-2. **You can move that CSS into a layer yourself** with `layer()` on the import — those files have no internal `@layer`, so wrapping them is safe and gives you full control. `@entur/typography` is the exception: it has an internal `@layer`, so never wrap it.
-3. **You cannot beat typography's unlayered rules from a layer.** An override of `.eds-paragraph` or `.eds-preformatted-text` placed in `app` loses to typography's own unlayered rule, no matter how high `app` sits. Override those unlayered, with equal-or-higher specificity (see rule 3 below).
+2. **You can move that CSS into a layer yourself** with `layer()` on the import — those files have no internal `@layer`, so wrapping them is safe and gives you full control. The two typography stylesheets and `@entur/utils/styles/layers` are the exceptions: they carry `@layer` themselves, so never wrap them.
+3. **On the stable typography stylesheet, you cannot beat its rules from a layer.** An override of `.eds-paragraph` or `.eds-preformatted-text` placed in `app` loses to typography's own unlayered rule, no matter how high `app` sits — override those unlayered, with equal-or-higher specificity (see rule 3 below). On `@entur/typography/beta/styles` this does not apply: its rules live in `core.reset`, `core.base` and `components.primitives`, so `app` wins as expected.
 
 ## Recipe: put everything in the layer order
 
@@ -32,7 +34,8 @@ Declare the order first, import Entur's component CSS into `components.primitive
 @import '@entur/tokens/dist/base.css' layer(core.tokens);
 @import '@entur/tokens/dist/styles.css' layer(core.tokens);
 
-/* 3. Typography has an internal @layer — import it bare, never with layer() */
+/* 3. Typography carries @layer itself — import it bare, never with layer().
+      Same for '@entur/typography/beta/styles' if you use the beta typography. */
 @import '@entur/typography/dist/styles.css';
 
 /* 4. Component packages into components.primitives */
@@ -48,7 +51,7 @@ Declare the order first, import Entur's component CSS into `components.primitive
 }
 ```
 
-With that in place a single class in `app` overrides component styling, because `app` is the highest layer and every wrapped package is inside it. Typography's unlayered bulk is the one exception — see consequence 3 above.
+With that in place a single class in `app` overrides component styling, because `app` is the highest layer and every wrapped package is inside it. The stable typography stylesheet's unlayered bulk is the one exception — see consequence 3 above.
 
 To pull the declarations from source instead of pasting them, in SCSS:
 
@@ -76,15 +79,16 @@ Where to put your own CSS:
 | Overrides of an `@entur/*` component                    | `components.overrides`                                       |
 | Utility classes                                         | `utilities`                                                  |
 | Page and app-level styles                               | `app`                                                        |
-| Overrides of an `@entur/typography` style               | nothing — keep it unlayered, see rule 3                      |
+| Overrides of a stable `@entur/typography` style         | nothing — keep it unlayered, see rule 3                      |
+| Overrides of an `@entur/typography/beta` style          | `components.overrides` or `app`                              |
 
 ## Rules
 
-1. **Declare the order first, before any import.** Re-declaring existing names does not reorder them, and new names in a later declaration are appended at the end — they cannot be inserted between existing layers. No `@entur/*` package declares the order for you, so the declaration in step 1 of the recipe is the one that governs: keep it as the first CSS statement in the app.
+1. **Declare the order first, before any import.** Re-declaring existing names does not reorder them, and new names in a later declaration are appended at the end — they cannot be inserted between existing layers. Whichever declaration the browser sees first wins, and `@entur/typography/beta/styles` carries one too: make yours the app's first CSS statement, either as the block in step 1 or via `@use '@entur/utils/styles/layers'`.
 
-2. **Never wrap a file that contains its own `@layer` in `layer()`.** `@import './file.css' layer(X)` nests that file's `@layer` blocks under `X`, so `core.reset` becomes `X.core.reset` — a different layer. This applies to `@entur/typography/dist/styles.css` only; every other `@entur/*` stylesheet is safe to wrap.
+2. **Never wrap a file that carries `@layer` in `layer()`.** `@import './file.css' layer(X)` nests that file's `@layer` rules under `X`, so `core.reset` becomes `X.core.reset` — a different layer. Three `@entur/*` files carry `@layer`: `@entur/typography/dist/styles.css` (a `core.reset` block), `@entur/typography/beta/styles` (four layered blocks plus the order declarations) and `@entur/utils/styles/layers` (the declarations alone, Sass only). Every other `@entur/*` stylesheet is plain unlayered CSS and safe to wrap.
 
-3. **Unlayered CSS is beaten only by unlayered CSS.** That covers both component CSS you chose not to wrap and everything `@entur/typography` ships outside `core.reset`. Beat it with unlayered CSS of equal-or-higher specificity — use the scoped `className` anchor pattern in the "Component overrides" section of `getting-started.md`. Reach for the component's own props and tokens before either approach.
+3. **Unlayered CSS is beaten only by unlayered CSS.** That covers both component CSS you chose not to wrap and everything the stable `@entur/typography/dist/styles.css` ships outside `core.reset`. Beat it with unlayered CSS of equal-or-higher specificity — use the scoped `className` anchor pattern in the "Component overrides" section of `getting-started.md`. Reach for the component's own props and tokens before either approach.
 
 ## Tailwind CSS v4
 
@@ -107,7 +111,7 @@ Where to put your own CSS:
 
 Utilities land in `utilities`, and Entur's own reset is the only reset in play.
 
-**Skip preflight when `@entur/typography` is installed.** Typography's `core.reset` block already ships modern-normalize plus `box-sizing: border-box`, so preflight is a second reset over the same ground. It is not merely redundant: preflight sets `svg { vertical-align: middle }`, and `.eds-icon` only sets `display: inline` — no `vertical-align` of its own. Icons rendered with `inline` get `.eds-icon--inline { position: relative; top: 0.2em }`, an offset calibrated for a baseline-aligned svg. Centre the svg first and the nudge becomes a second correction: the `BreadcrumbItem` separator lands ~4px below the breadcrumb text. Layer order does not help — no EDS rule opposes preflight's declaration, so it wins wherever it sits.
+**Skip preflight when `@entur/typography` is installed.** Both typography stylesheets ship modern-normalize plus `box-sizing: border-box` in their `core.reset` block, so preflight is a second reset over the same ground. It is not merely redundant: preflight sets `svg { vertical-align: middle }`, and in `@entur/icons` 10.0.1 and earlier `.eds-icon` only sets `display: inline` — no `vertical-align` of its own. Icons rendered with `inline` get `.eds-icon--inline { position: relative; top: 0.2em }`, an offset calibrated for a baseline-aligned svg. Centre the svg first and the nudge becomes a second correction: the `BreadcrumbItem` separator lands ~4px below the breadcrumb text. Layer order does not help — no EDS rule opposes preflight's declaration, so it wins wherever it sits.
 
 If you must keep preflight (a large existing Tailwind codebase depending on its normalization), neutralize that one rule in `third-party.overrides` or higher:
 
@@ -119,7 +123,7 @@ If you must keep preflight (a large existing Tailwind codebase depending on its 
 }
 ```
 
-For a Tailwind utility to actually override an Entur component, that component's CSS must sit in a layer below `utilities` — so use the `layer(components.primitives)` imports from the recipe above. Without them the component's unlayered rules outrank `utilities`, and `className="p-4"` silently does nothing. Typography's unlayered rules outrank `utilities` too, so a `text-*` or `leading-*` utility on an `.eds-paragraph` needs an unlayered override instead.
+For a Tailwind utility to actually override an Entur component, that component's CSS must sit in a layer below `utilities` — so use the `layer(components.primitives)` imports from the recipe above. Without them the component's unlayered rules outrank `utilities`, and `className="p-4"` silently does nothing. The stable typography stylesheet's unlayered rules outrank `utilities` too, so a `text-*` or `leading-*` utility on an `.eds-paragraph` needs an unlayered override instead — unless you import `@entur/typography/beta/styles`, where `utilities` beats `components.primitives` as expected.
 
 ## Micro frontends
 

--- a/skills/entur-web-development/references/getting-started.md
+++ b/skills/entur-web-development/references/getting-started.md
@@ -235,7 +235,7 @@ Then rebuild and verify styles load in the correct order.
 
 ### Tailwind or third-party CSS overrides Entur styles
 
-Most `@entur/*` CSS is unlayered, and unlayered CSS outranks every cascade layer. So a framework's unlayered rules (Tailwind's preflight, normalize.css) can flatten Entur component styling, while the same rules placed in a layer cannot. See `references/css-layers.md` for which Entur CSS is layered, how to declare layer order, and how to integrate Tailwind v4.
+Most `@entur/*` CSS is unlayered, and unlayered CSS outranks every cascade layer. So a framework's unlayered rules (Tailwind's preflight, normalize.css) can flatten Entur component styling, while the same rules placed in a layer cannot. With `@entur/typography` installed you do not need a third-party reset at all — it ships modern-normalize and `box-sizing: border-box`, and preflight's `svg { vertical-align: middle }` misaligns inline icons no matter which layer it lands in. See `references/css-layers.md` for which Entur CSS is layered, how to declare layer order, and how to integrate Tailwind v4.
 
 ### Missing styles / unstyled components
 


### PR DESCRIPTION
## 💡 Hvorfor?

Tilbakemelding fra et team som integrerte Tailwind v4 med Linje avdekket at `css-layers.md` beskriver noe annet enn det pakkene faktisk gjør:

- Dokumentet sier at `@entur/typography` legger stilene sine i `core.reset`, `core.base` og `components.primitives` og bærer de delte `@layer`-deklarasjonene. I virkeligheten har pakken én `@layer`-blokk (`core.reset`, ~4 kB av 27 kB) og deklarerer ingen lagrekkefølge. De resterende ~23 kB er ulaget og slår derfor alle lag. Teamet fulgte dokumentasjonen, la en override i `app`-laget og fikk en regresjon fordi typography vant likevel.
- Tailwind-oppskriften anbefaler `@import 'tailwindcss/preflight' layer(core.reset)`. Typography leverer allerede modern-normalize og `box-sizing: border-box`, så preflight er en ekstra reset over samme grunn – og `svg { vertical-align: middle }` fra preflight forskyver innline-ikoner (skilletegnet i `BreadcrumbItem` havner ~4 px for lavt) uansett hvilket lag den lander i, siden ingen EDS-regel setter `vertical-align`.

## 🔧 Hvordan?

- Retter tabellen «What Entur ships» og legger til en verifiserbar kommando (`grep -c '@layer' …`) med faktiske tall.
- Ny konsekvens 3 og ny rad i «Where to put your own CSS»: overrides av typography-stiler må være ulagede.
- Regel 1 hevder ikke lenger at typography deklarerer rekkefølgen; regel 2 og 3 er formulert om så de dekker både ulaget komponent-CSS og typography.
- Tailwind-oppskriften dropper preflight, med begrunnelse og en escape hatch (`svg.eds-icon { vertical-align: baseline }` i `third-party.overrides`) for kodebaser som må beholde den.
- Svar på spørsmålet om `@entur/tokens/dist/base.css`: importen skal beholdes. De fleste komponentpakker inlinker de samme token-deklarasjonene i sin egen `styles.css`, så en manglende `base.css` feiler stille helt til importlista endres.
- `getting-started.md`: feilsøkingspunktet om Tailwind peker nå på at man ikke trenger en tredjeparts-reset i det hele tatt.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [x] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

Endringen retter dokumentasjonen mot dagens oppførsel. Alternativet – å flytte resten av typography inn i `core.base` og `components.primitives` slik dokumentet påsto – er en breaking change for alle som overstyrer typography ulaget i dag, og bør tas som en egen vurdering.

Samme tilbakemelding avdekket fire CSS-variabler som brukes uten å være definert. De rettes i en egen PR.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

Kun endringer i skills-dokumentasjon – ingen kodeendringer. Alle påstandene i teksten er verifisert mot kilden i denne repoen: `packages/typography/dist/styles.css` (én `@layer`-blokk, 27 148 bytes), `packages/icons/src/index.scss` (setter kun `display: inline`), og at 16 av 22 pakker `@use`-r `@entur/tokens/dist/base.scss` og dermed inlinker base-tokens.

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden
