### PR TITLE
fix(menu, form, datepicker): define or remove four dead CSS custom properties

### DIFF
--- a/packages/datepicker/src/shared/FieldSegment.scss
+++ b/packages/datepicker/src/shared/FieldSegment.scss
@@ -12,7 +12,8 @@
     }
 
     &--placeholder {
-      color: var(--components-datepicker-datefield-standard-text-content);
+      // Same token as ::placeholder in BaseFormControl, so date segments match other fields
+      color: var(--components-form-baseform-standard-text-label);
     }
 
     &--dot-separator {

--- a/packages/form/src/FeedbackText.scss
+++ b/packages/form/src/FeedbackText.scss
@@ -48,7 +48,7 @@
     color: var(--components-form-feedbacktext-negative-standard-icon-fill);
 
     circle {
-      fill: var(--components-form-feedbacktext-negative-standard-icon-symbol);
+      fill: var(--components-form-feedbacktext-negative-standard-symbol);
     }
 
     .eds-contrast & {

--- a/packages/menu/src/OverflowMenu.scss
+++ b/packages/menu/src/OverflowMenu.scss
@@ -34,7 +34,6 @@
 
     &:active {
       background: var(--components-menu-overflowmenu-fill-active);
-      color: var(--components-menu-overflowmenu-text-active);
     }
 
     &--disabled {

--- a/packages/menu/src/SideNavigation.scss
+++ b/packages/menu/src/SideNavigation.scss
@@ -67,7 +67,7 @@
 
     .eds-contrast & {
       background-color: var(--components-menu-sidenavigation-contrast-background);
-      color: var(--components-menu-sidenavigation-contast-text);
+      color: var(--components-menu-sidenavigation-contrast-text);
       box-shadow: t.$shadows-box-shadow;
     }
 


### PR DESCRIPTION
## 💡 Hvorfor?

Tilbakemelding fra et team som integrerte Linje i egen app avdekket CSS-variabler som brukes uten å være definert noe sted. En udefinert `var()` uten fallback gjør hele deklarasjonen ugyldig ved beregning av verdien, så egenskapen faller stille bort – ingen konsollvarsel, ingen synlig feil før noen ser nøye på fargen.

Et sveip over alle `var()`-referanser i `packages/*/src/**/*.scss`, kryssjekket mot alle deklarasjoner i repoet og mot variabler som settes fra JS, ga fire treff:

| Variabel | Sted | Konsekvens |
| --- | --- | --- |
| `--components-menu-sidenavigation-contast-text` | `SideNavigation.scss` | Skrivefeil (`contast` → `contrast`). Collapse-knappen i kontrastmodus falt tilbake til standard tekstfarge |
| `--components-menu-overflowmenu-text-active` | `OverflowMenu.scss` | Finnes ikke i tokensettet, verken i lys eller mørk modus. Deklarasjonen har alltid vært død |
| `--components-form-feedbacktext-negative-standard-icon-symbol` | `FeedbackText.scss` | Riktig navn er `...negative-standard-symbol`, uten `icon`. Symbolet inne i feilikonet mistet fyllfargen |
| `--components-datepicker-datefield-standard-text-content` | `FieldSegment.scss` | Datepicker har ingen `datefield`-gruppe i tokensettet. Uutfylte segmenter ble tegnet i vanlig tekstfarge, ikke dempet |

De tre øvrige udefinerte navnene sveipet fant (`--eds-viewport-height`, `--eds-sidebar-padding`, `--eds-portal-main-padding`, `--eds-side-navigation-padding-inline-start`) er dokumenterte knotter for konsumenter og har SCSS-fallback – de er ikke feil. `--col` og `--row` finnes bare i kommentarer.

En femte variabel fra tilbakemeldingen, `--textarea-label-background`, ble rettet i `@entur/form` 10.0.0 (commit `5309457cd`).

## 🔧 Hvordan?

Én commit per pakke:

- `fix(menu/side navigation, menu/overflow menu)` – retter skrivefeilen, og fjerner `color` på `:active` i overflow-menyen siden det ikke finnes noe token for tilstanden. Bakgrunnsendringen på `:active` beholdes.
- `fix(form/feedback text)` – peker på tokenet som faktisk genereres. Navneavviket ligger i Figma: success, information og warning har alle `icon` i navnet, negative har det ikke.
- `fix(datepicker/date field)` – bruker `--components-form-baseform-standard-text-label`, samme token som `::placeholder` i `BaseFormControl`, slik at datosegmenter dempes som placeholder i andre felt.

`componentVariables.scss` er generert fra Figma og er ikke rørt.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 🖼️ Skjermbilder

Legges ved etter visuell gjennomgang – se sjekklisten under Testing.

## 💬 Tilleggsnotater

Datepicker-endringen er den eneste med synlig effekt på et vanlig oppsett: uutfylte segmenter går fra normal tekstfarge til dempet. Det er oppførselen navnet på klassen (`--placeholder`) tilsier, og det matcher andre felt, men bør bekreftes mot Figma før merge.

De to andre var usynlige i standardmodus og retter kun tilstander som allerede var feil (kontrastmodus, feilikon, `:active`).

Tilbakemeldingen inneholdt også ett funn som ikke er en variabelfeil: `.eds-icon` setter ingen `vertical-align`, så `.eds-icon--inline`-forskyvningen på `0.2em` avhenger av resetten i appen. Med Tailwind Preflight (`svg { vertical-align: middle }`) havner blant annet skilletegnet i `BreadcrumbItem` ~4 px for lavt. Dokumentert som workaround i skills-dokumentasjonen i #455; selve pakkefiksen bør tas separat.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

Verifisert i bygget CSS: `--components-menu-sidenavigation-contrast-text` forekommer 9 ganger i `menu/dist/styles.css`, `--components-form-feedbacktext-negative-standard-symbol` 3 ganger i `form/dist/styles.css`, `overflowmenu-text-active` 0 ganger, og `.eds-date-and-time-field__segment--placeholder` sender ut form-tokenet. Stylelint gir bare de eksisterende feilene i repoet – ingen på endrede linjer.

Endringene er ren CSS, så enhetstester fanger dem ikke. Visuell gjennomgang som må gjøres:

### `@entur/menu` – `CollapsibleSideNavigation`

- [ ] Collapse-knapp, standard modus – lys fargemodus (skal være uendret)
- [ ] Collapse-knapp inne i `.eds-contrast` – tekst/ikon lys mot mørk bakgrunn (dette er feilen som rettes)
- [ ] Collapse-knapp inne i `.eds-contrast` med `data-color-mode="dark"`
- [ ] Utvidet og sammenslått tilstand (`isCollapsed` true/false)
- [ ] `:hover` og `:focus-visible` på knappen, begge fargemodi

### `@entur/menu` – `OverflowMenu`

- [ ] Element i default-tilstand – lys og mørk fargemodus
- [ ] Element under museklikk (`:active`) – bakgrunn endres, tekstfargen skal være uendret mot default
- [ ] Element markert med tastatur (`--highlighted`)
- [ ] Deaktivert element (`--disabled`) – uendret

### `@entur/form` – `FeedbackText`

- [ ] `variant="error"` og `variant="negative"` – symbolet inne i det røde ikonet skal være synlig, lys fargemodus
- [ ] Samme med `data-color-mode="dark"`
- [ ] Samme inne i `.eds-contrast`
- [ ] Regresjon: `success`, `warning` og `information` uendret i alle tre oppsett
- [ ] Vist via `TextField` og `TextArea` med `variant="error"` og `feedback`
- [ ] Vist via `Dropdown`, `SearchableDropdown`, `MultiSelect` og `NativeDropdown`
- [ ] Vist via `DatePicker`, `TimePicker`, `NativeDatePicker`, `NativeTimePicker` og `SimpleTimePicker`

### `@entur/datepicker` – `DateField`, `DatePicker`, `TimePicker` (synlig endring)

- [ ] Tomt felt: alle segmenter (`dd.mm.åååå`, `tt:mm`) dempet, som placeholder i `TextField`
- [ ] Delvis utfylt felt: utfylte segmenter i normal tekstfarge, resten dempet
- [ ] Utfylt felt – uendret
- [ ] Fokusert segment (`:focus-visible`) – dempet tekst mot bakgrunnsmarkeringen er fortsatt lesbar
- [ ] Deaktivert felt
- [ ] Lys og mørk fargemodus, og inne i `.eds-contrast`
- [ ] Kontrastkrav (WCAG 1.4.3) for den dempede fargen mot feltbakgrunnen i begge fargemodi
- [ ] `DateField` og `TimePicker` brukt frittstående, uten `DatePicker`-wrapper
- [ ] `SimpleTimePicker` – bruker ikke `FieldSegment`, skal være uendret

### Tverrgående

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden
