### PR TITLE
Rett feil i skanneren som gir upålitelige bruksdata

### DIFF
--- a/tools/design-system-scanner/src/__fixtures__/deep-import-app/package.json
+++ b/tools/design-system-scanner/src/__fixtures__/deep-import-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "deep-import-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@entur/layout": "^3.0.0",
+    "@entur/table": "^5.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/tools/design-system-scanner/src/__fixtures__/deep-import-app/src/TableView.test.tsx
+++ b/tools/design-system-scanner/src/__fixtures__/deep-import-app/src/TableView.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { EditableCell, Table } from '@entur/table';
+
+export const renderedInTestsOnly = (
+  <Table>
+    <EditableCell>Bergen</EditableCell>
+  </Table>
+);

--- a/tools/design-system-scanner/src/__fixtures__/deep-import-app/src/TableView.tsx
+++ b/tools/design-system-scanner/src/__fixtures__/deep-import-app/src/TableView.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Table, TableRow, DataCell } from '@entur/table';
+import { Sidebar } from '@entur/layout/beta';
+
+export const TableView: React.FC = () => (
+  <Sidebar>
+    <Table>
+      <TableRow>
+        <DataCell>Oslo S</DataCell>
+      </TableRow>
+    </Table>
+  </Sidebar>
+);

--- a/tools/design-system-scanner/src/analyzers/importAnalyzer.test.ts
+++ b/tools/design-system-scanner/src/analyzers/importAnalyzer.test.ts
@@ -82,4 +82,36 @@ describe('importAnalyzer', () => {
       expect(finding.findingType).toBe('import');
     }
   });
+
+  describe('file findings mode', () => {
+    const deepImportApp = path.join(FIXTURES_DIR, 'deep-import-app');
+
+    it('keeps test files out of the aggregate while collecting them as findings', async () => {
+      // Findings mode widens the crawl; the aggregate must not change with it.
+      const withFindings = await analyzeImports(deepImportApp, true);
+      const withoutFindings = await analyzeImports(deepImportApp, false);
+
+      const byName = (result: Awaited<ReturnType<typeof analyzeImports>>) =>
+        [...result.imports].sort((a, b) =>
+          a.symbolName.localeCompare(b.symbolName),
+        );
+
+      // Compares reference and file counts too: the fixture's test file imports
+      // Table, which TableView.tsx also imports, so a leak inflates an existing
+      // symbol instead of adding a name.
+      expect(byName(withFindings)).toEqual(byName(withoutFindings));
+      expect(byName(withFindings).map(i => i.symbolName)).not.toContain(
+        'EditableCell',
+      );
+
+      const testFindings = withFindings.fileFindings.filter(f => f.isTestFile);
+      expect(testFindings.length).toBeGreaterThan(0);
+      expect(testFindings.map(f => f.symbolName)).toContain('EditableCell');
+    });
+
+    it('collects no findings when the flag is off', async () => {
+      const { fileFindings } = await analyzeImports(deepImportApp, false);
+      expect(fileFindings).toEqual([]);
+    });
+  });
 });

--- a/tools/design-system-scanner/src/analyzers/importAnalyzer.ts
+++ b/tools/design-system-scanner/src/analyzers/importAnalyzer.ts
@@ -39,6 +39,12 @@ const EXCLUDE_FILE_PATTERNS = [
   /\.d\.[jt]sx?$/,
 ];
 
