### PR TITLE
fix(icons): keep inline icon alignment independent of the app's CSS reset

### DIFF
--- a/packages/icons/src/index.scss
+++ b/packages/icons/src/index.scss
@@ -11,6 +11,9 @@
   p & {
     position: relative;
     top: 0.2em;
+    // The offset assumes a baseline-aligned icon, so state it instead of inheriting whatever
+    // the host reset decided — Tailwind Preflight and some normalize variants center svg.
+    vertical-align: baseline;
   }
 
   :where(g, path) {


### PR DESCRIPTION
## 💡 Hvorfor?

`BreadcrumbItem` setter `inline` på skilletegnsikonet sitt, som gir `.eds-icon--inline { position: relative; top: 0.2em }`. Forskyvningen er kalibrert for et ikon som ligger på grunnlinjen: et 16 px svg på grunnlinjen ligger ~3,8 px over den optiske midten av teksten, så +3,2 px lander riktig.

Men `.eds-icon` setter bare `display: inline` – aldri `vertical-align`. Er ikonet allerede sentrert av appens egen reset, blir nudgen en dobbel korreksjon. Tailwind Preflight setter `svg { vertical-align: middle }`, og flere normalize-varianter gjør det samme. Lagrekkefølge hjelper ikke: ingen EDS-regel motsier deklarasjonen, så den vinner uansett hvor den ligger.

Rapportert av et team som integrerte Linje med Tailwind v4, verifisert mot `@entur/icons` 10.0.1.

## 🔧 Hvordan?

`vertical-align: baseline` settes i samme blokk som forskyvningen, altså kun på `.eds-icon--inline` og `.eds-icon` inne i `<p>` – de ikonene forskyvningen faktisk gjelder for.

Bevisst avgrenset til den blokken og ikke lagt på `.eds-icon` generelt: `@entur/button` setter `.eds-button :where(.eds-icon) { vertical-align: middle }` med samme spesifisitet (0,1,0), så en regel på `.eds-icon` ville blitt avgjort av importrekkefølgen mellom pakkene. Ikoner uten forskyvning har ingen EDS-kalibrering å beskytte og lar vertikal justering være opp til konteksten, som før.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

Apper uten reset som sentrerer svg ser ingen endring – `baseline` er initialverdien, så regelen slår bare inn der noe annet har overstyrt den.

Apper som i dag kompenserer for feilen med en egen override (f.eks. `top: 0` på skilletegnet) vil få ikonet 3–4 px for høyt til de fjerner kompensasjonen. Verdt en linje i changelog-beskrivelsen.

#455 dokumenterer workarounden i skills-dokumentasjonen. Når denne er sluppet, kan avsnittet der forenkles til at Preflight bare er overflødig, ikke skadelig.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [ ] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

Målt i Chromium på en statisk side som laster faktisk `dist`-CSS (tokens → typography → icons → menu) med `BreadcrumbItem`-markup, der Preflights `svg { vertical-align: middle }` og fiksen kan skrus av og på uavhengig. Avstand mellom ikonets midtpunkt og tekstens optiske midte:

| Oppsett | Avvik |
| --- | --- |
| Uten Preflight, med fiks | −0,05 px |
| Med Preflight, med fiks | −0,05 px |
| Med Preflight, uten fiks | 4,16 px for lavt |

Tallene stemmer med de rapporterte (4,1 px før, 0,08 px etter).

Gjenstår å sjekke visuelt:

- [x] `BreadcrumbNavigation` – skilletegn på én linje og over flere linjer, standard og `.eds-contrast`
- [x] Ikon med `inline` inne i løpende tekst (`Paragraph`, `LeadParagraph`, `SmallText`)
- [x] Ikon uten `inline` inne i `<p>` – treffes også av regelen
- [x] Ikoner i knapper (`PrimaryButton`, `SecondaryButton`, `IconButton`, `SquareButton`) – skal være uendret
- [x] Ikoner i `SideNavigation`, `Tab`, `Alert`, `FeedbackText`, `Chip` – skal være uendret
- [x] `Link` med `--ext-icon` – har egen `top: 0` i `<p>`-kontekst
- [ ] Ikoner i flex- og grid-oppsett – `vertical-align` har ingen effekt der, skal være uendret
- [ ] Med Tailwind v4 + Preflight i en testapp, og med `@import 'tailwindcss'` uten splitting
- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [x] Testet i dokumentasjonsiden
