### PR TITLE
fix(modal): keep the modal centered when a CSS reset zeroes out margins

### DIFF
--- a/packages/modal/src/Modal.scss
+++ b/packages/modal/src/Modal.scss
@@ -11,14 +11,17 @@ html:has(.eds-modal__overlay[open]) {
 }
 
 .eds-modal {
-  // Native <dialog> centers itself via UA margin:auto. We strip UA chrome and
-  // set max-width per size; width:100% (capped) gives ModalContent a parent
-  // width to fill so its own width:100% resolves.
+  // We strip UA chrome and set max-width per size; width:100% (capped) gives
+  // ModalContent a parent width to fill so its own width:100% resolves.
   &__overlay {
     border: none;
     padding: 0;
     background: transparent;
     color: inherit;
+
+    // Centering. Same as the UA dialog rule, but restated so resets that zero
+    // out margins on every element (e.g. Tailwind Preflight) cannot win.
+    margin: auto;
   }
 
   /* stylelint-disable-next-line selector-max-specificity --


### PR DESCRIPTION
## 💡 Hvorfor?

Etter at Modal gikk over til native `<dialog>` i 2.0 ble modalen ikke lenger midtstilt hos konsumenter som bruker Tailwind ([ETU-75962](https://entur.atlassian.net/browse/ETU-75962)).

Midtstillingen kom fra nettleserens egen regel `dialog { margin: auto }`. CSS-resets som nullstiller marginer på alle elementer – for eksempel Tailwind Preflight med `*, ::before, ::after { margin: 0 }` – er forfatter-stiler og vinner derfor over nettleserstilen, uansett spesifisitet. Resultatet er at modalen legger seg øverst til venstre.

Konsumentene måtte løse det med en lokal overstyring av en intern klasse:

```css
.eds-modal__overlay:modal {
  margin: auto;
}
```

## 🔧 Hvordan?

Setter `margin: auto` eksplisitt på `.eds-modal__overlay`, altså samme regel som nettleseren hadde. Klasseselektoren (0-1-0) vinner over Preflight sin `*`-regel (0-0-0), og siden modal-CSS-en er utenfor `@layer` vinner den også over Tailwind v4 der Preflight ligger i `@layer base`.

`padding` og `border` var allerede satt eksplisitt, så dette var den siste egenskapen Preflight kunne rive bort. `Drawer` bruker ikke `<dialog>` og er uberørt.

## 🧩 Type endring

- [x] 🐞 Feilretting
- [ ] 🚀 Ny funksjonalitet
- [ ] 💥 Breaking change (krever kodeendringer hos brukere)
- [ ] 📝 Dokumentasjonsoppdatering
- [ ] 🧹 Refaktorering (ingen funksjonelle endringer)
- [ ] ⚡️ Ytelsesforbedring
- [ ] 🏗️ Bygg-/CI-endring

## 💬 Tilleggsnotater

Ikke breaking: gjenoppretter oppførselen fra 1.x. Lokale overstyringer hos konsumenter har høyere spesifisitet og vinner fortsatt, så de kan oppdatere først og rydde etterpå.

Hvis noen trenger modalen plassert et annet sted enn midtstilt, bør det støttes i komponenten – ikke løses med overstyring av interne klasser.

## ✅ Sjekkliste

- [x] Navnestandarder følges
- [x] Kode og Figma reflekterer hverandre
- [x] Dokumentasjonen er oppdatert (hvis aktuelt)
- [x] Ingen ubrukte imports / varsler / console.logs

## 🧪 Testing

`yarn workspace @entur/modal test` er kjørt og er grønn, og stylelint gir ingen nye feil.

- [ ] Testet med skjermleser
- [ ] Testet i Safari og Firefox
- [ ] Testet i dokumentasjonsiden


[ETU-75962]: https://entur.atlassian.net/browse/ETU-75962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