+/** Whether a file is collected for findings only, and kept out of the aggregate. */
+function isFindingsOnlyFile(filePath: string): boolean {
+  const basename = path.basename(filePath);
+  return EXCLUDE_FILE_PATTERNS.some(p => p.test(basename));
+}
+
 /**
  * Check if a module specifier matches a known @entur/* design system package.
  * Returns the canonical package name (e.g., "@entur/button") or null.
@@ -348,7 +354,13 @@ export async function analyzeImports(
       }
     }
 
-    const imports = aggregateImports(allEntries);
+    // includeFileFindings widens the crawl to test, story and declaration files;
+    // excluding them here keeps aggregateImports comparable across scans.
+    const imports = aggregateImports(
+      includeFileFindings
+        ? allEntries.filter(entry => !isFindingsOnlyFile(entry.filePath))
+        : allEntries,
+    );
     const fileFindings = includeFileFindings
       ? entriesToFileFindings(allEntries)
       : [];

--- a/tools/design-system-scanner/src/analyzers/reactScannerAnalyzer.test.ts
+++ b/tools/design-system-scanner/src/analyzers/reactScannerAnalyzer.test.ts
@@ -1,0 +1,34 @@
+import * as path from 'path';
+import { analyzeComponents } from './reactScannerAnalyzer';
+
+const FIXTURES_DIR = path.join(__dirname, '..', '__fixtures__');
+const DEEP_IMPORT_APP = path.join(FIXTURES_DIR, 'deep-import-app');
+
+describe('reactScannerAnalyzer', () => {
+  describe('deep import paths', () => {
+    it('reports a real subpath import', async () => {
+      const { components } = await analyzeComponents(DEEP_IMPORT_APP);
+
+      const sidebar = components.find(c => c.componentName === 'Sidebar');
+      expect(sidebar).toBeDefined();
+      expect(sidebar!.packageName).toBe('@entur/layout/beta');
+      expect(sidebar!.deepImportPath).toBe('/beta');
+    });
+
+    it('does not treat a longer package name as a subpath of a shorter one', async () => {
+      // '@entur/table' shares a prefix with the '@entur/tab' entry in the package
+      // list. Matching without a separator reported every table symbol as a deep
+      // import of '@entur/tab' with subpath 'le'.
+      const { components } = await analyzeComponents(DEEP_IMPORT_APP);
+
+      const tableComponents = components.filter(
+        c => c.packageName === '@entur/table',
+      );
+      expect(tableComponents.length).toBeGreaterThan(0);
+
+      for (const component of tableComponents) {
+        expect(component.deepImportPath).toBeUndefined();
+      }
+    });
+  });
+});

--- a/tools/design-system-scanner/src/analyzers/reactScannerAnalyzer.ts
+++ b/tools/design-system-scanner/src/analyzers/reactScannerAnalyzer.ts
@@ -54,8 +54,10 @@ function mapImportStyle(importType?: string): ImportStyle {
  * E.g., "@entur/layout/beta" → "/beta", "@entur/button" → undefined
  */
 function extractDeepImportPath(moduleName: string): string | undefined {
+  // Require a path separator after the package name. A bare startsWith would let
+  // "@entur/table" match the "@entur/tab" entry and report "le" as the subpath.
   for (const pkg of DESIGN_SYSTEM_PACKAGES) {
-    if (moduleName.startsWith(pkg) && moduleName.length > pkg.length) {
+    if (moduleName.startsWith(pkg + '/')) {
       return moduleName.slice(pkg.length);
     }
   }

--- a/tools/design-system-scanner/src/index.ts
+++ b/tools/design-system-scanner/src/index.ts
@@ -150,6 +150,17 @@ async function aggregateResults(args: ParsedArgs): Promise<void> {
   const totalRepos = args.totalRepos || repositories.length;
   const failedRepos = totalRepos - repositories.length;
 
+  // A scan that discovers far fewer repos than minRepos is degraded even when every
+  // discovered repo scanned cleanly.
+  const belowFloor = args.minRepos !== undefined && totalRepos < args.minRepos;
+
+  if (belowFloor) {
+    console.warn(
+      `Discovered ${totalRepos} repos, below the expected floor of ${args.minRepos}. ` +
+        `Marking this scan as partial.`,
+    );
+  }
+
   const scanRun: ScanRunMetadata = {
     scanId: crypto.randomUUID(),
     scanTimestamp: new Date().toISOString(),
@@ -158,10 +169,10 @@ async function aggregateResults(args: ParsedArgs): Promise<void> {
     totalReposScanned: repositories.length,
     totalReposFailed: failedRepos,
     scanStatus:
-      failedRepos === 0
-        ? 'success'
-        : repositories.length === 0
+      repositories.length === 0
         ? 'failure'
+        : failedRepos === 0 && !belowFloor
+        ? 'success'
         : 'partial',
   };
 
@@ -780,6 +791,7 @@ interface ParsedArgs {
   createdAt?: string;
   // Feature flags
   includeFileFindings?: boolean;
+  minRepos?: number;
   catalog?: string;
   // PostHog export flags
   posthogExport?: string;
@@ -817,6 +829,9 @@ function parseArgs(argv: string[]): ParsedArgs {
         break;
       case '--total-repos':
         args.totalRepos = parseInt(argv[++i], 10) || undefined;
+        break;
+      case '--min-repos':
+        args.minRepos = parseInt(argv[++i], 10);
         break;
       case '--output':
         args.output = argv[++i];
@@ -881,6 +896,7 @@ Options:
   --last-commit <iso-date>   Last commit timestamp
   --aggregate <path>         Path to directory with per-repo JSON results
   --total-repos <n>          Total repos discovered (for report metadata)
+  --min-repos <n>            Expected minimum discovered; below it the scan is partial
   --bigquery-export <path>   Path to scan-report.json to export as NDJSON
   --catalog <path>           Path to catalog.json for unused symbol detection
   --posthog-export <path>    Path to scan-report.json to send to PostHog


### PR DESCRIPTION
## 💡 Hvorfor?

Tre feil gjør bruksdataene fra skanneren upålitelige:

- Symboler fra `@entur/table` registreres som dype importer fra `@entur/tab` med understi `le`, fordi prefikssammenligningen mangler sjekk på skilletegn.
- Funn per fil samles aldri inn, selv om skanneren har støtte for det.
- En kjøring som finner langt færre repoer enn forventet rapporteres som fullført.

## 🔧 Hvordan?

- `extractDeepImportPath` krever nå skilletegn etter pakkenavnet, slik at `@entur/table` ikke lenger treffer oppføringen `@entur/tab`.
- `analyzeImports` holder test-, story- og deklarasjonsfiler utenfor aggregeringen når `includeFileFindings` er satt. Flagget utvidet tidligere også søket aggregeringen bygger på, så det kunne ikke skrus på uten at tallene endret seg. Filene beholdes blant funnene per fil, merket med `isTestFile` og `isStorybookFile`.
- Nytt `--min-repos`: finner aggregeringen færre repoer enn grensen, settes status til `partial` i stedet for `success`.

## 🧩 Type endring

- [x] 🐞 Feilretting

## 🧪 Testing

`yarn workspace @entur/design-system-scanner test` — 83 tester, 8 suiter.

Fire nye tester. Begge rettelsene er verifisert ved å reversere dem og se testene feile:

- uten skilletegn-sjekken: `Received: "le"`
- uten filtreringen: `referenceCount` på `Table` går fra 2 til 4

Testen for aggregeringen sammenligner hele `imports`-objektene, ikke bare symbolnavn. Fixturens testfil importerer `Table`, som produksjonsfilen også importerer, slik at en lekkasje blåser opp et eksisterende symbol i stedet for å legge til et nytt navn.

- [ ] Testet med skjermleser — ikke aktuelt
- [ ] Testet i Safari og Firefox — ikke aktuelt
- [ ] Testet i dokumentasjonsiden — ikke aktuelt
